### PR TITLE
feat: Authenticated API requests

### DIFF
--- a/ReactApp/src/main.jsx
+++ b/ReactApp/src/main.jsx
@@ -7,9 +7,11 @@ import { createRoot, StrictMode } from '@wordpress/element';
  * Internal dependencies
  */
 import { initializeApiFetch } from './misc/api-fetch-setup';
+import { getGBKit } from './misc/store.js';
 import App from './App.jsx';
 import './index.css';
 
+window.GBKit = getGBKit();
 initializeApiFetch();
 
 createRoot(document.getElementById('root')).render(

--- a/ReactApp/src/misc/api-fetch-setup.js
+++ b/ReactApp/src/misc/api-fetch-setup.js
@@ -19,22 +19,8 @@ export function initializeApiFetch() {
 	const rootURL = siteURL ? `${siteURL}/wp-json/` : undefined;
 
 	apiFetch.use(apiFetch.createRootURLMiddleware(rootURL));
-	apiFetch.use((options, next) => {
-		options.mode = 'cors';
-		return next(options);
-	});
-	apiFetch.use((options, next) => {
-		options.headers = {
-			...options.headers,
-			'Content-Type': 'application/json',
-		};
-
-		if (authToken) {
-			options.headers.Authorization = `Basic ${authToken}`;
-		}
-
-		return next(options);
-	});
+	apiFetch.use(corsMiddleware);
+	apiFetch.use(createHeadersMiddleware(authToken));
 
 	// Preload some endpoints to return data needed for some components
 	// Like PostTitle.
@@ -117,4 +103,24 @@ export function initializeApiFetch() {
 			},
 		})
 	);
+}
+
+function corsMiddleware(options, next) {
+	options.mode = 'cors';
+	return next(options);
+}
+
+function createHeadersMiddleware(authToken) {
+	return (options, next) => {
+		options.headers = {
+			...options.headers,
+			'Content-Type': 'application/json',
+		};
+
+		if (authToken) {
+			options.headers.Authorization = `Basic ${authToken}`;
+		}
+
+		return next(options);
+	};
 }

--- a/ReactApp/src/misc/api-fetch-setup.js
+++ b/ReactApp/src/misc/api-fetch-setup.js
@@ -112,10 +112,7 @@ function corsMiddleware(options, next) {
 
 function createHeadersMiddleware(authToken) {
 	return (options, next) => {
-		options.headers = {
-			...options.headers,
-			'Content-Type': 'application/json',
-		};
+		options.headers = options.headers || {};
 
 		if (authToken) {
 			options.headers.Authorization = `Basic ${authToken}`;

--- a/ReactApp/src/misc/api-fetch-setup.js
+++ b/ReactApp/src/misc/api-fetch-setup.js
@@ -20,6 +20,10 @@ export function initializeApiFetch() {
 
 	apiFetch.use(apiFetch.createRootURLMiddleware(rootURL));
 	apiFetch.use((options, next) => {
+		options.mode = 'cors';
+		return next(options);
+	});
+	apiFetch.use((options, next) => {
 		options.headers = {
 			...options.headers,
 			'Content-Type': 'application/json',

--- a/ReactApp/src/misc/api-fetch-setup.js
+++ b/ReactApp/src/misc/api-fetch-setup.js
@@ -4,24 +4,32 @@
 import apiFetch from '@wordpress/api-fetch';
 
 /**
+ * Internal dependencies
+ */
+import { getGBKit } from './store';
+
+/**
  * Initializes the API fetch configuration and middleware.
  *
  * This function sets up the root URL middleware, adds headers to requests,
  * and preloads some endpoints with mock data for specific components.
  */
 export function initializeApiFetch() {
-	apiFetch.use(apiFetch.createRootURLMiddleware(''));
+	const { siteURL, authToken } = getGBKit();
+	const rootURL = siteURL ? `${siteURL}/wp-json/` : undefined;
 
+	apiFetch.use(apiFetch.createRootURLMiddleware(rootURL));
 	apiFetch.use((options, next) => {
-		options.headers = options.headers || new Headers();
-		options.headers.set('Content-Type', 'application/json');
+		options.headers = {
+			...options.headers,
+			'Content-Type': 'application/json',
+		};
 
-		return next({
-			...options,
-			headers: {
-				Authorization: 'Basic ',
-			},
-		});
+		if (authToken) {
+			options.headers.Authorization = `Basic ${authToken}`;
+		}
+
+		return next(options);
 	});
 
 	// Preload some endpoints to return data needed for some components

--- a/ReactApp/src/misc/store.js
+++ b/ReactApp/src/misc/store.js
@@ -1,0 +1,19 @@
+/**
+ * Retrieves the native-host-provided GBKit object from localStorage or returns
+ * an empty object if not found.
+ *
+ * @returns {Object} The GBKit object.
+ */
+export function getGBKit() {
+	if (window.GBKit) {
+		return window.GBKit;
+	}
+
+	const emptyObject = {};
+	try {
+		return JSON.parse(localStorage.getItem('GBKit')) || emptyObject;
+	} catch (error) {
+		console.error('Failed parsing GBKit from localStorage:', error);
+		return emptyObject;
+	}
+}

--- a/Sources/GutenbergKit/Sources/EditorJSMessage.swift
+++ b/Sources/GutenbergKit/Sources/EditorJSMessage.swift
@@ -14,6 +14,11 @@ struct EditorJSMessage {
         self.body = object["body"]
     }
 
+    init(type: MessageType) {
+        self.type = type
+        self.body = nil
+    }
+
     func decode<T: Decodable>(_ type: T.Type) throws -> T {
         guard let body else {
             throw URLError(.unknown)
@@ -23,6 +28,8 @@ struct EditorJSMessage {
     }
 
     enum MessageType: String {
+        /// The web view loaded the specified URL or file
+        case onLoaded
         /// The editor was mounted (initial useEffect was called).
         case onEditorLoaded
         /// The editor content changed.

--- a/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -11,6 +11,8 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     private let controller = GutenbergEditorController()
     private let timestampInit = CFAbsoluteTimeGetCurrent()
     private let service: EditorService
+    private let siteURL: String
+    private let authToken: String
 
     public private(set) var state = EditorState()
 
@@ -33,9 +35,11 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     private var cancellables: [AnyCancellable] = []
 
     /// Initalizes the editor with the initial content (Gutenberg).
-    public init(content: String = "", service: EditorService) {
+    public init(content: String = "", service: EditorService, siteURL: String = "", authToken: String = "") {
         self._initialRawContent = content
         self.service = service
+        self.siteURL = siteURL
+        self.authToken = authToken
 
         Task {
             await service.warmup()
@@ -119,6 +123,17 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
             let reactAppURL = Bundle.module.url(forResource: "index", withExtension: "html", subdirectory: "Gutenberg")!
             webView.loadFileURL(reactAppURL, allowingReadAccessTo: Bundle.module.resourceURL!)
         }
+    }
+
+    func injectEditorConfiguration() {
+        evaluate("""
+        window.GBKit = {
+            siteURL: '\(siteURL)',
+            authToken: '\(authToken)'
+        };
+        localStorage.setItem('GBKit', JSON.stringify(window.GBKit));
+        "done";
+        """)
     }
 
     // MARK: - Public API
@@ -213,6 +228,8 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     fileprivate func controller(_ controller: GutenbergEditorController, didReceiveMessage message: EditorJSMessage) {
         do {
             switch message.type {
+            case .onLoaded:
+                injectEditorConfiguration()
             case .onEditorLoaded:
                 didLoadEditor()
             case .onBlocksChanged:
@@ -256,7 +273,9 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         }
         let editorViewController = EditorViewController(
             content: "",
-            service: EditorService(client: MockClient())
+            service: EditorService(client: MockClient()),
+            siteURL: "",
+            authToken: ""
         )
         _ = editorViewController.view // Trigger viewDidLoad
 
@@ -280,6 +299,10 @@ private final class GutenbergEditorController: NSObject, WKNavigationDelegate, W
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         NSLog("navigation: \(String(describing: navigation))")
+        MainActor.assumeIsolated {
+            let message = EditorJSMessage(type: EditorJSMessage.MessageType.onLoaded)
+            delegate?.controller(self, didReceiveMessage: message)
+        }
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {


### PR DESCRIPTION
Enable authenticated API requests to a site URL via the basic authentication
scheme with application passwords.

## Testing Instructions

1. Manually set `siteURL` and `authToken` values within the
   `EditorViewController` constructor.
1. Build and run the demo app.
1. Inspect the network traffic and verify the preloaded requests succeed.
