### PR TITLE
feat: Improve block inspector accessibility

### DIFF
--- a/Demo/Sources/EditorView.swift
+++ b/Demo/Sources/EditorView.swift
@@ -1,32 +1,44 @@
 import SwiftUI
 import GutenbergKit
 
+private struct DialogVisible: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
+extension EnvironmentValues {
+    var dialogVisible: Bool {
+        get { self[DialogVisible.self] }
+        set { self[DialogVisible.self] = newValue }
+    }
+}
+
 struct EditorView: View {
     var editorURL: URL?
+    @State private var dialogVisible = false
 
     var body: some View {
-        _EditorView(editorURL: editorURL)
+        _EditorView(editorURL: editorURL, dialogVisible: $dialogVisible)
             .toolbar {
                 ToolbarItemGroup(placement: .topBarLeading) {
                     Button(action: {}, label: {
                         Image(systemName: "xmark")
-                    })
+                    }).accessibilityHidden(dialogVisible)
                 }
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Button(action: {}, label: {
                         Image(systemName: "arrow.uturn.backward")
-                    })
+                    }).accessibilityHidden(dialogVisible)
                     Button(action: {}, label: {
                         Image(systemName: "arrow.uturn.forward")
-                    }).disabled(true)
+                    }).disabled(true).accessibilityHidden(dialogVisible)
                 }
 
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Button(action: {}, label: {
                         Image(systemName: "safari")
-                    })
+                    }).accessibilityHidden(dialogVisible)
 
-                    moreMenu
+                    moreMenu.environment(\.dialogVisible, dialogVisible)
                 }
             }
     }
@@ -65,15 +77,18 @@ struct EditorView: View {
             Image(systemName: "ellipsis")
         }
         .tint(Color.primary)
+        .accessibilityHidden(dialogVisible)
     }
 }
 
 private struct _EditorView: UIViewControllerRepresentable {
     var editorURL: URL?
+    @Binding var dialogVisible: Bool
 
     func makeUIViewController(context: Context) -> EditorViewController {
         let viewController = EditorViewController(service: .init(client: Client()))
         viewController.editorURL = editorURL
+        viewController.dialogVisible = $dialogVisible
         if #available(iOS 16.4, *) {
             viewController.webView.isInspectable = true
         }
@@ -81,7 +96,7 @@ private struct _EditorView: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: EditorViewController, context: Context) {
-        // Do nothing
+        uiViewController.dialogVisible = $dialogVisible
     }
 }
 

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -138,7 +138,7 @@ function Editor({ post = POST_MOCK }) {
 				<PostTitle ref={titleRef} />
 			</div>
 			<BlockTools>
-				<div className="editor-styles-wrapper">
+				<div id="canvas" className="editor-styles-wrapper">
 					<BlockEditorKeyboardShortcuts.Register />
 					<WritingFlow>
 						<ObserveTyping>

--- a/ReactApp/src/components/EditorToolbar.jsx
+++ b/ReactApp/src/components/EditorToolbar.jsx
@@ -24,25 +24,33 @@ const EditorToolbar = (props) => {
 		);
 	}
 
+	const toggleBlockSettings = () => {
+		setBlockInspectorShown((prev) => !prev);
+		// TODO: Replace DOM manipulation with React state
+		document
+			.getElementById('canvas')
+			.setAttribute('aria-hidden', !isBlockInspectorShown);
+	};
+
 	return (
 		<div className="gbkit gbkit-editor-toolbar">
 			<div className="gbkit-editor-toolbar_toolbar-group">
 				{addBlockButton}
 
 				<button
-					onClick={() => setBlockInspectorShown(true)}
-					className="components-button gbkit-editor-toolbar_settings_icon "
+					onClick={toggleBlockSettings}
+					className="components-button gbkit-editor-toolbar_settings_icon"
 				></button>
 			</div>
 
 			{isBlockInspectorShown && (
 				<Popover
+					aria-label="Block Settings"
+					aria-modal
+					role="dialog"
 					expandOnMobile={true}
-					focusOnMount="container"
 					headerTitle="Block Settings"
-					onClose={() => {
-						setBlockInspectorShown(false);
-					}}
+					onClose={toggleBlockSettings}
 				>
 					<BlockInspector />
 				</Popover>
@@ -60,7 +68,7 @@ const EditorToolbar = (props) => {
                     <Sheet.Header />
                     <Sheet.Content>
                         <Sheet.Scroller>
-                            
+
                                 <BlockInspector />
                             </div>
                         </Sheet.Scroller>

--- a/ReactApp/src/components/EditorToolbar.jsx
+++ b/ReactApp/src/components/EditorToolbar.jsx
@@ -30,6 +30,9 @@ const EditorToolbar = (props) => {
 		document
 			.getElementById('canvas')
 			.setAttribute('aria-hidden', !isBlockInspectorShown);
+		postMessage('onToggleDialogVisibility', {
+			visible: !isBlockInspectorShown,
+		});
 	};
 
 	return (

--- a/Sources/GutenbergKit/Sources/EditorJSMessage.swift
+++ b/Sources/GutenbergKit/Sources/EditorJSMessage.swift
@@ -36,9 +36,15 @@ struct EditorJSMessage {
         case onBlocksChanged
         /// The user tapped the inserter button.
         case showBlockPicker
+        /// Hide the editor chrome from accessibility tools
+        case onToggleDialogVisibility
     }
 
     struct DidUpdateBlocksBody: Decodable {
         let isEmpty: Bool
+    }
+    
+    struct DidToggleDialogVisibility: Decodable {
+        let visible: Bool
     }
 }

--- a/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -31,6 +31,8 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
 
     /// A custom URL for the editor.
     public var editorURL: URL?
+    /// Hide the editor chrome from accessibility tools
+    public var dialogVisible: Binding<Bool>?
 
     private var cancellables: [AnyCancellable] = []
 
@@ -195,6 +197,10 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         let host = UIHostingController(rootView: view)
         present(host, animated: true)
     }
+    
+    private func toggleDialogVisibility(visible: Bool) {
+        dialogVisible?.wrappedValue = visible
+    }
 
     // MARK: - Internal (Initial Content)
 
@@ -238,6 +244,9 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
                 delegate?.editor(self, didUpdateContentWithState: state)
             case .showBlockPicker:
                 showBlockInserter()
+            case .onToggleDialogVisibility:
+                let body = try message.decode(EditorJSMessage.DidToggleDialogVisibility.self)
+                toggleDialogVisibility(visible: body.visible)
             }
         } catch {
             fatalError("failed to decode message: \(error)")


### PR DESCRIPTION
Explore accessibility improvements spanning across both web and native UI. 

* Communicate dialog UI to accessibility tools. 
* Prevent accessibility tools moving selection outside of the block inspector dialog. 