### PR TITLE
Adds WordPress Element package

### DIFF
--- a/ReactApp/package-lock.json
+++ b/ReactApp/package-lock.json
@@ -14,6 +14,7 @@
 				"@wordpress/block-library": "^9.5.0",
 				"@wordpress/core-data": "^7.5.0",
 				"@wordpress/editor": "^14.5.0",
+				"@wordpress/element": "^6.5.0",
 				"@wordpress/format-library": "^5.5.0",
 				"react": "^18.3.1"
 			},

--- a/ReactApp/package.json
+++ b/ReactApp/package.json
@@ -18,6 +18,7 @@
 		"@wordpress/block-library": "^9.5.0",
 		"@wordpress/core-data": "^7.5.0",
 		"@wordpress/editor": "^14.5.0",
+		"@wordpress/element": "^6.5.0",
 		"@wordpress/format-library": "^5.5.0",
 		"react": "^18.3.1"
 	},

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
-
-// WordPress
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef, useState } from '@wordpress/element';
 import {
 	BlockEditorKeyboardShortcuts,
 	BlockEditorProvider,

--- a/ReactApp/src/components/EditorToolbar.jsx
+++ b/ReactApp/src/components/EditorToolbar.jsx
@@ -1,10 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
 import {
 	BlockInspector,
 	BlockToolbar,
 	Inserter,
 } from '@wordpress/block-editor';
 import { Popover } from '@wordpress/components';
-import { useState } from 'react';
 // import { Sheet } from 'react-modal-sheet';
 import { postMessage } from '../misc/Helpers';
 

--- a/ReactApp/src/main.jsx
+++ b/ReactApp/src/main.jsx
@@ -1,8 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { createRoot, StrictMode } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,8 +12,8 @@ import './index.css';
 
 initializeApiFetch();
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-	<React.StrictMode>
+createRoot(document.getElementById('root')).render(
+	<StrictMode>
 		<App />
-	</React.StrictMode>
+	</StrictMode>
 );


### PR DESCRIPTION
Following this [comment](https://github.com/wordpress-mobile/GutenbergKit/pull/9#discussion_r1711677965) we are adding the [@wordpress/element package](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-element/) to follow Core's practices to not import from React directly.