### PR TITLE
Adds Post Title

### DIFF
--- a/ReactApp/package-lock.json
+++ b/ReactApp/package-lock.json
@@ -10,9 +10,9 @@
 			"dependencies": {
 				"@monaco-editor/react": "^4.6.0",
 				"@wordpress/api-fetch": "^7.4.0",
-				"@wordpress/block-editor": "^13.0.0",
-				"@wordpress/block-library": "^9.0.0",
-				"@wordpress/format-library": "^5.1.0",
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/block-library": "^9.5.0",
+				"@wordpress/format-library": "^5.5.0",
 				"react": "^18.3.1"
 			},
 			"devDependencies": {
@@ -42,38 +42,38 @@
 			}
 		},
 		"node_modules/@ariakit/core": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.11.tgz",
-			"integrity": "sha512-+MnOeqnA4FLI/7vqsZLbZQHHN4ofd9kvkNjz44fNi0gqmD+ZbMWiDkFAvZII75dYnxYw5ZPpWjA4waK22VBWig=="
+			"version": "0.4.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.7.tgz",
+			"integrity": "sha512-GUy/3ZY4kW1KdYHtMZRrRlj5FYbZTAyHlimxHI7Zs0xsC+kAzIf8lopnf67Y9IYLgEMr37KosIV7kwpkJpNs5Q=="
 		},
 		"node_modules/@ariakit/react": {
-			"version": "0.3.14",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.14.tgz",
-			"integrity": "sha512-h71BPMZ2eW+E2ESbdYxSAEMR1DozYzd5eHE5IOzGd9Egi5u7EZxqmuW4CXVXZ1Y6vbaDMV3SudgPh7iHS/ArFw==",
+			"version": "0.4.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.7.tgz",
+			"integrity": "sha512-uUruuCo1M0Nj2oq1nTwDfUlVTLuoI9xeHP75EkuXX46lg5hzE5vVWbSMO1D6MCy7UwrUx2Ts4IqxdKr97suTwQ==",
 			"dependencies": {
-				"@ariakit/react-core": "0.3.14"
+				"@ariakit/react-core": "0.4.7"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/ariakit"
 			},
 			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@ariakit/react-core": {
-			"version": "0.3.14",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.14.tgz",
-			"integrity": "sha512-16Qj6kDPglpdWtU5roY9q+G66naOjauTY5HvUIaL2aLY0187ATaRrABIKoMMzTtJyhvsud4jFlzivz+/zCQ8yw==",
+			"version": "0.4.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.7.tgz",
+			"integrity": "sha512-OogUyQ20cxkRNRuqLI05JbmpR4Lr5HwhUIqnb/sipzt6bkg/3wCXEnUAjfxg3nPjLTMjJ8+ODWmPC9JMJTW/yg==",
 			"dependencies": {
-				"@ariakit/core": "0.3.11",
+				"@ariakit/core": "0.4.7",
 				"@floating-ui/dom": "^1.0.0",
 				"use-sync-external-store": "^1.2.0"
 			},
 			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0"
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -406,15 +406,15 @@
 			}
 		},
 		"node_modules/@emotion/babel-plugin": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
-			"integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
+			"integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.16.7",
 				"@babel/runtime": "^7.18.3",
-				"@emotion/hash": "^0.9.1",
-				"@emotion/memoize": "^0.8.1",
-				"@emotion/serialize": "^1.1.2",
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/serialize": "^1.2.0",
 				"babel-plugin-macros": "^3.1.0",
 				"convert-source-map": "^1.5.0",
 				"escape-string-regexp": "^4.0.0",
@@ -440,59 +440,59 @@
 			}
 		},
 		"node_modules/@emotion/cache": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
-			"integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+			"version": "11.13.1",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
+			"integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
 			"dependencies": {
-				"@emotion/memoize": "^0.8.1",
-				"@emotion/sheet": "^1.2.2",
-				"@emotion/utils": "^1.2.1",
-				"@emotion/weak-memoize": "^0.3.1",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.0",
+				"@emotion/weak-memoize": "^0.4.0",
 				"stylis": "4.2.0"
 			}
 		},
 		"node_modules/@emotion/css": {
-			"version": "11.11.2",
-			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.11.2.tgz",
-			"integrity": "sha512-VJxe1ucoMYMS7DkiMdC2T7PWNbrEI0a39YRiyDvK2qq4lXwjRbVP/z4lpG+odCsRzadlR+1ywwrTzhdm5HNdew==",
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.0.tgz",
+			"integrity": "sha512-BUk99ylT+YHl+W/HN7nv1RCTkDYmKKqa1qbvM/qLSQEg61gipuBF5Hptk/2/ERmX2DCv0ccuFGhz9i0KSZOqPg==",
 			"dependencies": {
-				"@emotion/babel-plugin": "^11.11.0",
-				"@emotion/cache": "^11.11.0",
-				"@emotion/serialize": "^1.1.2",
-				"@emotion/sheet": "^1.2.2",
-				"@emotion/utils": "^1.2.1"
+				"@emotion/babel-plugin": "^11.12.0",
+				"@emotion/cache": "^11.13.0",
+				"@emotion/serialize": "^1.3.0",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.0"
 			}
 		},
 		"node_modules/@emotion/hash": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-			"integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
 		},
 		"node_modules/@emotion/is-prop-valid": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-			"integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.0.tgz",
+			"integrity": "sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==",
 			"dependencies": {
-				"@emotion/memoize": "^0.8.1"
+				"@emotion/memoize": "^0.9.0"
 			}
 		},
 		"node_modules/@emotion/memoize": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-			"integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
 		},
 		"node_modules/@emotion/react": {
-			"version": "11.11.4",
-			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
-			"integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.0.tgz",
+			"integrity": "sha512-WkL+bw1REC2VNV1goQyfxjx1GYJkcc23CRQkXX+vZNLINyfI7o+uUn/rTGPt/xJ3bJHd5GcljgnxHf4wRw5VWQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
-				"@emotion/babel-plugin": "^11.11.0",
-				"@emotion/cache": "^11.11.0",
-				"@emotion/serialize": "^1.1.3",
-				"@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-				"@emotion/utils": "^1.2.1",
-				"@emotion/weak-memoize": "^0.3.1",
+				"@emotion/babel-plugin": "^11.12.0",
+				"@emotion/cache": "^11.13.0",
+				"@emotion/serialize": "^1.3.0",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+				"@emotion/utils": "^1.4.0",
+				"@emotion/weak-memoize": "^0.4.0",
 				"hoist-non-react-statics": "^3.3.1"
 			},
 			"peerDependencies": {
@@ -505,33 +505,33 @@
 			}
 		},
 		"node_modules/@emotion/serialize": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.4.tgz",
-			"integrity": "sha512-RIN04MBT8g+FnDwgvIUi8czvr1LU1alUMI05LekWB5DGyTm8cCBMCRpq3GqaiyEDRptEXOyXnvZ58GZYu4kBxQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.0.tgz",
+			"integrity": "sha512-jACuBa9SlYajnpIVXB+XOXnfJHyckDfe6fOpORIM6yhBDlqGuExvDdZYHDQGoDf3bZXGv7tNr+LpLjJqiEQ6EA==",
 			"dependencies": {
-				"@emotion/hash": "^0.9.1",
-				"@emotion/memoize": "^0.8.1",
-				"@emotion/unitless": "^0.8.1",
-				"@emotion/utils": "^1.2.1",
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/unitless": "^0.9.0",
+				"@emotion/utils": "^1.4.0",
 				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/@emotion/sheet": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
-			"integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+			"integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
 		},
 		"node_modules/@emotion/styled": {
-			"version": "11.11.5",
-			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
-			"integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
+			"integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
-				"@emotion/babel-plugin": "^11.11.0",
-				"@emotion/is-prop-valid": "^1.2.2",
-				"@emotion/serialize": "^1.1.4",
-				"@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
-				"@emotion/utils": "^1.2.1"
+				"@emotion/babel-plugin": "^11.12.0",
+				"@emotion/is-prop-valid": "^1.3.0",
+				"@emotion/serialize": "^1.3.0",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
+				"@emotion/utils": "^1.4.0"
 			},
 			"peerDependencies": {
 				"@emotion/react": "^11.0.0-rc.0",
@@ -544,27 +544,27 @@
 			}
 		},
 		"node_modules/@emotion/unitless": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-			"integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.9.0.tgz",
+			"integrity": "sha512-TP6GgNZtmtFaFcsOgExdnfxLLpRDla4Q66tnenA9CktvVSdNKDvMVuUah4QvWPIpNjrWsGg3qeGo9a43QooGZQ=="
 		},
 		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
-			"integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
+			"integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
 			"peerDependencies": {
 				"react": ">=16.8.0"
 			}
 		},
 		"node_modules/@emotion/utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
-			"integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.0.tgz",
+			"integrity": "sha512-spEnrA1b6hDR/C68lC2M7m6ALPUHZC0lIY7jAS/B/9DuuO1ZP04eov8SMv/6fwRd8pzmsn2AuJEznRREWlQrlQ=="
 		},
 		"node_modules/@emotion/weak-memoize": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
-			"integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.20.2",
@@ -1006,26 +1006,26 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.2.tgz",
-			"integrity": "sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==",
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+			"integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.0"
+				"@floating-ui/utils": "^0.2.7"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.6.5",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
-			"integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
+			"version": "1.6.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+			"integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
 			"dependencies": {
-				"@floating-ui/core": "^1.0.0",
-				"@floating-ui/utils": "^0.2.0"
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.7"
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.0.tgz",
-			"integrity": "sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
+			"integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
 			"dependencies": {
 				"@floating-ui/dom": "^1.0.0"
 			},
@@ -1035,9 +1035,9 @@
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
-			"integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+			"integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.14",
@@ -1175,11 +1175,11 @@
 			}
 		},
 		"node_modules/@preact/signals": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.3.tgz",
-			"integrity": "sha512-M2DXse3Wi8HwjI1d2vQWOLJ3lHogvqTsJYvl4ofXRXgMFQzJ7kmlZvlt5i8x5S5VwgZu0ghru4HkLqOoFfU2JQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.0.tgz",
+			"integrity": "sha512-EOMeg42SlLS72dhoq6Vjq08havnLseWmPQ8A0YsgIAqMgWgx7V1a39+Pxo6i7SY5NwJtH4849JogFq3M67AzWg==",
 			"dependencies": {
-				"@preact/signals-core": "^1.6.0"
+				"@preact/signals-core": "^1.7.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1190,243 +1190,357 @@
 			}
 		},
 		"node_modules/@preact/signals-core": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.6.0.tgz",
-			"integrity": "sha512-O/XGxwP85h1F7+ouqTMOIZ3+V1whfaV9ToIVcuyGriD4JkSD00cQo54BKdqjvBJxbenvp7ynfqRHEwI6e+NIhw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.8.0.tgz",
+			"integrity": "sha512-OBvUsRZqNmjzCZXWLxkZfhcgT+Fk8DDcT/8vD6a1xhDemodyy87UJRJfASMuSD8FaAIeGgGm85ydXhm7lr4fyA==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
 			}
 		},
 		"node_modules/@radix-ui/primitive": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
-			"integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+			"integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10"
 			}
 		},
 		"node_modules/@radix-ui/react-compose-refs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
-			"integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+			"integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-context": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
-			"integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+			"integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-dialog": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.0.tgz",
-			"integrity": "sha512-Yn9YU+QlHYLWwV1XfKiqnGVpWYWk6MeBVM6x/bcoyPvxgjQGoeT35482viLPctTMWoMw0PoHgqfSox7Ig+957Q==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
+			"integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
-				"@radix-ui/primitive": "1.0.0",
-				"@radix-ui/react-compose-refs": "1.0.0",
-				"@radix-ui/react-context": "1.0.0",
-				"@radix-ui/react-dismissable-layer": "1.0.0",
-				"@radix-ui/react-focus-guards": "1.0.0",
-				"@radix-ui/react-focus-scope": "1.0.0",
-				"@radix-ui/react-id": "1.0.0",
-				"@radix-ui/react-portal": "1.0.0",
-				"@radix-ui/react-presence": "1.0.0",
-				"@radix-ui/react-primitive": "1.0.0",
-				"@radix-ui/react-slot": "1.0.0",
-				"@radix-ui/react-use-controllable-state": "1.0.0",
+				"@radix-ui/primitive": "1.0.1",
+				"@radix-ui/react-compose-refs": "1.0.1",
+				"@radix-ui/react-context": "1.0.1",
+				"@radix-ui/react-dismissable-layer": "1.0.5",
+				"@radix-ui/react-focus-guards": "1.0.1",
+				"@radix-ui/react-focus-scope": "1.0.4",
+				"@radix-ui/react-id": "1.0.1",
+				"@radix-ui/react-portal": "1.0.4",
+				"@radix-ui/react-presence": "1.0.1",
+				"@radix-ui/react-primitive": "1.0.3",
+				"@radix-ui/react-slot": "1.0.2",
+				"@radix-ui/react-use-controllable-state": "1.0.1",
 				"aria-hidden": "^1.1.1",
-				"react-remove-scroll": "2.5.4"
+				"react-remove-scroll": "2.5.5"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
 				"react": "^16.8 || ^17.0 || ^18.0",
 				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-dismissable-layer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.0.tgz",
-			"integrity": "sha512-n7kDRfx+LB1zLueRDvZ1Pd0bxdJWDUZNQ/GWoxDn2prnuJKRdxsjulejX/ePkOsLi2tTm6P24mDqlMSgQpsT6g==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+			"integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
-				"@radix-ui/primitive": "1.0.0",
-				"@radix-ui/react-compose-refs": "1.0.0",
-				"@radix-ui/react-primitive": "1.0.0",
-				"@radix-ui/react-use-callback-ref": "1.0.0",
-				"@radix-ui/react-use-escape-keydown": "1.0.0"
+				"@radix-ui/primitive": "1.0.1",
+				"@radix-ui/react-compose-refs": "1.0.1",
+				"@radix-ui/react-primitive": "1.0.3",
+				"@radix-ui/react-use-callback-ref": "1.0.1",
+				"@radix-ui/react-use-escape-keydown": "1.0.3"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
 				"react": "^16.8 || ^17.0 || ^18.0",
 				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-focus-guards": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz",
-			"integrity": "sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
+			"integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-focus-scope": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.0.tgz",
-			"integrity": "sha512-C4SWtsULLGf/2L4oGeIHlvWQx7Rf+7cX/vKOAD2dXW0A1b5QXwi3wWeaEgW+wn+SEVrraMUk05vLU9fZZz5HbQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz",
+			"integrity": "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.0",
-				"@radix-ui/react-primitive": "1.0.0",
-				"@radix-ui/react-use-callback-ref": "1.0.0"
+				"@radix-ui/react-compose-refs": "1.0.1",
+				"@radix-ui/react-primitive": "1.0.3",
+				"@radix-ui/react-use-callback-ref": "1.0.1"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
 				"react": "^16.8 || ^17.0 || ^18.0",
 				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-id": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
-			"integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+			"integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-use-layout-effect": "1.0.0"
+				"@radix-ui/react-use-layout-effect": "1.0.1"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-portal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.0.tgz",
-			"integrity": "sha512-a8qyFO/Xb99d8wQdu4o7qnigNjTPG123uADNecz0eX4usnQEj7o+cG4ZX4zkqq98NYekT7UoEQIjxBNWIFuqTA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
+			"integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-primitive": "1.0.0"
+				"@radix-ui/react-primitive": "1.0.3"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
 				"react": "^16.8 || ^17.0 || ^18.0",
 				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-presence": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
-			"integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+			"integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.0",
-				"@radix-ui/react-use-layout-effect": "1.0.0"
+				"@radix-ui/react-compose-refs": "1.0.1",
+				"@radix-ui/react-use-layout-effect": "1.0.1"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
 				"react": "^16.8 || ^17.0 || ^18.0",
 				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-primitive": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.0.tgz",
-			"integrity": "sha512-EyXe6mnRlHZ8b6f4ilTDrXmkLShICIuOTTj0GX4w1rp+wSxf3+TD05u1UOITC8VsJ2a9nwHvdXtOXEOl0Cw/zQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+			"integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-slot": "1.0.0"
+				"@radix-ui/react-slot": "1.0.2"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
 				"react": "^16.8 || ^17.0 || ^18.0",
 				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-slot": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.0.tgz",
-			"integrity": "sha512-3mrKauI/tWXo1Ll+gN5dHcxDPdm/Df1ufcDLCecn+pnCIVcdWE7CujXo8QaXOWRJyZyQWWbpB8eFwHzWXlv5mQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+			"integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-compose-refs": "1.0.0"
+				"@radix-ui/react-compose-refs": "1.0.1"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-use-callback-ref": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
-			"integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+			"integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-use-controllable-state": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
-			"integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+			"integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-use-callback-ref": "1.0.0"
+				"@radix-ui/react-use-callback-ref": "1.0.1"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-use-escape-keydown": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.0.tgz",
-			"integrity": "sha512-JwfBCUIfhXRxKExgIqGa4CQsiMemo1Xt0W/B4ei3fpzpvPENKpMKQ8mZSB6Acj3ebrAEgi2xiQvcI1PAAodvyg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
+			"integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
-				"@radix-ui/react-use-callback-ref": "1.0.0"
+				"@radix-ui/react-use-callback-ref": "1.0.1"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@radix-ui/react-use-layout-effect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
-			"integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+			"integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10"
 			},
 			"peerDependencies": {
+				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@react-spring/animated": {
-			"version": "9.7.3",
-			"resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.3.tgz",
-			"integrity": "sha512-5CWeNJt9pNgyvuSzQH+uy2pvTg8Y4/OisoscZIR8/ZNLIOI+CatFBhGZpDGTF/OzdNFsAoGk3wiUYTwoJ0YIvw==",
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.4.tgz",
+			"integrity": "sha512-7As+8Pty2QlemJ9O5ecsuPKjmO0NKvmVkRR1n6mEotFgWar8FKuQt2xgxz3RTgxcccghpx1YdS1FCdElQNexmQ==",
 			"dependencies": {
-				"@react-spring/shared": "~9.7.3",
-				"@react-spring/types": "~9.7.3"
+				"@react-spring/shared": "~9.7.4",
+				"@react-spring/types": "~9.7.4"
 			},
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/@react-spring/core": {
-			"version": "9.7.3",
-			"resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.3.tgz",
-			"integrity": "sha512-IqFdPVf3ZOC1Cx7+M0cXf4odNLxDC+n7IN3MDcVCTIOSBfqEcBebSv+vlY5AhM0zw05PDbjKrNmBpzv/AqpjnQ==",
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.4.tgz",
+			"integrity": "sha512-GzjA44niEJBFUe9jN3zubRDDDP2E4tBlhNlSIkTChiNf9p4ZQlgXBg50qbXfSXHQPHak/ExYxwhipKVsQ/sUTw==",
 			"dependencies": {
-				"@react-spring/animated": "~9.7.3",
-				"@react-spring/shared": "~9.7.3",
-				"@react-spring/types": "~9.7.3"
+				"@react-spring/animated": "~9.7.4",
+				"@react-spring/shared": "~9.7.4",
+				"@react-spring/types": "~9.7.4"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1436,31 +1550,37 @@
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
+		"node_modules/@react-spring/rafz": {
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.4.tgz",
+			"integrity": "sha512-mqDI6rW0Ca8IdryOMiXRhMtVGiEGLIO89vIOyFQXRIwwIMX30HLya24g9z4olDvFyeDW3+kibiKwtZnA4xhldA=="
+		},
 		"node_modules/@react-spring/shared": {
-			"version": "9.7.3",
-			"resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.3.tgz",
-			"integrity": "sha512-NEopD+9S5xYyQ0pGtioacLhL2luflh6HACSSDUZOwLHoxA5eku1UPuqcJqjwSD6luKjjLfiLOspxo43FUHKKSA==",
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.4.tgz",
+			"integrity": "sha512-bEPI7cQp94dOtCFSEYpxvLxj0+xQfB5r9Ru1h8OMycsIq7zFZon1G0sHrBLaLQIWeMCllc4tVDYRTLIRv70C8w==",
 			"dependencies": {
-				"@react-spring/types": "~9.7.3"
+				"@react-spring/rafz": "~9.7.4",
+				"@react-spring/types": "~9.7.4"
 			},
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/@react-spring/types": {
-			"version": "9.7.3",
-			"resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.3.tgz",
-			"integrity": "sha512-Kpx/fQ/ZFX31OtlqVEFfgaD1ACzul4NksrvIgYfIFq9JpDHFwQkMVZ10tbo0FU/grje4rcL4EIrjekl3kYwgWw=="
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.4.tgz",
+			"integrity": "sha512-iQVztO09ZVfsletMiY+DpT/JRiBntdsdJ4uqk3UJFhrhS8mIC9ZOZbmfGSRs/kdbNPQkVyzucceDicQ/3Mlj9g=="
 		},
 		"node_modules/@react-spring/web": {
-			"version": "9.7.3",
-			"resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.3.tgz",
-			"integrity": "sha512-BXt6BpS9aJL/QdVqEIX9YoUy8CE6TJrU0mNCqSoxdXlIeNcEBWOfIyE6B14ENNsyQKS3wOWkiJfco0tCr/9tUg==",
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.4.tgz",
+			"integrity": "sha512-UMvCZp7I5HCVIleSa4BwbNxynqvj+mJjG2m20VO2yPoi2pnCYANy58flvz9v/YcXTAvsmL655FV3pm5fbr6akA==",
 			"dependencies": {
-				"@react-spring/animated": "~9.7.3",
-				"@react-spring/core": "~9.7.3",
-				"@react-spring/shared": "~9.7.3",
-				"@react-spring/types": "~9.7.3"
+				"@react-spring/animated": "~9.7.4",
+				"@react-spring/core": "~9.7.4",
+				"@react-spring/shared": "~9.7.4",
+				"@react-spring/types": "~9.7.4"
 			},
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
@@ -1849,13 +1969,13 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.1.0.tgz",
-			"integrity": "sha512-3sElZpfb72mWBRLD3k5YqwJi4zKQUQ6fBNrrNI+nY8/X8IyKWb5rDsNslqCkc3Zb+PpvtXns8hV3bQnoc+NUZA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.5.0.tgz",
+			"integrity": "sha512-sQmA4kTqu252to6ppVhti2RxSCFcAgWMc3l6rY2kBpj90uK5gtvLKQMr/GvydhildG/OzFSswbk1YBgSPGaudw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/dom-ready": "^4.1.0",
-				"@wordpress/i18n": "^5.1.0"
+				"@wordpress/dom-ready": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -1863,13 +1983,13 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.4.0.tgz",
-			"integrity": "sha512-14cEYs04nxhWEL/TjDVx1rUmmkCZvAzkbWTd5Yzg0S1ETVJpTpdChnLLiQpr9jWMffjVPo711kG2sKpKqNmi6g==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.5.0.tgz",
+			"integrity": "sha512-ShUbXTYaQD9G7rROidMtlByu4i1N8Pj4gB5tIUUg2d0IUwDdXJnABQWI2+ebSXLKIRNaAOrw/Gb5xef08TR0ag==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.4.0",
-				"@wordpress/url": "^4.4.0"
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/url": "^4.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -1877,9 +1997,9 @@
 			}
 		},
 		"node_modules/@wordpress/autop": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.1.0.tgz",
-			"integrity": "sha512-zA/7cAqrrM7hL/CZUlqBX38LS9vj3ho0wegREYsFhgLhLQ2Yxs8L+pslkN8WaRnBMOl7e7fQ16OYCtbjtlKekA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.5.0.tgz",
+			"integrity": "sha512-r68rGyfig+qxonsGQTOOWVpxnmGRYlWgzvDlGRPQbM3KKHA46C7ZS0kYhiZ1RC1RTinLRsu+KX2Y3FbEWcNaWg==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -1889,9 +2009,9 @@
 			}
 		},
 		"node_modules/@wordpress/blob": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.1.0.tgz",
-			"integrity": "sha512-sZhNg/2tGe+IyMWZvVsa0EIlKqvyKR5mRadKjHursE6zFAmC4QdgjE0ok+q4sup0m8hDVaBPVBBjDEzEnABqoA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.5.0.tgz",
+			"integrity": "sha512-EVTa4duxIesuRc9p8GWEGb3067v30tEngR+ZF1CoVrboRusJ8WSYtQdmEIvJRgQt3t7WTUtc6P4uAFjONOqU0g==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -1901,43 +2021,43 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-13.1.0.tgz",
-			"integrity": "sha512-LfXdXrplpbdZgPHKVlpf3J5tRvqJipf7fFtfspH4TMwtl+dW1UVo5Jvlkcvjp2DqkGcAg/PCm/OWBgi2wM53OA==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-14.0.0.tgz",
+			"integrity": "sha512-IODsUPm37DpZxLMcJXidlHeUAvALX+E9edY+z9UGJWP/PvhLCXllCRVQABcuYkPTsraFSF0Yrk9i/7WJF2NkaA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@emotion/react": "^11.7.1",
 				"@emotion/styled": "^11.6.0",
 				"@react-spring/web": "^9.4.5",
-				"@wordpress/a11y": "^4.1.0",
-				"@wordpress/api-fetch": "^7.1.0",
-				"@wordpress/blob": "^4.1.0",
-				"@wordpress/blocks": "^13.1.0",
-				"@wordpress/commands": "^1.1.0",
-				"@wordpress/components": "^28.1.0",
-				"@wordpress/compose": "^7.1.0",
-				"@wordpress/data": "^10.1.0",
-				"@wordpress/date": "^5.1.0",
-				"@wordpress/deprecated": "^4.1.0",
-				"@wordpress/dom": "^4.1.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/escape-html": "^3.1.0",
-				"@wordpress/hooks": "^4.1.0",
-				"@wordpress/html-entities": "^4.1.0",
-				"@wordpress/i18n": "^5.1.0",
-				"@wordpress/icons": "^10.1.0",
-				"@wordpress/is-shallow-equal": "^5.1.0",
-				"@wordpress/keyboard-shortcuts": "^5.1.0",
-				"@wordpress/keycodes": "^4.1.0",
-				"@wordpress/notices": "^5.1.0",
-				"@wordpress/preferences": "^4.1.0",
-				"@wordpress/private-apis": "^1.1.0",
-				"@wordpress/rich-text": "^7.1.0",
-				"@wordpress/style-engine": "^2.1.0",
-				"@wordpress/token-list": "^3.1.0",
-				"@wordpress/url": "^4.1.0",
-				"@wordpress/warning": "^3.1.0",
-				"@wordpress/wordcount": "^4.1.0",
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/api-fetch": "^7.5.0",
+				"@wordpress/blob": "^4.5.0",
+				"@wordpress/blocks": "^13.5.0",
+				"@wordpress/commands": "^1.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/date": "^5.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/dom": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/escape-html": "^3.5.0",
+				"@wordpress/hooks": "^4.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/is-shallow-equal": "^5.5.0",
+				"@wordpress/keyboard-shortcuts": "^5.5.0",
+				"@wordpress/keycodes": "^4.5.0",
+				"@wordpress/notices": "^5.5.0",
+				"@wordpress/preferences": "^4.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/rich-text": "^7.5.0",
+				"@wordpress/style-engine": "^2.5.0",
+				"@wordpress/token-list": "^3.5.0",
+				"@wordpress/url": "^4.5.0",
+				"@wordpress/warning": "^3.5.0",
+				"@wordpress/wordcount": "^4.5.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -1947,7 +2067,7 @@
 				"memize": "^2.1.0",
 				"postcss": "^8.4.21",
 				"postcss-prefixwrap": "^1.41.0",
-				"postcss-urlrebase": "^1.0.0",
+				"postcss-urlrebase": "^1.4.0",
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^5.0.6",
 				"remove-accents": "^0.5.0"
@@ -1962,44 +2082,44 @@
 			}
 		},
 		"node_modules/@wordpress/block-library": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.0.0.tgz",
-			"integrity": "sha512-v/BILeZvae1jgu/nQU30WB0QJRTcLSLrOXJxXJwAAL91XzBOTAkOgpb45BQlmQp9U2EzN78HtQjnU5yt3KLoww==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.5.0.tgz",
+			"integrity": "sha512-GjZtQzSDZQDg14dJdgEzj7Y2i4xdhVyr/avaIKmecdoKBLT0wuStf83H7XBxuR+ijf0DXPel6fGce5KUEJ4SiQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.0.0",
-				"@wordpress/api-fetch": "^7.0.0",
-				"@wordpress/autop": "^4.0.0",
-				"@wordpress/blob": "^4.0.0",
-				"@wordpress/block-editor": "^13.0.0",
-				"@wordpress/blocks": "^13.0.0",
-				"@wordpress/components": "^28.0.0",
-				"@wordpress/compose": "^7.0.0",
-				"@wordpress/core-data": "^7.0.0",
-				"@wordpress/data": "^10.0.0",
-				"@wordpress/date": "^5.0.0",
-				"@wordpress/deprecated": "^4.0.0",
-				"@wordpress/dom": "^4.0.0",
-				"@wordpress/element": "^6.0.0",
-				"@wordpress/escape-html": "^3.0.0",
-				"@wordpress/hooks": "^4.0.0",
-				"@wordpress/html-entities": "^4.0.0",
-				"@wordpress/i18n": "^5.0.0",
-				"@wordpress/icons": "^10.0.0",
-				"@wordpress/interactivity": "^6.0.0",
-				"@wordpress/interactivity-router": "^2.0.0",
-				"@wordpress/keyboard-shortcuts": "^5.0.0",
-				"@wordpress/keycodes": "^4.0.0",
-				"@wordpress/notices": "^5.0.0",
-				"@wordpress/patterns": "^2.0.0",
-				"@wordpress/primitives": "^4.0.0",
-				"@wordpress/private-apis": "^1.0.0",
-				"@wordpress/reusable-blocks": "^5.0.0",
-				"@wordpress/rich-text": "^7.0.0",
-				"@wordpress/server-side-render": "^5.0.0",
-				"@wordpress/url": "^4.0.0",
-				"@wordpress/viewport": "^6.0.0",
-				"@wordpress/wordcount": "^4.0.0",
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/api-fetch": "^7.5.0",
+				"@wordpress/autop": "^4.5.0",
+				"@wordpress/blob": "^4.5.0",
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/blocks": "^13.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/core-data": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/date": "^5.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/dom": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/escape-html": "^3.5.0",
+				"@wordpress/hooks": "^4.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/interactivity": "^6.5.0",
+				"@wordpress/interactivity-router": "^2.5.0",
+				"@wordpress/keyboard-shortcuts": "^5.5.0",
+				"@wordpress/keycodes": "^4.5.0",
+				"@wordpress/notices": "^5.5.0",
+				"@wordpress/patterns": "^2.5.0",
+				"@wordpress/primitives": "^4.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/reusable-blocks": "^5.5.0",
+				"@wordpress/rich-text": "^7.5.0",
+				"@wordpress/server-side-render": "^5.5.0",
+				"@wordpress/url": "^4.5.0",
+				"@wordpress/viewport": "^6.5.0",
+				"@wordpress/wordcount": "^4.5.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -2020,9 +2140,9 @@
 			}
 		},
 		"node_modules/@wordpress/block-serialization-default-parser": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.1.0.tgz",
-			"integrity": "sha512-aSBHoliIQXWBGVB9E62qrNG9wihAthZwQ5tvcah6dwWU9I3McMqmuvPmFii0EmkNW/sGn4Ji2hDkc8aWzyZUbA==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.5.0.tgz",
+			"integrity": "sha512-tUQ9LDFXbMvJY+BYI6lPqucwwSWISe9voBdwwYAbHfHcAcS5veYMdZGREOYpXNgmgd+RCI4+j49oy3EwqUUr4w==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -2032,25 +2152,26 @@
 			}
 		},
 		"node_modules/@wordpress/blocks": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-13.1.0.tgz",
-			"integrity": "sha512-utqXpeA7U8uuamIhHOC2/YXv6zSMuvuhtLNat4BT8g6oIIGm9qNSXIx7twkO8cAV9UJHgsN1wGVl1NADvxjoYw==",
+			"version": "13.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-13.5.0.tgz",
+			"integrity": "sha512-k8XSlVJQZ/HaZKib7HKILwi4MKMH8UxfdsB2j55Ed41v0exkV42wSK12H8IhFx6GXN/iy13m/f0tsIVGM4ZtIQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/autop": "^4.1.0",
-				"@wordpress/blob": "^4.1.0",
-				"@wordpress/block-serialization-default-parser": "^5.1.0",
-				"@wordpress/data": "^10.1.0",
-				"@wordpress/deprecated": "^4.1.0",
-				"@wordpress/dom": "^4.1.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/hooks": "^4.1.0",
-				"@wordpress/html-entities": "^4.1.0",
-				"@wordpress/i18n": "^5.1.0",
-				"@wordpress/is-shallow-equal": "^5.1.0",
-				"@wordpress/private-apis": "^1.1.0",
-				"@wordpress/rich-text": "^7.1.0",
-				"@wordpress/shortcode": "^4.1.0",
+				"@wordpress/autop": "^4.5.0",
+				"@wordpress/blob": "^4.5.0",
+				"@wordpress/block-serialization-default-parser": "^5.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/dom": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/hooks": "^4.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/is-shallow-equal": "^5.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/rich-text": "^7.5.0",
+				"@wordpress/shortcode": "^4.5.0",
+				"@wordpress/warning": "^3.5.0",
 				"change-case": "^4.1.2",
 				"colord": "^2.7.0",
 				"fast-deep-equal": "^3.1.3",
@@ -2077,20 +2198,20 @@
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
 		},
 		"node_modules/@wordpress/commands": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.1.0.tgz",
-			"integrity": "sha512-RWdSdcxtGbyYdWPi3W789Zmf5EUfa3Nlqm9PAfc0TRIhZArp5ahesbLbiD7ZAKswCX2kS7pbqU71fuvgsolt/Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.5.0.tgz",
+			"integrity": "sha512-44BoBnVkdOllkrqXY1lcjdEXzyQrk3WF7hC6IjBgGHhXtdHm4ejn1VthLiAlK2KeA+M/XT5H/x1AiAhpnsrToA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/components": "^28.1.0",
-				"@wordpress/data": "^10.1.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/i18n": "^5.1.0",
-				"@wordpress/icons": "^10.1.0",
-				"@wordpress/keyboard-shortcuts": "^5.1.0",
-				"@wordpress/private-apis": "^1.1.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/keyboard-shortcuts": "^5.5.0",
+				"@wordpress/private-apis": "^1.5.0",
 				"clsx": "^2.1.1",
-				"cmdk": "^0.2.0"
+				"cmdk": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2102,11 +2223,11 @@
 			}
 		},
 		"node_modules/@wordpress/components": {
-			"version": "28.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.1.0.tgz",
-			"integrity": "sha512-GIiwHbjlhxj4Eou/ObLEibU/nXNhQaXYJm41x73jptZ8n0wDw7Bl/GJ+nlQu7tDrliaCJ5mwp3zPLhmbjif53A==",
+			"version": "28.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.5.0.tgz",
+			"integrity": "sha512-kZPb8MdpGW/Yv/ycJhbf+myb4czkyQ28gb5PY1kT2ABRB07J3oS1/badSLex3x06zD6NPtJt3kInbPUsSF2prQ==",
 			"dependencies": {
-				"@ariakit/react": "^0.3.12",
+				"@ariakit/react": "^0.4.7",
 				"@babel/runtime": "^7.16.0",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
@@ -2118,29 +2239,28 @@
 				"@types/gradient-parser": "0.1.3",
 				"@types/highlight-words-core": "1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.1.0",
-				"@wordpress/compose": "^7.1.0",
-				"@wordpress/date": "^5.1.0",
-				"@wordpress/deprecated": "^4.1.0",
-				"@wordpress/dom": "^4.1.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/escape-html": "^3.1.0",
-				"@wordpress/hooks": "^4.1.0",
-				"@wordpress/html-entities": "^4.1.0",
-				"@wordpress/i18n": "^5.1.0",
-				"@wordpress/icons": "^10.1.0",
-				"@wordpress/is-shallow-equal": "^5.1.0",
-				"@wordpress/keycodes": "^4.1.0",
-				"@wordpress/primitives": "^4.1.0",
-				"@wordpress/private-apis": "^1.1.0",
-				"@wordpress/rich-text": "^7.1.0",
-				"@wordpress/warning": "^3.1.0",
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/date": "^5.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/dom": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/escape-html": "^3.5.0",
+				"@wordpress/hooks": "^4.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/is-shallow-equal": "^5.5.0",
+				"@wordpress/keycodes": "^4.5.0",
+				"@wordpress/primitives": "^4.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/rich-text": "^7.5.0",
+				"@wordpress/warning": "^3.5.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
 				"date-fns": "^3.6.0",
 				"deepmerge": "^4.3.0",
-				"downshift": "^6.0.15",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.1.9",
 				"gradient-parser": "^0.1.5",
@@ -2164,19 +2284,19 @@
 			}
 		},
 		"node_modules/@wordpress/compose": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.1.0.tgz",
-			"integrity": "sha512-YxH191innNfsCzloxPLhxJh98avjMqYKH8as9srXqy6alN6QDQX7t4JYqT3+vjgRpJPwfzW7aBP2IO+u0cAz2w==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.5.0.tgz",
+			"integrity": "sha512-jWRmleIGxmvTIC/1VYtAvq0iRfCkW/AtlNmqoKiyd0Ah5lccWRtxSH5V3Vh1BEkBQRANMWxJpOpRTKDFTcfTvg==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.1.0",
-				"@wordpress/dom": "^4.1.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/is-shallow-equal": "^5.1.0",
-				"@wordpress/keycodes": "^4.1.0",
-				"@wordpress/priority-queue": "^3.1.0",
-				"@wordpress/undo-manager": "^1.1.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/dom": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/is-shallow-equal": "^5.5.0",
+				"@wordpress/keycodes": "^4.5.0",
+				"@wordpress/priority-queue": "^3.5.0",
+				"@wordpress/undo-manager": "^1.5.0",
 				"change-case": "^4.1.2",
 				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
@@ -2191,26 +2311,27 @@
 			}
 		},
 		"node_modules/@wordpress/core-data": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.0.0.tgz",
-			"integrity": "sha512-ON/XJoUe4FenOkYX2Szu+V7M6CGmuR2sctUI9lfAyHOPT9j0pKdeBi+h0hN24pAiFDwWi4T4DVBmzAx3JEhJPw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.5.0.tgz",
+			"integrity": "sha512-NzKmf09yUw6ZH6NLRtM8qYci2HrA8dla2SJB4r/mtSpcVilDJL+j/hnuzMpvRJAGA5mWdB2ANnvlXWfG+BVsiA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^7.0.0",
-				"@wordpress/block-editor": "^13.0.0",
-				"@wordpress/blocks": "^13.0.0",
-				"@wordpress/compose": "^7.0.0",
-				"@wordpress/data": "^10.0.0",
-				"@wordpress/deprecated": "^4.0.0",
-				"@wordpress/element": "^6.0.0",
-				"@wordpress/html-entities": "^4.0.0",
-				"@wordpress/i18n": "^5.0.0",
-				"@wordpress/is-shallow-equal": "^5.0.0",
-				"@wordpress/private-apis": "^1.0.0",
-				"@wordpress/rich-text": "^7.0.0",
-				"@wordpress/sync": "^1.0.0",
-				"@wordpress/undo-manager": "^1.0.0",
-				"@wordpress/url": "^4.0.0",
+				"@wordpress/api-fetch": "^7.5.0",
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/blocks": "^13.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/is-shallow-equal": "^5.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/rich-text": "^7.5.0",
+				"@wordpress/sync": "^1.5.0",
+				"@wordpress/undo-manager": "^1.5.0",
+				"@wordpress/url": "^4.5.0",
+				"@wordpress/warning": "^3.5.0",
 				"change-case": "^4.1.2",
 				"equivalent-key-map": "^0.2.2",
 				"fast-deep-equal": "^3.1.3",
@@ -2227,18 +2348,18 @@
 			}
 		},
 		"node_modules/@wordpress/data": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.1.0.tgz",
-			"integrity": "sha512-qMG9vNRMaxqDn9R35+SM6ga8ebiIxgUNbPKtv5Y+JQza/bvKU8vH3HogOeu6wUCI1epgvQbDtnKxsoDMnNdXXw==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.5.0.tgz",
+			"integrity": "sha512-Y2P5SC0fuTivcfdYmubL3c15WRbE0FJAyYcEfZeJ2C37a2DmBnCBz3uEzGy2kCilz56qMfK0qutAHkfytOpRQw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^7.1.0",
-				"@wordpress/deprecated": "^4.1.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/is-shallow-equal": "^5.1.0",
-				"@wordpress/priority-queue": "^3.1.0",
-				"@wordpress/private-apis": "^1.1.0",
-				"@wordpress/redux-routine": "^5.1.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/is-shallow-equal": "^5.5.0",
+				"@wordpress/priority-queue": "^3.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/redux-routine": "^5.5.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -2256,12 +2377,12 @@
 			}
 		},
 		"node_modules/@wordpress/date": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.1.0.tgz",
-			"integrity": "sha512-YSoiT+sHCT1y7e9G5VIEIlMJZt0M2nmPHZ6AFdFHx4GOzNk5OwNeQqRrAy3IzHpVTi7V5Vgdaw437io9dbLyCA==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.5.0.tgz",
+			"integrity": "sha512-dIo02TAIuXG/wkcVf+jsyXn64PUVsxs6HwuHanNiDNVZt95QVJ8b7wdJZNIrhTkmVXhIUzYAz5BpuXUC6IZAqg==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^4.1.0",
+				"@wordpress/deprecated": "^4.5.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -2271,12 +2392,12 @@
 			}
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.1.0.tgz",
-			"integrity": "sha512-iZ/Vmhf3Tkq03DIuyef/+ZXsQanCZJsUc8xFPFXKn4ACHeo6Ds0krfFZ/AC0qwpW+cnHCaIEdqoEosHUnemGsQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.5.0.tgz",
+			"integrity": "sha512-r3xGAM45XTd+z+hnUvLGtSz+Y0ebybuw/cyE0CatksJBGvXez3kiTDaknALkgzjHRZzIGpNu6XTVUoIJs0H39A==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^4.1.0"
+				"@wordpress/hooks": "^4.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2284,12 +2405,12 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.1.0.tgz",
-			"integrity": "sha512-G3RhtPkuOLy/q46W4PWC5hMPX7Y7Gn7MLzbmOi1M5z0xUIWJWKXaxXx1hm6qgmRokY/Z8yRHl/PqEGe/UQIV6w==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.5.0.tgz",
+			"integrity": "sha512-XjnpRbbhZ1hdgv758vSXQacjfy/N0H2oI0oWukrLmlkKDP5ZrGfdziHQ2+KcoW+QDx8pu4JYcUpjmuJLugDStw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/deprecated": "^4.1.0"
+				"@wordpress/deprecated": "^4.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2297,9 +2418,9 @@
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.1.0.tgz",
-			"integrity": "sha512-FxlhDPGpe29rWLph3GpkQUG3sRSNRxji871S9+DviE4zt/872rKe6caum1QptsJN8rcn/hm+HIOS7qrYFjS2Xg==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.5.0.tgz",
+			"integrity": "sha512-5dALG1lQtoH/Rk7DWFe9DaIF2bQQM5U0x+c1lQnk1cnBJ69AijIcbZMYaMzlgngo4dVF2PnFZ/VKVSUOKghhQQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -2309,14 +2430,14 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.1.0.tgz",
-			"integrity": "sha512-DqAGqal1i6gTfYxz95zHnckbweS43MroHqMcz/Rww60pysTCoaRG5KZ/v4/3hry1tNCem1WQguY4ZMTF0MMTBQ==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.5.0.tgz",
+			"integrity": "sha512-N9w3jfceltdDEN71jpaMCXU+jbvec9kredvQIn/6YNiUMarPXWth7DJYU3+mDtbYawnTIvytzGjbj/J+bqqdHg==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@types/react": "^18.2.79",
 				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.1.0",
+				"@wordpress/escape-html": "^3.5.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -2328,9 +2449,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.1.0.tgz",
-			"integrity": "sha512-wcRGrGuGV4kTd5hJMXy/bdjCObqcwqFmd/HkDAUi2pfngEsv2aJhAeTfkGP5NwmY/F03Oqz2Qgd4UzTiIu2bjQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.5.0.tgz",
+			"integrity": "sha512-8dUWTmsDZuqAmBtRgk0JpiIafRKPM4n8tqCr147AugTbP/vyQ7rIzG3M/YCtVSmDr6f/qZ32YU8J7c34RhZ/9g==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -2340,23 +2461,23 @@
 			}
 		},
 		"node_modules/@wordpress/format-library": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/format-library/-/format-library-5.1.0.tgz",
-			"integrity": "sha512-oXUaGcFjW+qEq72lMaVeqqAe6KNNsNTiDvx/MkEe+bItSXBJtqxFCqpElHrnEQxK0qnAJz0Wreo1m0QdCTs7VA==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/format-library/-/format-library-5.5.0.tgz",
+			"integrity": "sha512-LMu9szPrXOEeZnv7EY/AobxtFdm6Gr82lY6HxMC9KROUByRzrLSgTWHO8IHGpsERT9tO3fO6CaJztO9MxPhU7A==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.1.0",
-				"@wordpress/block-editor": "^13.1.0",
-				"@wordpress/components": "^28.1.0",
-				"@wordpress/compose": "^7.1.0",
-				"@wordpress/data": "^10.1.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/html-entities": "^4.1.0",
-				"@wordpress/i18n": "^5.1.0",
-				"@wordpress/icons": "^10.1.0",
-				"@wordpress/private-apis": "^1.1.0",
-				"@wordpress/rich-text": "^7.1.0",
-				"@wordpress/url": "^4.1.0"
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/rich-text": "^7.5.0",
+				"@wordpress/url": "^4.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2368,9 +2489,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.4.0.tgz",
-			"integrity": "sha512-KO0gUx0KLhH3XCatg9ZOU1TH0fgyQUccAEIM8liErfgmrabHl8JhDoR2Uk5k0jNKZNPog7XxvKgPFVtCzvzQig==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.5.0.tgz",
+			"integrity": "sha512-wr1l1WM1yobyNGFLRgbLNBGtYIkzAGfmbT2e9zIOvqllRJT4wprYTqqhgovOKHlET5ij/TKdv4tApkGLUIXTsA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -2380,9 +2501,9 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.1.0.tgz",
-			"integrity": "sha512-9VXyZy99hZwkBK8p8p4bOo7oGOhyLlaVPoIX2D/bspcSh1r58CPXkHq8jK/+uqE8ihLs+WnW21Lud8qe0tg4Bw==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.5.0.tgz",
+			"integrity": "sha512-iQo2P1Sc499MxguelJ4aMcF08jnYkOdvb+FAOyOfGCyDjEtNbldRFc2BJ9NmJ/9nmtlwc/IzUzXop0M1gjy9tw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -2392,12 +2513,12 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.4.0.tgz",
-			"integrity": "sha512-nU4vpcBn5X+O/lUw2zhg44iTxh3smmBT6wLDFigGXpBKcVjJjlhVkwWLqpP/ZIc+mfhplgu4TJcTSbHyKsQLgg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.5.0.tgz",
+			"integrity": "sha512-MtCJIjNHCWs7R77f5Xml1CCnVXqrle4cDpqMU9myx4Cq8ZijqSayX1CTtwtk+Z3/3xa+dBZu5Koe4wiW1yIUSA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^4.4.0",
+				"@wordpress/hooks": "^4.5.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
@@ -2412,13 +2533,13 @@
 			}
 		},
 		"node_modules/@wordpress/icons": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.1.0.tgz",
-			"integrity": "sha512-s0USxIPq54Ubmsrz+lHepgJieKhi/PyvS/EI/ZVsFnyQbNKwuTSVHY2vifWrkZffwdG1XeP6Cz2Qnoy2cs9TeQ==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.5.0.tgz",
+			"integrity": "sha512-BZwKBRKoTef9uW73T+FwK6d4JlcvgdVAaz3LB5dCluXg5PLV5ufMdumAaMxKWq/Ffl92/ddt8CKIdHjxfAZF4A==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/primitives": "^4.1.0"
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/primitives": "^4.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2426,12 +2547,11 @@
 			}
 		},
 		"node_modules/@wordpress/interactivity": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.0.0.tgz",
-			"integrity": "sha512-s86Bj54jaUpY6lvwAqLLI7H9DhpYC470Rv0kEigL0S1bwtejOUE4diftSRbp4RGt2aFiDtPE3tlQihVUzf2e6A==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.5.0.tgz",
+			"integrity": "sha512-njxbzxBFfNDhiob0UKGTNvJAyKNEmHcZ9eN7Fb1Gl8jAFnMHWbG3D6dJt7Z/E8/W7aMOjRJn/OmNhhupNHkuMw==",
 			"dependencies": {
 				"@preact/signals": "^1.2.2",
-				"deepsignal": "^1.4.0",
 				"preact": "^10.19.3"
 			},
 			"engines": {
@@ -2440,11 +2560,11 @@
 			}
 		},
 		"node_modules/@wordpress/interactivity-router": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.0.0.tgz",
-			"integrity": "sha512-hAsZhI2TE7SZsFPAEmaJsuddr7M0aks8oxtqZwfDnDsgsAJBERJGsSfqo7O5iw9hJ7+TYTYUZi6MF5svt6POHA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.5.0.tgz",
+			"integrity": "sha512-8IukvNdtdHG3Dyzv9epfi6ZKg+Lv5W1a9wT6ueIRYHpmKY0Zvcsq/Oy0RnnsDFIBLNlsz6HTaVwNwPzOWwJEBA==",
 			"dependencies": {
-				"@wordpress/interactivity": "^6.0.0"
+				"@wordpress/interactivity": "^6.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2452,9 +2572,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.1.0.tgz",
-			"integrity": "sha512-OZH/p43ZNJaSF40oi6dNdlsLqxjd4pZ1H4QxDg46vXT0TztU1rT/HOeJWyVmHIjx/4utuGaLJBZcfK4cKPQXUg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.5.0.tgz",
+			"integrity": "sha512-nkCz45HgMBkjhyxffDgpAgJbfnKyZML94/gHhBtxizHfaNuZ5as7DfEyN1xgebvDiLbOaRU7em1pPAuEhIoTfQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -2464,14 +2584,14 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.1.0.tgz",
-			"integrity": "sha512-3FdZT+YjcbLbUVrWWbSWoNB79SdV93SNBk8N/5+f5ckQoG3z/A+jl9tUTUnI/Y/cf3HXEXmOpvH6423sQw+Taw==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.5.0.tgz",
+			"integrity": "sha512-U+64UvlrWjxnn6YJ5ZW7Oi9EJE9J7aWRGzpCAL8yoRDqiVC/zUzvgnVmo9AoA8jVEBxKUeDFyntckCE2qW0STQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/data": "^10.1.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/keycodes": "^4.1.0"
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/keycodes": "^4.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2482,12 +2602,12 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.1.0.tgz",
-			"integrity": "sha512-ibAR7qg4q7082s9kOPnZ0Hqb6KM/zjAZBjEH2Yrc2jwLJ83QDGKDWCSx6dNYkN7m9jGpH52w8j4nz1wcbFZSiw==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.5.0.tgz",
+			"integrity": "sha512-5kCxbP+xqAr0pwftdvnM+oAqGa6r0IQoct9TyvqXE2hdE9Cnu5RlnVG30Ki7/3d1KoMRBh00nFoS2RzpWbOq+A==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.1.0"
+				"@wordpress/i18n": "^5.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2495,13 +2615,13 @@
 			}
 		},
 		"node_modules/@wordpress/notices": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.1.0.tgz",
-			"integrity": "sha512-9UaeEfwaF3At3idyMW3iRf6LvL3/ztgMR5goars3UZch0RPpGugl1rRZQBAi3I/NvUoiF3HhYdPxUhB/bQYHBg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.5.0.tgz",
+			"integrity": "sha512-QcTbGAyHJ7V8LvSDJttUKCmClIFBQQ2/gk7pTBMBwe+argYQLOVRAQP/+97AnP9KFVtzuENrjbQtsyYeMWaTSw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.1.0",
-				"@wordpress/data": "^10.1.0"
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/data": "^10.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2512,25 +2632,25 @@
 			}
 		},
 		"node_modules/@wordpress/patterns": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.0.0.tgz",
-			"integrity": "sha512-wqZ90fjGiL99d/mmnKTLebM08USAAcdUjL400Xnjb8y2/cLbhN8aeh2yX6ZKqKZ2AAFNExtXh0XH3+qonYgYEA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.5.0.tgz",
+			"integrity": "sha512-jL41tCIShAUg017kGLSpD39L9zSWyepIiWZe+U0gD9FZo42c8aAMUmKTy4pwUI3hv67x0ZpvtcR5KegOJlZKfw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.0.0",
-				"@wordpress/block-editor": "^13.0.0",
-				"@wordpress/blocks": "^13.0.0",
-				"@wordpress/components": "^28.0.0",
-				"@wordpress/compose": "^7.0.0",
-				"@wordpress/core-data": "^7.0.0",
-				"@wordpress/data": "^10.0.0",
-				"@wordpress/element": "^6.0.0",
-				"@wordpress/html-entities": "^4.0.0",
-				"@wordpress/i18n": "^5.0.0",
-				"@wordpress/icons": "^10.0.0",
-				"@wordpress/notices": "^5.0.0",
-				"@wordpress/private-apis": "^1.0.0",
-				"@wordpress/url": "^4.0.0"
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/blocks": "^13.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/core-data": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/notices": "^5.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/url": "^4.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2542,20 +2662,20 @@
 			}
 		},
 		"node_modules/@wordpress/preferences": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.1.0.tgz",
-			"integrity": "sha512-4BGXljtwtYOYu9+UUgkQki/BpSE9G3KibeylyqLZk4+RadyHh0nYqPHlwDcyZ37MaNvmJ3EWpoWfgQ0oEPJ2CA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.5.0.tgz",
+			"integrity": "sha512-cDk+StQGyjwWzyo8dmVfdwYvL45hMd+m3qUNbP29PizJb4jPHBLVg4WTabuFG0I5TEs75zIjDWQsb3HeG//cHw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.1.0",
-				"@wordpress/components": "^28.1.0",
-				"@wordpress/compose": "^7.1.0",
-				"@wordpress/data": "^10.1.0",
-				"@wordpress/deprecated": "^4.1.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/i18n": "^5.1.0",
-				"@wordpress/icons": "^10.1.0",
-				"@wordpress/private-apis": "^1.1.0",
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/private-apis": "^1.5.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -2581,23 +2701,26 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.1.0.tgz",
-			"integrity": "sha512-+SSPqaHLz6ZNu+jDLoXYW+TFWyLsvZBQYjfU46YT6l6eWq3o7YO6Exrbr4wtEgXv1AY+b/9GJ8OUMPPywrXw0A==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.5.0.tgz",
+			"integrity": "sha512-1TYCpCAr2BmYJESlD8v325GgYXSgUbrFtebwgvpMN/28CEwmPN+ORRECV41nPX4yVJ2k0kYzYxzQUGp/78xWsw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/element": "^6.1.0",
+				"@wordpress/element": "^6.5.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.1.0.tgz",
-			"integrity": "sha512-soJddzCToRuF5ofayRUo0YYeJ9KZLM7ROzwwKIANOEcDt8+hnFRGmGorpfHYiDSThI4PtNqy6PdMOSy5/hvbFw==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.5.0.tgz",
+			"integrity": "sha512-ilbG70ZuUJd0UTC7uyLP8zI/ZSN0d4ceG3qwlDx13yQAcjAcuw1Ei1CwzFBsbmI3OS1KkfkDpwZzKOrA+j/00Q==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"requestidlecallback": "^0.3.0"
@@ -2608,9 +2731,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.1.0.tgz",
-			"integrity": "sha512-xsROx+IVeqaSTPDOToRnWVf1/K3K3P8qwxjN4EFVBA6KD1a53TG6iQkYBjm5DSBl4HNMheT2qTZc3nsaDiDFrw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.5.0.tgz",
+			"integrity": "sha512-taGW34kyyHMnbmTbWIyOJt7C4KFVCg7F5PNFwJQmS43FESC9BAjPw7VeEDTJ0XNqocH4NNeBJclhFyj82QySTQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -2620,9 +2743,9 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.1.0.tgz",
-			"integrity": "sha512-YKtJEOPdn5rpiSMJaWE+dz0P2p15uQS5Uqg5dSjrivvfmgW2JHp1E3HNTDLpmE/qHbBvSdrU8hx9qu7nS0tZZg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.5.0.tgz",
+			"integrity": "sha512-PvIgq0lI2PLjechCq+pRFIE/xbFwznytupGscD95qks3fFM9jtqVhlgO2oW0pA7C6CIz8zQ0zONFjsQlOaeDKA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"is-plain-object": "^5.0.0",
@@ -2638,22 +2761,22 @@
 			}
 		},
 		"node_modules/@wordpress/reusable-blocks": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.0.0.tgz",
-			"integrity": "sha512-KCJYENZ3KNaUlwZOogWNy2hDntfgSKj7drCh5gHOhg5MhSCkg+WJI7OTaf4CGJtIVQgAojRUeg/K++KFLOKRQQ==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.5.0.tgz",
+			"integrity": "sha512-lpin5UU7+RpgrpKjG65LHJWfbPWWDXdDDFsAkB6yNbbVamR0R9BMeFKzjPxKSfue7bRrmq2L7l9g9HneZcuvEQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/block-editor": "^13.0.0",
-				"@wordpress/blocks": "^13.0.0",
-				"@wordpress/components": "^28.0.0",
-				"@wordpress/core-data": "^7.0.0",
-				"@wordpress/data": "^10.0.0",
-				"@wordpress/element": "^6.0.0",
-				"@wordpress/i18n": "^5.0.0",
-				"@wordpress/icons": "^10.0.0",
-				"@wordpress/notices": "^5.0.0",
-				"@wordpress/private-apis": "^1.0.0",
-				"@wordpress/url": "^4.0.0"
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/blocks": "^13.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/core-data": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/notices": "^5.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/url": "^4.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2665,19 +2788,19 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.1.0.tgz",
-			"integrity": "sha512-PXwfAQ6cRnrsKorUmZiGH1D6CX3ywlp3T2odfrkj5dMhpWRnArJczQqI8lsAFB653PeX+7NCbtOsO/HXiGWajQ==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.5.0.tgz",
+			"integrity": "sha512-qHeTZNaLbsO6coBph1CD4qn/nfzvJV/DamiCpSgBJ1eQO7u8DdVB8abDxODOOD5hVOLHTOM/OBjFPTVFevNrmw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/a11y": "^4.1.0",
-				"@wordpress/compose": "^7.1.0",
-				"@wordpress/data": "^10.1.0",
-				"@wordpress/deprecated": "^4.1.0",
-				"@wordpress/element": "^6.1.0",
-				"@wordpress/escape-html": "^3.1.0",
-				"@wordpress/i18n": "^5.1.0",
-				"@wordpress/keycodes": "^4.1.0",
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/escape-html": "^3.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/keycodes": "^4.5.0",
 				"memize": "^2.1.0"
 			},
 			"engines": {
@@ -2689,20 +2812,20 @@
 			}
 		},
 		"node_modules/@wordpress/server-side-render": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-5.0.0.tgz",
-			"integrity": "sha512-7HZocZcTbqtKBXJOvaaVxbOlfH049pBu2OGMyVXB5ew5/Y+tTLfqZEpLR+pxveES+Rb/2QLqJU0NnRESS7CWXA==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-5.5.0.tgz",
+			"integrity": "sha512-k+ns+sQE6xJhoJ9mxwEmCTPVAedvPh1l1gkS0IlG8ST+cZbDiAPerfvVtlywrhsKz65w2VHK9HEBf7nkg1ivSA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^7.0.0",
-				"@wordpress/blocks": "^13.0.0",
-				"@wordpress/components": "^28.0.0",
-				"@wordpress/compose": "^7.0.0",
-				"@wordpress/data": "^10.0.0",
-				"@wordpress/deprecated": "^4.0.0",
-				"@wordpress/element": "^6.0.0",
-				"@wordpress/i18n": "^5.0.0",
-				"@wordpress/url": "^4.0.0",
+				"@wordpress/api-fetch": "^7.5.0",
+				"@wordpress/blocks": "^13.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/url": "^4.5.0",
 				"fast-deep-equal": "^3.1.3"
 			},
 			"engines": {
@@ -2715,9 +2838,9 @@
 			}
 		},
 		"node_modules/@wordpress/shortcode": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.1.0.tgz",
-			"integrity": "sha512-uK+VbeVd9NdJvh88mxqqMZ9Bt5aXvKFjuxI1f3+8yNfPyRJKMuWD1ZqGw5LvhEh5pXtyAsOcSgPb4O0AZvhnbQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.5.0.tgz",
+			"integrity": "sha512-Ed0Gh7ZMaz5UkVo6yF5eQY/Nzpv4afxrr8dGjMNQpmUbq92CwaAq8tfj5vT89IV/Ano0F2EQtkcyKEVJ7VPqrw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"memize": "^2.0.1"
@@ -2728,9 +2851,9 @@
 			}
 		},
 		"node_modules/@wordpress/style-engine": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.1.0.tgz",
-			"integrity": "sha512-OOSzArFGjN0CuyHKXDjl1rqJPAsjAZ/73UaEpx3MNvsXZL1nPfdK0dqIIHt3aEmYy44xAEoFDqhQPSiNIYAJgQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.5.0.tgz",
+			"integrity": "sha512-mV6cOtEO5zGg8ZYUNsHDBnywb76Jc+k1Q65PVSNezD+NtZasuASxZGz2J3gEwgNL/1p++JO7JQf9qyoZUs/jZw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"change-case": "^4.1.2"
@@ -2741,13 +2864,13 @@
 			}
 		},
 		"node_modules/@wordpress/sync": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.0.0.tgz",
-			"integrity": "sha512-B/OczyKPjop4/Ya7NTI+7qChDUr+kvjsr48nwdIypHvVM3XNI8QXQppUujlgSpRHXp9VpQsQkJC1EA//lnRHUw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.5.0.tgz",
+			"integrity": "sha512-c/p7YQqMjZAKFO3Q8FnikPp5Tm3/Iy4I0M4Rc5ML1VZMy+hwZVKQZ1AyfKfHAjDWv+XprSUVSbXpYL5YcYthlA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"@types/simple-peer": "^9.11.5",
-				"@wordpress/url": "^4.0.0",
+				"@wordpress/url": "^4.5.0",
 				"import-locals": "^2.0.0",
 				"lib0": "^0.2.42",
 				"simple-peer": "^9.11.0",
@@ -2762,9 +2885,9 @@
 			}
 		},
 		"node_modules/@wordpress/token-list": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.1.0.tgz",
-			"integrity": "sha512-Fw+MdhCMVhkoYA6qOAzIa2aaIvicsuE7rxUBJnrEZOH6XO4uksqql+rLHlf3BplzFowYo+lPKTHQKraaGHE9qw==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.5.0.tgz",
+			"integrity": "sha512-n/a7HYJz3b922qHcs4yyywzuFKZg8Du/xE6KSnPz9EiUVCHthYFJ8m587f9xtgdUDjZKK7fpZZ0yCK/Krwna+Q==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -2774,12 +2897,12 @@
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.1.0.tgz",
-			"integrity": "sha512-9n+tSxWomyfvGhCWA2fevIgP8/sLcMX3kwdBAwr3PQJ/EbOoamFh7BLMRbSk2oKfXaPSwk8aN4QE92BQpYnL5g==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.5.0.tgz",
+			"integrity": "sha512-ijvKwnXzKMV9xEcVB4mOIPih6BP5ZnZ1QYsv/EaPV7qlt2zgEevAHGa/FLQMW/lWlGCa5OhUK4tqDV+ZvrjTGw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/is-shallow-equal": "^5.1.0"
+				"@wordpress/is-shallow-equal": "^5.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2787,9 +2910,9 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.4.0.tgz",
-			"integrity": "sha512-t9yPr+c/T/8y04Yktdb/URJrQCQ4xPM7M9dq6h63IZHSaz3Ndr94Sn/1T10rXFlOoBJ6pr6AdetecFRfLLbh4g==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.5.0.tgz",
+			"integrity": "sha512-xv/wqUnqNedo9fyiCVJgZnfLtYJbBph30Z2neTFR8Ivy8HA4p74xGqlt8TJceYLeRUrT9EgsMITbHNJMftdNbA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"remove-accents": "^0.5.0"
@@ -2800,14 +2923,14 @@
 			}
 		},
 		"node_modules/@wordpress/viewport": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.0.0.tgz",
-			"integrity": "sha512-ffG7pSUCB5NGeJSvUZRWo/cIm3mRZMfI7sdiObbbRjWMuROmo+iGjmswHfJ7wNnOHHuRUDUMaPBZfS+tosh2ig==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.5.0.tgz",
+			"integrity": "sha512-kIBe26eQI1kcVF1kR983qX0P4r+NAO0yuiyLQcfqPc04P74icWiIbqnHWnKXJIxRIrM3UQBX0cvvhntQbjR8fg==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/compose": "^7.0.0",
-				"@wordpress/data": "^10.0.0",
-				"@wordpress/element": "^6.0.0"
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/element": "^6.5.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2818,18 +2941,18 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.1.0.tgz",
-			"integrity": "sha512-NKFqBXszT9YFpZJQQyEYqvTtkXse3XT3CDyV8gGWSeKhY4be1nDtFyGdZYYREGXccsGb8ftUmpilTDEVwNnsMA==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.5.0.tgz",
+			"integrity": "sha512-cYM2Vqf2EokJJoWHD5Ry15OUmdsKtDgR8/qxE0sWHUAdSQeoTuJZnqhgYI898cZGxHaZWX2xJCxQa7Qtwl8lqw==",
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/wordcount": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.1.0.tgz",
-			"integrity": "sha512-M20Iconm130KDIZSFmfIuaVgX7gbyf9oLUTN9i9RtvAxsirALcKSS+Gr3H4y58ndVRCRbmoKTHajE2FGUvyQUA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.5.0.tgz",
+			"integrity": "sha512-LgSA2Mra6e9r15eRUIFNk2TCWnoyNhecPOOWrT061sl9dEvJ92zAjNWILrMa8rnTTX651bnF2HJD1PkivxDVzw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -3348,11 +3471,12 @@
 			}
 		},
 		"node_modules/cmdk": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/cmdk/-/cmdk-0.2.1.tgz",
-			"integrity": "sha512-U6//9lQ6JvT47+6OF6Gi8BvkxYQ8SCRRSKIJkthIMsFsLZRG0cKvTtuTaefyIKMQb8rvvXy0wGdpTNq/jPtm+g==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.0.0.tgz",
+			"integrity": "sha512-gDzVf0a09TvoJ5jnuPvygTB77+XdOSwEmJ88L6XPFPlv7T3RxbP9jgenfylrAMD0+Le1aO0nVjQUzl2g+vjz5Q==",
 			"dependencies": {
-				"@radix-ui/react-dialog": "1.0.0"
+				"@radix-ui/react-dialog": "1.0.5",
+				"@radix-ui/react-primitive": "1.0.3"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0",
@@ -3376,11 +3500,6 @@
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
 			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
-		},
-		"node_modules/compute-scroll-into-view": {
-			"version": "1.0.20",
-			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
-			"integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
 		},
 		"node_modules/computed-style": {
 			"version": "0.1.4",
@@ -3541,31 +3660,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/deepsignal": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.5.0.tgz",
-			"integrity": "sha512-bFywDpBUUWMs576H2dgLFLLFuQ/UWXbzHfKD98MZTfGsl7+twIzvz4ihCNrRrZ/Emz3kqJaNIAp5eBWUEWhnAw==",
-			"peerDependencies": {
-				"@preact/signals": "^1.1.4",
-				"@preact/signals-core": "^1.5.1",
-				"@preact/signals-react": "^1.3.8 || ^2.0.0",
-				"preact": "^10.16.0"
-			},
-			"peerDependenciesMeta": {
-				"@preact/signals": {
-					"optional": true
-				},
-				"@preact/signals-core": {
-					"optional": true
-				},
-				"@preact/signals-react": {
-					"optional": true
-				},
-				"preact": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -3638,26 +3732,6 @@
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
 			}
-		},
-		"node_modules/downshift": {
-			"version": "6.1.12",
-			"resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
-			"integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
-			"dependencies": {
-				"@babel/runtime": "^7.14.8",
-				"compute-scroll-into-view": "^1.0.17",
-				"prop-types": "^15.7.2",
-				"react-is": "^17.0.2",
-				"tslib": "^2.3.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.12.0"
-			}
-		},
-		"node_modules/downshift/node_modules/react-is": {
-			"version": "17.0.2",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.4.796",
@@ -4315,9 +4389,9 @@
 			}
 		},
 		"node_modules/framer-motion": {
-			"version": "11.2.10",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.2.10.tgz",
-			"integrity": "sha512-/gr3PLZUVFCc86a9MqCUboVrALscrdluzTb3yew+2/qKBU8CX6nzs918/SRBRCqaPbx0TZP10CB6yFgK2C5cYQ==",
+			"version": "11.3.24",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.24.tgz",
+			"integrity": "sha512-kl0YI7HwAtyV0VOAWuU/rXoOS8+z5qSkMN6rZS+a9oe6fIha6SC3vjJN6u/hBpvjrg5MQNdSnqnjYxm0WYTX9g==",
 			"dependencies": {
 				"tslib": "^2.4.0"
 			},
@@ -5268,9 +5342,9 @@
 			}
 		},
 		"node_modules/lib0": {
-			"version": "0.2.94",
-			"resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.94.tgz",
-			"integrity": "sha512-hZ3p54jL4Wpu7IOg26uC7dnEWiMyNlUrb9KoG7+xYs45WkQwpVvKFndVq2+pqLYKe1u8Fp3+zAfZHVvTK34PvQ==",
+			"version": "0.2.96",
+			"resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.96.tgz",
+			"integrity": "sha512-xeV9M34+D4HD1sd6xAarnWYgU7pKau64bvmPySibX85G+hx/KonzISpO409K6OS9IVLORWfQZkKBRZV5sQegFQ==",
 			"dependencies": {
 				"isomorphic.js": "^0.2.4"
 			},
@@ -5763,17 +5837,17 @@
 			}
 		},
 		"node_modules/postcss-prefixwrap": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/postcss-prefixwrap/-/postcss-prefixwrap-1.48.0.tgz",
-			"integrity": "sha512-CXnUo/BsymtFe/4/ic3rbCGdd+SZQE7XJDl1gMtk5o0BUamO9G6L9OxKhbNYb20Na7paZhsKvaDqOeY522Hx5w==",
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/postcss-prefixwrap/-/postcss-prefixwrap-1.51.0.tgz",
+			"integrity": "sha512-PuP4md5zFSY921dUcLShwSLv2YyyDec0dK9/puXl/lu7ZNvJ1U59+ZEFRMS67xwfNg5nIIlPXnAycPJlhA/Isw==",
 			"peerDependencies": {
 				"postcss": "*"
 			}
 		},
 		"node_modules/postcss-urlrebase": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/postcss-urlrebase/-/postcss-urlrebase-1.3.0.tgz",
-			"integrity": "sha512-LOFN43n1IewKriXiypMNNinXeptttSyGGRLPbBMdQzuTvvCEo5mz/gG06y/HqrkN7p3ayHQf2R2bTBv639FOaQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/postcss-urlrebase/-/postcss-urlrebase-1.4.0.tgz",
+			"integrity": "sha512-rRaxMmWvXrn8Rk1PqsxmaJwldRHsr0WbbASKKCZYxXwotHkM/5X/6IrwaEe8pdzpbNGCEY86yhYMN0MhgOkADA==",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
 			},
@@ -5787,9 +5861,9 @@
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
 		},
 		"node_modules/preact": {
-			"version": "10.22.0",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.22.0.tgz",
-			"integrity": "sha512-RRurnSjJPj4rp5K6XoP45Ui33ncb7e4H7WiOHVpjbkvqvA3U+N8Z6Qbo0AE6leGYBV66n8EhEaFixvIu3SkxFw==",
+			"version": "10.23.1",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.23.1.tgz",
+			"integrity": "sha512-O5UdRsNh4vdZaTieWe3XOgSpdMAmkIYBCT3VhQDlKrzyCm8lUYsk0fmVEvoQQifoOjFRTaHZO69ylrzTW2BH+A==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
@@ -5921,9 +5995,9 @@
 			}
 		},
 		"node_modules/react-easy-crop": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.0.7.tgz",
-			"integrity": "sha512-6d5IUt09M3HwdDGwrcjPVgfrOfYWAOku8sCTn/xU7b1vkEg+lExMLwW8UbR39L8ybQi0hJZTU57yprF9h5Q5Ig==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.0.8.tgz",
+			"integrity": "sha512-KjulxXhR5iM7+ATN2sGCum/IyDxGw7xT0dFoGcqUP+ysaPU5Ka7gnrDa2tUHFHUoMNyPrVZ05QA+uvMgC5ym/g==",
 			"dependencies": {
 				"normalize-wheel": "^1.0.1",
 				"tslib": "^2.0.1"
@@ -5948,9 +6022,9 @@
 			}
 		},
 		"node_modules/react-remove-scroll": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.4.tgz",
-			"integrity": "sha512-xGVKJJr0SJGQVirVFAUZ2k1QLyO6m+2fy0l8Qawbp5Jgrv3DeLalrfMNBFSlmz5kriGGzsVBtGVnf4pTKIhhWA==",
+			"version": "2.5.5",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+			"integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
 			"dependencies": {
 				"react-remove-scroll-bar": "^2.3.3",
 				"react-style-singleton": "^2.2.1",
@@ -7125,9 +7199,9 @@
 			"dev": true
 		},
 		"node_modules/ws": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-			"integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
 			"optional": true,
 			"engines": {
 				"node": ">=10.0.0"
@@ -7312,9 +7386,9 @@
 			}
 		},
 		"node_modules/yjs": {
-			"version": "13.6.15",
-			"resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.15.tgz",
-			"integrity": "sha512-moFv4uNYhp8BFxIk3AkpoAnnjts7gwdpiG8RtyFiKbMtxKCS0zVZ5wPaaGpwC3V2N/K8TK8MwtSI3+WO9CHWjQ==",
+			"version": "13.6.18",
+			"resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.18.tgz",
+			"integrity": "sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==",
 			"dependencies": {
 				"lib0": "^0.2.86"
 			},

--- a/ReactApp/package-lock.json
+++ b/ReactApp/package-lock.json
@@ -12,6 +12,8 @@
 				"@wordpress/api-fetch": "^7.4.0",
 				"@wordpress/block-editor": "^14.0.0",
 				"@wordpress/block-library": "^9.5.0",
+				"@wordpress/core-data": "^7.5.0",
+				"@wordpress/editor": "^14.5.0",
 				"@wordpress/format-library": "^5.5.0",
 				"react": "^18.3.1"
 			},
@@ -2376,6 +2378,33 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/dataviews": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-4.1.0.tgz",
+			"integrity": "sha512-8lumuvMiVZgz4cYRv3hY4kmVeG7cNk+JtvRoEb0ysre0k6QEl/SZFinEge0eMfpsdvCdagFv4le/n7CXidEB2g==",
+			"dependencies": {
+				"@ariakit/react": "^0.4.7",
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/primitives": "^4.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/warning": "^3.5.0",
+				"clsx": "^2.1.1",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
 		"node_modules/@wordpress/date": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.5.0.tgz",
@@ -2427,6 +2456,67 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/editor": {
+			"version": "14.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.5.0.tgz",
+			"integrity": "sha512-6fsUiaTrluTiq403OZkaeHj8thclgrOYB2cQ/BoHg9OkUFOAae4cns0+LU+o8BobSY4KGX99v/WT4SMtg4h3TQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/api-fetch": "^7.5.0",
+				"@wordpress/blob": "^4.5.0",
+				"@wordpress/block-editor": "^14.0.0",
+				"@wordpress/blocks": "^13.5.0",
+				"@wordpress/commands": "^1.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/core-data": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/dataviews": "^4.1.0",
+				"@wordpress/date": "^5.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/dom": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/hooks": "^4.5.0",
+				"@wordpress/html-entities": "^4.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/interface": "^6.5.0",
+				"@wordpress/keyboard-shortcuts": "^5.5.0",
+				"@wordpress/keycodes": "^4.5.0",
+				"@wordpress/media-utils": "^5.5.0",
+				"@wordpress/notices": "^5.5.0",
+				"@wordpress/patterns": "^2.5.0",
+				"@wordpress/plugins": "^7.5.0",
+				"@wordpress/preferences": "^4.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/reusable-blocks": "^5.5.0",
+				"@wordpress/rich-text": "^7.5.0",
+				"@wordpress/server-side-render": "^5.5.0",
+				"@wordpress/url": "^4.5.0",
+				"@wordpress/warning": "^3.5.0",
+				"@wordpress/wordcount": "^4.5.0",
+				"change-case": "^4.1.2",
+				"client-zip": "^2.4.5",
+				"clsx": "^2.1.1",
+				"date-fns": "^3.6.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"react-autosize-textarea": "^7.1.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/element": {
@@ -2571,6 +2661,35 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/interface": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-6.5.0.tgz",
+			"integrity": "sha512-FLvXDb7namO6yCc/OipcEHauqCq1MKWSSLbnVBPlXDaTvoaw9LkU5JACI//yFemIe4v5RjKQ7fdXouccixosng==",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/a11y": "^4.5.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/data": "^10.5.0",
+				"@wordpress/deprecated": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/i18n": "^5.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/plugins": "^7.5.0",
+				"@wordpress/preferences": "^4.5.0",
+				"@wordpress/private-apis": "^1.5.0",
+				"@wordpress/viewport": "^6.5.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
 		"node_modules/@wordpress/is-shallow-equal": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.5.0.tgz",
@@ -2607,6 +2726,22 @@
 			"integrity": "sha512-5kCxbP+xqAr0pwftdvnM+oAqGa6r0IQoct9TyvqXE2hdE9Cnu5RlnVG30Ki7/3d1KoMRBh00nFoS2RzpWbOq+A==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^5.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-utils": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.5.0.tgz",
+			"integrity": "sha512-jrbM+lw6s2b5+CAOXs6K+NYGoZY0Yggu4X73RrKeYG9Vwmg23oMP742nZwztVGMuyr06Yh/1Ym7Amgfrd3cKqA==",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/api-fetch": "^7.5.0",
+				"@wordpress/blob": "^4.5.0",
+				"@wordpress/element": "^6.5.0",
 				"@wordpress/i18n": "^5.5.0"
 			},
 			"engines": {
@@ -2651,6 +2786,29 @@
 				"@wordpress/notices": "^5.5.0",
 				"@wordpress/private-apis": "^1.5.0",
 				"@wordpress/url": "^4.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/plugins": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.5.0.tgz",
+			"integrity": "sha512-1bvoT+Shi6FdrVgHqzzMyb3tF82eaSpvuRQsVYYPLCZnfEztDhdfuhgWD/M7oh2Mbxd4kkV1HWbMAKCbop/8/g==",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/components": "^28.5.0",
+				"@wordpress/compose": "^7.5.0",
+				"@wordpress/element": "^6.5.0",
+				"@wordpress/hooks": "^4.5.0",
+				"@wordpress/icons": "^10.5.0",
+				"@wordpress/is-shallow-equal": "^5.5.0",
+				"memize": "^2.0.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -3422,6 +3580,11 @@
 				"snake-case": "^3.0.4",
 				"tslib": "^2.0.3"
 			}
+		},
+		"node_modules/client-zip": {
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/client-zip/-/client-zip-2.4.5.tgz",
+			"integrity": "sha512-4y4d5ZeTH/szIAMQeC8ju67pxtvj+3u20wMGwOFrZk+pegy3aSEA2JkwgC8XVDTXP/Iqn1gyqNQXmkyBp4KLEQ=="
 		},
 		"node_modules/clipboard": {
 			"version": "2.0.11",

--- a/ReactApp/package.json
+++ b/ReactApp/package.json
@@ -14,9 +14,9 @@
 	"dependencies": {
 		"@monaco-editor/react": "^4.6.0",
 		"@wordpress/api-fetch": "^7.4.0",
-		"@wordpress/block-editor": "^13.0.0",
-		"@wordpress/block-library": "^9.0.0",
-		"@wordpress/format-library": "^5.1.0",
+		"@wordpress/block-editor": "^14.0.0",
+		"@wordpress/block-library": "^9.5.0",
+		"@wordpress/format-library": "^5.5.0",
 		"react": "^18.3.1"
 	},
 	"devDependencies": {

--- a/ReactApp/package.json
+++ b/ReactApp/package.json
@@ -16,6 +16,8 @@
 		"@wordpress/api-fetch": "^7.4.0",
 		"@wordpress/block-editor": "^14.0.0",
 		"@wordpress/block-library": "^9.5.0",
+		"@wordpress/core-data": "^7.5.0",
+		"@wordpress/editor": "^14.5.0",
 		"@wordpress/format-library": "^5.5.0",
 		"react": "^18.3.1"
 	},

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -107,33 +107,31 @@ function Editor({ post = POST_MOCK }) {
 	// }
 
 	return (
-		<>
+		<BlockEditorProvider
+			value={blocks}
+			onInput={didChangeBlocks}
+			onChange={didChangeBlocks}
+			settings={settings}
+		>
 			<div className="editor-visual-editor__post-title-wrapper">
 				<PostTitle ref={titleRef} />
 			</div>
-			<BlockEditorProvider
-				value={blocks}
-				onInput={didChangeBlocks}
-				onChange={didChangeBlocks}
-				settings={settings}
-			>
-				<BlockTools>
-					<div className="editor-styles-wrapper">
-						<BlockEditorKeyboardShortcuts.Register />
-						<WritingFlow>
-							<ObserveTyping>
-								<BlockList />
-								<EditorToolbar
-									registeredBlocks={registeredBlocks}
-								/>{' '}
-								{/* not sure if optimal placement */}
-							</ObserveTyping>
-						</WritingFlow>
-					</div>
-				</BlockTools>
-				<Popover.Slot />
-			</BlockEditorProvider>
-		</>
+			<BlockTools>
+				<div className="editor-styles-wrapper">
+					<BlockEditorKeyboardShortcuts.Register />
+					<WritingFlow>
+						<ObserveTyping>
+							<BlockList />
+							<EditorToolbar
+								registeredBlocks={registeredBlocks}
+							/>{' '}
+							{/* not sure if optimal placement */}
+						</ObserveTyping>
+					</WritingFlow>
+				</div>
+			</BlockTools>
+			<Popover.Slot />
+		</BlockEditorProvider>
 	);
 }
 

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -49,7 +49,9 @@ function Editor({ post = POST_MOCK }) {
 	const titleRef = useRef();
 	const { setupEditor } = useDispatch(editorStore);
 
-	setupEditor(post, [], {});
+	useEffect(() => {
+		setupEditor(post, [], {});
+	}, []);
 
 	function didChangeBlocks(blocks) {
 		setBlocks(blocks);

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 // WordPress
 import {
@@ -13,6 +13,8 @@ import { Popover } from '@wordpress/components';
 import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { parse, serialize, registerBlockType } from '@wordpress/blocks';
+import { store as editorStore, PostTitle } from '@wordpress/editor';
+import { useDispatch } from '@wordpress/data';
 
 // Default styles that are needed for the editor.
 import '@wordpress/components/build-style/style.css';
@@ -35,10 +37,19 @@ import { postMessage } from '../misc/Helpers';
 // Current editor (assumes can be only one instance).
 let editor = {};
 
-function Editor() {
+const POST_MOCK = {
+	id: 1,
+	type: 'post',
+};
+
+function Editor({ post = POST_MOCK }) {
 	const [blocks, setBlocks] = useState([]);
 	const [registeredBlocks, setRegisteredBlocks] = useState([]);
 	const [isCodeEditorEnabled, setCodeEditorEnabled] = useState(false);
+	const titleRef = useRef();
+	const { setupEditor } = useDispatch(editorStore);
+
+	setupEditor(post, [], {});
 
 	function didChangeBlocks(blocks) {
 		setBlocks(blocks);
@@ -89,7 +100,6 @@ function Editor() {
 
 	const settings = {
 		hasFixedToolbar: true,
-		bodyPlaceholder: 'Hello!',
 	};
 
 	// if (isCodeEditorEnabled) {
@@ -97,28 +107,33 @@ function Editor() {
 	// }
 
 	return (
-		<BlockEditorProvider
-			value={blocks}
-			onInput={didChangeBlocks}
-			onChange={didChangeBlocks}
-			settings={settings}
-		>
-			<BlockTools>
-				<div className="editor-styles-wrapper">
-					<BlockEditorKeyboardShortcuts.Register />
-					<WritingFlow>
-						<ObserveTyping>
-							<BlockList />
-							<EditorToolbar
-								registeredBlocks={registeredBlocks}
-							/>{' '}
-							{/* not sure if optimal placement */}
-						</ObserveTyping>
-					</WritingFlow>
-				</div>
-			</BlockTools>
-			<Popover.Slot />
-		</BlockEditorProvider>
+		<>
+			<div className="editor-visual-editor__post-title-wrapper">
+				<PostTitle ref={titleRef} />
+			</div>
+			<BlockEditorProvider
+				value={blocks}
+				onInput={didChangeBlocks}
+				onChange={didChangeBlocks}
+				settings={settings}
+			>
+				<BlockTools>
+					<div className="editor-styles-wrapper">
+						<BlockEditorKeyboardShortcuts.Register />
+						<WritingFlow>
+							<ObserveTyping>
+								<BlockList />
+								<EditorToolbar
+									registeredBlocks={registeredBlocks}
+								/>{' '}
+								{/* not sure if optimal placement */}
+							</ObserveTyping>
+						</WritingFlow>
+					</div>
+				</BlockTools>
+				<Popover.Slot />
+			</BlockEditorProvider>
+		</>
 	);
 }
 

--- a/ReactApp/src/index.css
+++ b/ReactApp/src/index.css
@@ -325,3 +325,22 @@ There has to be a setting or any other better way of doing that.
 	.components-popover__content {
 	min-width: 274px !important;
 }
+
+/* Post Title */
+.rich-text [data-rich-text-placeholder] {
+	pointer-events: none;
+}
+.rich-text [data-rich-text-placeholder]:after {
+	content: attr(data-rich-text-placeholder);
+	opacity: 0.62;
+}
+
+.editor-visual-editor__post-title-wrapper {
+	margin-top: 1rem;
+	min-height: 35px;
+}
+
+.editor-visual-editor__post-title-wrapper .wp-block-post-title {
+	font-size: 20px;
+	margin-bottom: 0;
+}


### PR DESCRIPTION
This PR introduces support for the `PostTitle` component in the editor by adding the following:

- Implements initial `setupEditor` support, currently setting up mock data for a post.
- Adds the `@wordpress/editor` and `@wordpress/core-data` packages.
- Updates other packages to maintain compatibility with the new additions.

<kbd><img src="https://github.com/user-attachments/assets/459e3e51-155e-4317-ae11-56c206fc96c7" width=250 /></kbd>


