### PR TITLE
feat: Third-party blocks

### DIFF
--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -82,7 +82,9 @@ function Editor() {
 		return () => {
 			window.editor = {};
 			getBlockTypes().forEach((block) => {
-				unregisterBlockType(block.name);
+				if (block.name.startsWith('core/')) {
+					unregisterBlockType(block.name);
+				}
 			});
 		};
 	}, []);

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -1,19 +1,3 @@
-import { useEffect, useState } from 'react';
-
-// WordPress
-import {
-	BlockEditorKeyboardShortcuts,
-	BlockEditorProvider,
-	BlockList,
-	BlockTools,
-	WritingFlow,
-	ObserveTyping,
-} from '@wordpress/block-editor';
-import { Popover } from '@wordpress/components';
-import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
-import { registerCoreBlocks } from '@wordpress/block-library';
-import { parse, serialize, registerBlockType } from '@wordpress/blocks';
-
 // Default styles that are needed for the editor.
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
@@ -24,13 +8,27 @@ import '@wordpress/block-library/build-style/editor.css';
 import '@wordpress/block-library/build-style/theme.css';
 
 // Registers standard formatting options for RichText.
-import '@wordpress/format-library';
 import '@wordpress/format-library/build-style/style.css';
 
 // Internal imports
 import EditorToolbar from './EditorToolbar';
 import { postMessage } from '../misc/Helpers';
 // import CodeEditor from './CodeEditor';
+
+// WordPress
+const { useEffect, useState } = window.wp.element;
+const {
+	BlockEditorKeyboardShortcuts,
+	BlockEditorProvider,
+	BlockList,
+	BlockTools,
+	WritingFlow,
+	ObserveTyping,
+} = window.wp.blockEditor;
+const { Popover } = window.wp.components;
+const { getBlockTypes, unregisterBlockType } = window.wp.blocks;
+const { registerCoreBlocks } = window.wp.blockLibrary;
+const { parse, serialize, registerBlockType } = window.wp.blocks;
 
 // Current editor (assumes can be only one instance).
 let editor = {};

--- a/ReactApp/src/components/EditorToolbar.jsx
+++ b/ReactApp/src/components/EditorToolbar.jsx
@@ -1,12 +1,9 @@
-import {
-	BlockInspector,
-	BlockToolbar,
-	Inserter,
-} from '@wordpress/block-editor';
-import { Popover } from '@wordpress/components';
-import { useState } from 'react';
 // import { Sheet } from 'react-modal-sheet';
 import { postMessage } from '../misc/Helpers';
+
+const { useState } = window.wp.element;
+const { BlockInspector, BlockToolbar, Inserter } = window.wp.blockEditor;
+const { Popover } = window.wp.components;
 
 const EditorToolbar = (props) => {
 	const [isBlockInspectorShown, setBlockInspectorShown] = useState(false);
@@ -57,7 +54,6 @@ const EditorToolbar = (props) => {
                     <Sheet.Header />
                     <Sheet.Content>
                         <Sheet.Scroller>
-                            
                                 <BlockInspector />
                             </div>
                         </Sheet.Scroller>

--- a/ReactApp/src/main.jsx
+++ b/ReactApp/src/main.jsx
@@ -3,6 +3,22 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 
+window.GBKit = getGBKit(window);
+
+function getGBKit(global) {
+	if (global.GBKit) {
+		return global.GBKit;
+	}
+
+	const emptyObject = {};
+	try {
+		return JSON.parse(localStorage.getItem('GBKit')) || emptyObject;
+	} catch (error) {
+		console.error('Failed parsing GBKit from localStorage:', error);
+		return emptyObject;
+	}
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(
 	<React.StrictMode>
 		<App />

--- a/ReactApp/src/main.jsx
+++ b/ReactApp/src/main.jsx
@@ -1,13 +1,22 @@
 import { getGBKit } from './misc/Helpers.js';
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App.jsx';
+import { loadRemoteEditor } from './misc/editor.js';
 import './index.css';
 
 window.GBKit = getGBKit();
+initializeEditor();
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-	<React.StrictMode>
-		<App />
-	</React.StrictMode>
-);
+async function initializeEditor() {
+	// Load remote editor scripts
+	// TODO: Make a remote editor optional, fallback to a local editor
+	await loadRemoteEditor(window);
+
+	// Using the remote editor globals, render the editor
+	const { createRoot } = window.ReactDOM;
+	const { StrictMode } = window.wp.element;
+	const { default: App } = await import('./App.jsx');
+	createRoot(document.getElementById('root')).render(
+		<StrictMode>
+			<App />
+		</StrictMode>
+	);
+}

--- a/ReactApp/src/main.jsx
+++ b/ReactApp/src/main.jsx
@@ -1,23 +1,10 @@
+import { getGBKit } from './misc/Helpers.js';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 
-window.GBKit = getGBKit(window);
-
-function getGBKit(global) {
-	if (global.GBKit) {
-		return global.GBKit;
-	}
-
-	const emptyObject = {};
-	try {
-		return JSON.parse(localStorage.getItem('GBKit')) || emptyObject;
-	} catch (error) {
-		console.error('Failed parsing GBKit from localStorage:', error);
-		return emptyObject;
-	}
-}
+window.GBKit = getGBKit();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
 	<React.StrictMode>

--- a/ReactApp/src/misc/Helpers.js
+++ b/ReactApp/src/misc/Helpers.js
@@ -1,3 +1,17 @@
+export function getGBKit() {
+	if (window.GBKit) {
+		return window.GBKit;
+	}
+
+	const emptyObject = {};
+	try {
+		return JSON.parse(localStorage.getItem('GBKit')) || emptyObject;
+	} catch (error) {
+		console.error('Failed parsing GBKit from localStorage:', error);
+		return emptyObject;
+	}
+}
+
 export function postMessage(message, parameters = {}) {
 	if (window.webkit) {
 		const value = { message: message, body: parameters };

--- a/ReactApp/src/misc/editor.js
+++ b/ReactApp/src/misc/editor.js
@@ -61,10 +61,10 @@ function injectStyles(styles) {
 const localGutenbergPackages = ['api-fetch'];
 const excludedScripts = new RegExp(
 	localGutenbergPackages
-		.map(
-			(script) =>
-				`wp-content/plugins/gutenberg/build/${script.replace(/\//g, '\\/')}\\b`
-		)
+		.flatMap((script) => [
+			`wp-content/plugins/gutenberg/build/${script.replace(/\//g, '\\/')}\\b`,
+			`wp-includes/js/dist/${script.replace(/\//g, '\\/')}\\b`,
+		])
 		.join('|')
 );
 

--- a/ReactApp/src/misc/editor.js
+++ b/ReactApp/src/misc/editor.js
@@ -1,0 +1,110 @@
+import { getGBKit } from './Helpers.js';
+import apiFetch from '@wordpress/api-fetch';
+
+export async function loadRemoteEditor(global) {
+	const { siteUrl } = getGBKit();
+	if (!siteUrl) {
+		console.error('No site URL found in GBKit');
+		return;
+	}
+
+	// Define necessary `wp` globals prior to loading remote editor scripts
+	global.wp = global.wp || {};
+	global.wp.apiFetch = apiFetch;
+
+	apiFetch.use(apiFetch.createRootURLMiddleware(`${siteUrl}/wp-json/`));
+	apiFetch.setFetchHandler(fetchHandler);
+
+	try {
+		const response = await apiFetch({ path: '/beae/v1/editor-assets' });
+		const { styles, scripts } = await response.json();
+		injectStyles(styles);
+		await injectScripts(scripts);
+	} catch (error) {
+		console.error('Remote editor loading failed:', error);
+	}
+}
+
+function fetchHandler(options) {
+	const { apiToken } = window.GBKit;
+	const { path, url, ...rest } = options;
+
+	if (!apiToken) {
+		console.warn('No API token found in GBKit');
+	}
+
+	return fetch(url || path, {
+		...rest,
+		headers: {
+			Authorization: `Bearer ${apiToken}`,
+		},
+	});
+}
+
+function injectStyles(styles) {
+	const styleContainer = document.createElement('div');
+	styleContainer.innerHTML = styles.replace(/(href=['"])\/\//g, '$1https://');
+	document.head.appendChild(styleContainer);
+}
+
+// Discard remote copies of localy-sourced Gutenberg packages to avoid conflicts
+const localGutenbergPackages = ['api-fetch'];
+const excludedScripts = new RegExp(
+	localGutenbergPackages
+		.map(
+			(script) =>
+				`wp-content/plugins/gutenberg/build/${script.replace(/\//g, '\\/')}\\b`
+		)
+		.join('|')
+);
+
+function injectScripts(scripts) {
+	const scriptContainer = document.createElement('div');
+	const sanitizedScripts = scripts
+		.replace(/\\"/g, "'")
+		.replace(/src="\/\//g, 'src="https://');
+	scriptContainer.innerHTML = sanitizedScripts;
+	const scriptTags = Array.from(scriptContainer.querySelectorAll('script'));
+
+	function loadScript(index) {
+		if (index >= scriptTags.length) return Promise.resolve();
+
+		return new Promise((resolve) => {
+			const scriptTag = scriptTags[index];
+
+			if (scriptTag.src && excludedScripts.test(scriptTag.src)) {
+				return resolve();
+			}
+
+			const newScript = document.createElement('script');
+
+			if (scriptTag.src) {
+				newScript.src = scriptTag.src;
+				newScript.onload = () => resolve();
+				newScript.onerror = () => resolve(); // Continue even if a script fails to load
+			} else {
+				const blob = new Blob([scriptTag.textContent], {
+					type: 'application/javascript',
+				});
+				const url = URL.createObjectURL(blob);
+				newScript.src = url;
+				newScript.onload = () => {
+					URL.revokeObjectURL(url);
+					resolve();
+				};
+				newScript.onerror = () => {
+					URL.revokeObjectURL(url);
+					resolve(); // Continue even if a script fails to load
+				};
+			}
+
+			if (scriptTag.id) {
+				newScript.id = scriptTag.id;
+			}
+
+			document.body.appendChild(newScript);
+		}).then(() => loadScript(index + 1));
+	}
+
+	return loadScript(0);
+}

--- a/ReactApp/src/misc/editor.js
+++ b/ReactApp/src/misc/editor.js
@@ -16,8 +16,9 @@ export async function loadRemoteEditor(global) {
 	apiFetch.setFetchHandler(fetchHandler);
 
 	try {
-		const response = await apiFetch({ path: '/beae/v1/editor-assets' });
-		const { styles, scripts } = await response.json();
+		const { styles, scripts } = await apiFetch({
+			path: '/beae/v1/editor-assets',
+		});
 		injectStyles(styles);
 		await injectScripts(scripts);
 	} catch (error) {
@@ -25,6 +26,7 @@ export async function loadRemoteEditor(global) {
 	}
 }
 
+// TODO: Increase fetch handler robustness and error handling
 function fetchHandler(options) {
 	const { apiToken } = window.GBKit;
 	const { path, url, ...rest } = options;
@@ -38,7 +40,15 @@ function fetchHandler(options) {
 		headers: {
 			Authorization: `Bearer ${apiToken}`,
 		},
-	});
+	})
+		.then((response) => {
+			if (!response.ok) {
+				throw new Error(`API request failed: ${response.status}`);
+			}
+
+			return response;
+		})
+		.then((response) => response.json());
 }
 
 function injectStyles(styles) {

--- a/ReactApp/src/misc/editor.js
+++ b/ReactApp/src/misc/editor.js
@@ -37,6 +37,7 @@ function fetchHandler(options) {
 
 	return fetch(url || path, {
 		...rest,
+		mode: 'cors',
 		headers: {
 			Authorization: `Bearer ${apiToken}`,
 		},

--- a/Sources/GutenbergKit/Sources/EditorJSMessage.swift
+++ b/Sources/GutenbergKit/Sources/EditorJSMessage.swift
@@ -14,6 +14,11 @@ struct EditorJSMessage {
         self.body = object["body"]
     }
 
+    init(type: MessageType) {
+        self.type = type
+        self.body = nil
+    }
+
     func decode<T: Decodable>(_ type: T.Type) throws -> T {
         guard let body else {
             throw URLError(.unknown)
@@ -23,6 +28,8 @@ struct EditorJSMessage {
     }
 
     enum MessageType: String {
+        /// The web view loaded the specified URL or file
+        case onLoaded
         /// The editor was mounted (initial useEffect was called).
         case onEditorLoaded
         /// The editor content changed.


### PR DESCRIPTION
Experimental exploration of third-party support. 

**Related:**

* https://github.com/dcalhoun/block-editor-assets-endpoint
* https://github.com/wordpress-mobile/WordPress-iOS/pull/23468

**Known Issues:**

* Dependent upon remote editor scripts, cannot fallback to a local editor. 
* Slow editor load time due to unoptimized remote editor asset fetching within the web view. 
* `Bearer` token authorization is unsupported, needs to be replaced with `Basic` (with application password) or some other mechanism. 
* Noted `TODO` comments within the source. 