### PR TITLE
Feat: Add initial API fetch setup

### DIFF
--- a/ReactApp/package-lock.json
+++ b/ReactApp/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@monaco-editor/react": "^4.6.0",
+				"@wordpress/api-fetch": "^7.4.0",
 				"@wordpress/block-editor": "^13.0.0",
 				"@wordpress/block-library": "^9.0.0",
 				"@wordpress/format-library": "^5.1.0",
@@ -1862,13 +1863,13 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.1.0.tgz",
-			"integrity": "sha512-mtEJi9IBPCRtNxyhP1VAwcLmncpQzt7CQX8rxhC4eAMnicamCG/fwZ3pFEKGXk3MUul3Bl1Q7y/UhdMtCGktGg==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.4.0.tgz",
+			"integrity": "sha512-14cEYs04nxhWEL/TjDVx1rUmmkCZvAzkbWTd5Yzg0S1ETVJpTpdChnLLiQpr9jWMffjVPo711kG2sKpKqNmi6g==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^5.1.0",
-				"@wordpress/url": "^4.1.0"
+				"@wordpress/i18n": "^5.4.0",
+				"@wordpress/url": "^4.4.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -2367,9 +2368,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.1.0.tgz",
-			"integrity": "sha512-uJ2zyLLs6AwWuEdLGv/P7oSXJuX27Ym6JglzWGBavxAKNXpTCCjiJwgxlZJbSjT3BzhRsRGl3bUMmzt3eh50Pg==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.4.0.tgz",
+			"integrity": "sha512-KO0gUx0KLhH3XCatg9ZOU1TH0fgyQUccAEIM8liErfgmrabHl8JhDoR2Uk5k0jNKZNPog7XxvKgPFVtCzvzQig==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -2391,12 +2392,12 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.1.0.tgz",
-			"integrity": "sha512-zNJiudByLnpIVhIS45hr92r53t+wRYp9a6XOJ585xNYeUmoUpymY5GTdLSrExmQaytMhV5cSXSn3qMMDBMjUsg==",
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.4.0.tgz",
+			"integrity": "sha512-nU4vpcBn5X+O/lUw2zhg44iTxh3smmBT6wLDFigGXpBKcVjJjlhVkwWLqpP/ZIc+mfhplgu4TJcTSbHyKsQLgg==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^4.1.0",
+				"@wordpress/hooks": "^4.4.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"sprintf-js": "^1.1.1",
@@ -2786,9 +2787,9 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.1.0.tgz",
-			"integrity": "sha512-6Yi9EbTgUGJgsm6XtfO4By8q2+9pTzWkxzx27ShKGF+PqIgIZjiDssf2NfD/oNUevIy48LbQMbyEyK+9r2Bw9A==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.4.0.tgz",
+			"integrity": "sha512-t9yPr+c/T/8y04Yktdb/URJrQCQ4xPM7M9dq6h63IZHSaz3Ndr94Sn/1T10rXFlOoBJ6pr6AdetecFRfLLbh4g==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"remove-accents": "^0.5.0"

--- a/ReactApp/package.json
+++ b/ReactApp/package.json
@@ -13,6 +13,7 @@
 	},
 	"dependencies": {
 		"@monaco-editor/react": "^4.6.0",
+		"@wordpress/api-fetch": "^7.4.0",
 		"@wordpress/block-editor": "^13.0.0",
 		"@wordpress/block-library": "^9.0.0",
 		"@wordpress/format-library": "^5.1.0",

--- a/ReactApp/src/main.jsx
+++ b/ReactApp/src/main.jsx
@@ -1,5 +1,13 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import './misc/api-fetch-setup';
 import App from './App.jsx';
 import './index.css';
 

--- a/ReactApp/src/main.jsx
+++ b/ReactApp/src/main.jsx
@@ -7,9 +7,11 @@ import ReactDOM from 'react-dom/client';
 /**
  * Internal dependencies
  */
-import './misc/api-fetch-setup';
+import { initializeApiFetch } from './misc/api-fetch-setup';
 import App from './App.jsx';
 import './index.css';
+
+initializeApiFetch();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
 	<React.StrictMode>

--- a/ReactApp/src/misc/api-fetch-setup.js
+++ b/ReactApp/src/misc/api-fetch-setup.js
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+apiFetch.use(apiFetch.createRootURLMiddleware(''));
+
+apiFetch.use((options, next) => {
+	options.headers = options.headers || new Headers();
+	options.headers.set('Content-Type', 'application/json');
+
+	return next({
+		...options,
+		headers: {
+			Authorization: 'Basic ',
+		},
+	});
+});
+
+// Preload some endpoints to return data needed for some components
+// Like PostTitle.
+const LOCAL_POST_ID = 1;
+const LOCAL_AUTHOR_ID = 1;
+
+apiFetch.use(
+	apiFetch.createPreloadingMiddleware({
+		'/wp/v2/types?context=view': {
+			body: {
+				post: {
+					description: '',
+					hierarchical: false,
+					has_archive: false,
+					name: 'Posts',
+					slug: 'post',
+					taxonomies: ['category', 'post_tag'],
+					rest_base: 'posts',
+					rest_namespace: 'wp/v2',
+					template: [],
+					template_lock: false,
+					_links: {},
+				},
+				page: {
+					description: '',
+					hierarchical: true,
+					has_archive: false,
+					name: 'Pages',
+					slug: 'page',
+					taxonomies: [],
+					rest_base: 'pages',
+					rest_namespace: 'wp/v2',
+					template: [],
+					template_lock: false,
+					_links: {},
+				},
+			},
+		},
+		'/wp/v2/types/post?context=edit': {
+			body: {
+				name: 'Posts',
+				slug: 'post',
+				supports: {
+					title: true,
+					editor: true,
+					author: true,
+					thumbnail: true,
+					excerpt: true,
+					trackbacks: true,
+					'custom-fields': true,
+					comments: true,
+					revisions: true,
+					'post-formats': true,
+					autosave: true,
+				},
+				taxonomies: ['category', 'post_tag'],
+				rest_base: 'posts',
+				rest_namespace: 'wp/v2',
+				template: [],
+				template_lock: false,
+			},
+		},
+		[`/wp/v2/posts/${LOCAL_POST_ID}?context=edit`]: {
+			body: {
+				id: LOCAL_POST_ID,
+				slug: '',
+				status: 'auto-draft',
+				type: 'post',
+				title: { raw: 'Auto Draft', rendered: 'Auto Draft' },
+				content: {
+					raw: '',
+					rendered: '',
+					protected: false,
+					block_version: 0,
+				},
+				excerpt: { raw: '', rendered: '', protected: false },
+				author: LOCAL_AUTHOR_ID,
+				featured_media: 0,
+			},
+		},
+	})
+);

--- a/ReactApp/src/misc/api-fetch-setup.js
+++ b/ReactApp/src/misc/api-fetch-setup.js
@@ -3,98 +3,106 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 
-apiFetch.use(apiFetch.createRootURLMiddleware(''));
+/**
+ * Initializes the API fetch configuration and middleware.
+ *
+ * This function sets up the root URL middleware, adds headers to requests,
+ * and preloads some endpoints with mock data for specific components.
+ */
+export function initializeApiFetch() {
+	apiFetch.use(apiFetch.createRootURLMiddleware(''));
 
-apiFetch.use((options, next) => {
-	options.headers = options.headers || new Headers();
-	options.headers.set('Content-Type', 'application/json');
+	apiFetch.use((options, next) => {
+		options.headers = options.headers || new Headers();
+		options.headers.set('Content-Type', 'application/json');
 
-	return next({
-		...options,
-		headers: {
-			Authorization: 'Basic ',
-		},
+		return next({
+			...options,
+			headers: {
+				Authorization: 'Basic ',
+			},
+		});
 	});
-});
 
-// Preload some endpoints to return data needed for some components
-// Like PostTitle.
-const LOCAL_POST_ID = 1;
-const LOCAL_AUTHOR_ID = 1;
+	// Preload some endpoints to return data needed for some components
+	// Like PostTitle.
+	const LOCAL_POST_ID = 1;
+	const LOCAL_AUTHOR_ID = 1;
 
-apiFetch.use(
-	apiFetch.createPreloadingMiddleware({
-		'/wp/v2/types?context=view': {
-			body: {
-				post: {
-					description: '',
-					hierarchical: false,
-					has_archive: false,
+	apiFetch.use(
+		apiFetch.createPreloadingMiddleware({
+			'/wp/v2/types?context=view': {
+				body: {
+					post: {
+						description: '',
+						hierarchical: false,
+						has_archive: false,
+						name: 'Posts',
+						slug: 'post',
+						taxonomies: ['category', 'post_tag'],
+						rest_base: 'posts',
+						rest_namespace: 'wp/v2',
+						template: [],
+						template_lock: false,
+						_links: {},
+					},
+					page: {
+						description: '',
+						hierarchical: true,
+						has_archive: false,
+						name: 'Pages',
+						slug: 'page',
+						taxonomies: [],
+						rest_base: 'pages',
+						rest_namespace: 'wp/v2',
+						template: [],
+						template_lock: false,
+						_links: {},
+					},
+				},
+			},
+			'/wp/v2/types/post?context=edit': {
+				body: {
 					name: 'Posts',
 					slug: 'post',
+					supports: {
+						title: true,
+						editor: true,
+						author: true,
+						thumbnail: true,
+						excerpt: true,
+						trackbacks: true,
+						'custom-fields': true,
+						comments: true,
+						revisions: true,
+						'post-formats': true,
+						autosave: true,
+					},
 					taxonomies: ['category', 'post_tag'],
 					rest_base: 'posts',
 					rest_namespace: 'wp/v2',
 					template: [],
 					template_lock: false,
-					_links: {},
-				},
-				page: {
-					description: '',
-					hierarchical: true,
-					has_archive: false,
-					name: 'Pages',
-					slug: 'page',
-					taxonomies: [],
-					rest_base: 'pages',
-					rest_namespace: 'wp/v2',
-					template: [],
-					template_lock: false,
-					_links: {},
 				},
 			},
-		},
-		'/wp/v2/types/post?context=edit': {
-			body: {
-				name: 'Posts',
-				slug: 'post',
-				supports: {
-					title: true,
-					editor: true,
-					author: true,
-					thumbnail: true,
-					excerpt: true,
-					trackbacks: true,
-					'custom-fields': true,
-					comments: true,
-					revisions: true,
-					'post-formats': true,
-					autosave: true,
+			[`/wp/v2/posts/${LOCAL_POST_ID}?context=edit`]: {
+				body: {
+					id: LOCAL_POST_ID,
+					slug: '',
+					status: 'auto-draft',
+					type: 'post',
+					title: { raw: 'Auto Draft', rendered: 'Auto Draft' },
+					content: {
+						raw: '',
+						rendered: '',
+						protected: false,
+						block_version: 0,
+					},
+					excerpt: { raw: '', rendered: '', protected: false },
+					author: LOCAL_AUTHOR_ID,
+					featured_media: 0,
 				},
-				taxonomies: ['category', 'post_tag'],
-				rest_base: 'posts',
-				rest_namespace: 'wp/v2',
-				template: [],
-				template_lock: false,
 			},
-		},
-		[`/wp/v2/posts/${LOCAL_POST_ID}?context=edit`]: {
-			body: {
-				id: LOCAL_POST_ID,
-				slug: '',
-				status: 'auto-draft',
-				type: 'post',
-				title: { raw: 'Auto Draft', rendered: 'Auto Draft' },
-				content: {
-					raw: '',
-					rendered: '',
-					protected: false,
-					block_version: 0,
-				},
-				excerpt: { raw: '', rendered: '', protected: false },
-				author: LOCAL_AUTHOR_ID,
-				featured_media: 0,
-			},
-		},
-	})
-);
+		})
+	);
+}


### PR DESCRIPTION
This PR adds the initial setup for the custom API Fetch implementation.

It brings changes from different PRs:
- https://github.com/wordpress-mobile/GutenbergKit/pull/7
- https://github.com/wordpress-mobile/GutenbergKit/pull/8
- https://github.com/wordpress-mobile/GutenbergKit/pull/9