### PR TITLE
Add EditorSnackbars

### DIFF
--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -17,6 +17,7 @@ import { parse, serialize, registerBlockType } from '@wordpress/blocks';
 import {
 	store as editorStore,
 	mediaUpload,
+	EditorSnackbars,
 	PostTitle,
 } from '@wordpress/editor';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -25,6 +26,7 @@ import { store as coreStore } from '@wordpress/core-data';
 // Default styles that are needed for the editor.
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
+import '@wordpress/editor/build-style/style.css';
 
 // Default styles that are needed for the core blocks.
 import '@wordpress/block-library/build-style/style.css';
@@ -150,6 +152,7 @@ function Editor({ post = POST_MOCK }) {
 				</div>
 			</BlockTools>
 			<Popover.Slot />
+			<EditorSnackbars />
 		</BlockEditorProvider>
 	);
 }

--- a/ReactApp/src/index.css
+++ b/ReactApp/src/index.css
@@ -344,3 +344,14 @@ There has to be a setting or any other better way of doing that.
 	font-size: 20px;
 	margin-bottom: 0;
 }
+
+/* Snackbar */
+
+.components-editor-notices__snackbar {
+	bottom: 54px;
+	padding-left: 24px;
+	padding-right: 24px;
+	position: fixed;
+	right: 0;
+	left: 0;
+}


### PR DESCRIPTION
This PR adds the `EditorSnackbars` which is responsible for displaying editor notices within the Gutenberg interface.

## To test:

- Open the editor
- Copy a block using the block settings menu
- **Expect** to see the Snackbar with the "Copied" block message

## Screenshot

https://github.com/user-attachments/assets/5a42470e-00aa-4157-b62b-807984b3485e