### PR TITLE
`test` SPM in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,9 @@ env:
   IMAGE_ID: $IMAGE_ID
 
 steps:
+  - label: ":bug: swift version?"
+    command: swift --version
+
   - label: ":react: Build React App"
     command: make build
     plugins: &plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,3 +25,7 @@ steps:
   - label: ":swift: Build Swift Package"
     command: make build_swift_package
     plugins: *plugins
+
+  - label: ":swift: Test Swift Package"
+    command: make test_swift_package
+    plugins: *plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,8 +19,6 @@ steps:
     agents:
       queue: android
     plugins: *plugins
-      - $CI_TOOLKIT_PLUGIN
-      - $NVM_PLUGIN
 
   - label: ":swift: Build Swift Package"
     command: make build_swift_package

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,10 +23,6 @@ steps:
       queue: android
     plugins: *plugins
 
-  - label: ":swift: Build Swift Package"
-    command: make build_swift_package
-    plugins: *plugins
-
   - label: ":swift: Test Swift Package"
     command: make test_swift_package
     plugins: *plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ env:
 steps:
   - label: ":react: Build React App"
     command: make build
-    plugins:
+    plugins: &plugins
       - $CI_TOOLKIT_PLUGIN
       - $NVM_PLUGIN
 
@@ -18,7 +18,10 @@ steps:
       ./Demo-Android/gradlew -p Demo-Android :gutenberg:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) :gutenberg:publish
     agents:
       queue: android
-    plugins:
+    plugins: *plugins
       - $CI_TOOLKIT_PLUGIN
       - $NVM_PLUGIN
 
+  - label: ":swift: Build Swift Package"
+    command: swift build
+    plugins: *plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,9 +5,6 @@ env:
   IMAGE_ID: $IMAGE_ID
 
 steps:
-  - label: ":bug: swift version?"
-    command: swift --version
-
   - label: ":react: Build React App"
     command: make build
     plugins: &plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,5 +23,5 @@ steps:
       - $NVM_PLUGIN
 
   - label: ":swift: Build Swift Package"
-    command: swift build
+    command: make build_swift_package
     plugins: *plugins

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ local-android-library: build
 	./Demo-Android/gradlew -p Demo-Android :gutenberg:publishToMavenLocal -exclude-task prepareToPublishToS3
 
 build_swift_package:
-	echo "--- :swift: Building Swift Package"
+	set -o pipefail # Otherwise, xcbeautify will swallow xcodebuild's error return code, if any
 	xcodebuild build \
 		-scheme GutenbergKit \
 		-sdk iphonesimulator \
@@ -36,6 +36,7 @@ build_swift_package:
 		| xcbeautify
 
 test_swift_package:
+	set -o pipefail # Otherwise, xcbeautify will swallow xcodebuild's error return code, if any
 	xcodebuild test \
 		-scheme GutenbergKit \
 		-sdk iphonesimulator \

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,10 @@ build_swift_package:
 		-sdk iphonesimulator \
 		-destination 'OS=17.5,name=iPhone 15 Plus' \
 		| xcbeautify
+
+test_swift_package:
+	xcodebuild test \
+		-scheme GutenbergKit \
+		-sdk iphonesimulator \
+		-destination 'OS=17.5,name=iPhone 15 Plus' \
+		| xcbeautify

--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,17 @@ local-android-library: build
 	./Demo-Android/gradlew -p Demo-Android :gutenberg:publishToMavenLocal -exclude-task prepareToPublishToS3
 
 build_swift_package:
-	# FIXME: Reintroduce xcbeautify once build failure in CI is sorted.
-	# Somehow, even with 'set -o pipefail' the failure from xcodebuild is swallowed
-	xcodebuild build \
+	@set -o pipefail && \
+		xcodebuild build \
 		-scheme GutenbergKit \
 		-sdk iphonesimulator \
-		-destination 'OS=17.5,name=iPhone 15 Plus'
+		-destination 'OS=17.5,name=iPhone 15 Plus' \
+		| xcbeautify
 
 test_swift_package:
-	xcodebuild test \
+	@set -o pipefail && \
+		xcodebuild test \
 		-scheme GutenbergKit \
 		-sdk iphonesimulator \
-		-destination 'OS=17.5,name=iPhone 15 Plus'
+		-destination 'OS=17.5,name=iPhone 15 Plus' \
+		| xcbeautify

--- a/Makefile
+++ b/Makefile
@@ -28,17 +28,15 @@ local-android-library: build
 	./Demo-Android/gradlew -p Demo-Android :gutenberg:publishToMavenLocal -exclude-task prepareToPublishToS3
 
 build_swift_package:
-	set -o pipefail # Otherwise, xcbeautify will swallow xcodebuild's error return code, if any
+	# FIXME: Reintroduce xcbeautify once build failure in CI is sorted.
+	# Somehow, even with 'set -o pipefail' the failure from xcodebuild is swallowed
 	xcodebuild build \
 		-scheme GutenbergKit \
 		-sdk iphonesimulator \
-		-destination 'OS=17.5,name=iPhone 15 Plus' \
-		| xcbeautify
+		-destination 'OS=17.5,name=iPhone 15 Plus'
 
 test_swift_package:
-	set -o pipefail # Otherwise, xcbeautify will swallow xcodebuild's error return code, if any
 	xcodebuild test \
 		-scheme GutenbergKit \
 		-sdk iphonesimulator \
-		-destination 'OS=17.5,name=iPhone 15 Plus' \
-		| xcbeautify
+		-destination 'OS=17.5,name=iPhone 15 Plus'

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,11 @@ lint-js: npm-dependencies
 local-android-library: build
 	echo "--- :android: Building Library"
 	./Demo-Android/gradlew -p Demo-Android :gutenberg:publishToMavenLocal -exclude-task prepareToPublishToS3
+
+build_swift_package:
+	echo "--- :swift: Building Swift Package"
+	xcodebuild build \
+		-scheme GutenbergKit \
+		-sdk iphonesimulator \
+		-destination 'OS=17.5,name=iPhone 15 Plus' \
+		| xcbeautify

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,15 @@
 
+SIMULATOR_DESTINATION := OS=17.5,name=iPhone 15 Plus
+
+define XCODEBUILD_CMD
+	@set -o pipefail && \
+		xcodebuild $(1) \
+		-scheme GutenbergKit \
+		-sdk iphonesimulator \
+		-destination '${SIMULATOR_DESTINATION}' \
+		| xcbeautify
+endef
+
 npm-dependencies:
 	echo "--- :npm: Installing NPM Dependencies"
 	npm --prefix ReactApp/ ci
@@ -28,17 +39,7 @@ local-android-library: build
 	./Demo-Android/gradlew -p Demo-Android :gutenberg:publishToMavenLocal -exclude-task prepareToPublishToS3
 
 build_swift_package: build
-	@set -o pipefail && \
-		xcodebuild build \
-		-scheme GutenbergKit \
-		-sdk iphonesimulator \
-		-destination 'OS=17.5,name=iPhone 15 Plus' \
-		| xcbeautify
+	$(call XCODEBUILD_CMD, build)
 
 test_swift_package: build
-	@set -o pipefail && \
-		xcodebuild test \
-		-scheme GutenbergKit \
-		-sdk iphonesimulator \
-		-destination 'OS=17.5,name=iPhone 15 Plus' \
-		| xcbeautify
+	$(call XCODEBUILD_CMD, test)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ local-android-library: build
 	echo "--- :android: Building Library"
 	./Demo-Android/gradlew -p Demo-Android :gutenberg:publishToMavenLocal -exclude-task prepareToPublishToS3
 
-build_swift_package:
+build_swift_package: build
 	@set -o pipefail && \
 		xcodebuild build \
 		-scheme GutenbergKit \
@@ -35,7 +35,7 @@ build_swift_package:
 		-destination 'OS=17.5,name=iPhone 15 Plus' \
 		| xcbeautify
 
-test_swift_package:
+test_swift_package: build
 	@set -o pipefail && \
 		xcodebuild test \
 		-scheme GutenbergKit \

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     targets: [
         .target(
             name: "GutenbergKit",
-            resources: [.copy("Gutenberg")]
+            resources: [.process("Gutenberg")]
         ),
         .testTarget(
             name: "GutenbergKitTests",

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     targets: [
         .target(
             name: "GutenbergKit",
-            resources: [.process("Gutenberg")]
+            resources: [.copy("Gutenberg")]
         ),
         .testTarget(
             name: "GutenbergKitTests",

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A proof of concept Gutenberg editor for native iOS apps built using web technolo
 
 ## Development
 
+Before getting started, you'll need the Node dependencies to be checked out locally, which you can get by running `make build`.
+
 ### React App
 
 The ReactJS app is embedded in the native GutenbergKit module.
@@ -22,7 +24,7 @@ A Swift package with native wrappers for the Gutenberg editor.
 
 ### Demo
 
-A host app that can be used to test the changes made to the editor quickly. 
+A host app that can be used to test the changes made to the editor quickly.
 
 By default, the demo app uses a production build of the React app included in the `GutenbergKit` package. During development, make sure to run the React app and pass the localhost URL as an environment variable of the demo app.
 

--- a/Tests/GutenbergKitTests/GutenbergKitTests.swift
+++ b/Tests/GutenbergKitTests/GutenbergKitTests.swift
@@ -3,11 +3,6 @@ import XCTest
 
 final class GutenbergKitTests: XCTestCase {
     func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
-
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
-        XCTAssert(false)
+        XCTAssert(true)
     }
 }

--- a/Tests/GutenbergKitTests/GutenbergKitTests.swift
+++ b/Tests/GutenbergKitTests/GutenbergKitTests.swift
@@ -8,5 +8,6 @@ final class GutenbergKitTests: XCTestCase {
 
         // Defining Test Cases and Test Methods
         // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+        XCTAssert(false)
     }
 }


### PR DESCRIPTION
This PR runs the tests for the GutenbergKit Swift package in CI. Or rather, the only dummy test currently present.

Even though there are no "real" tests, I think it's still valuable to have this in CI as a check that the standalone package builds with the `xcodebuild` toolchain.

I didn't add a `build` step because it is implicit in the `test` step.

Took me a while to get this sorted because I didn't realize the dependency on Node libraries.

To be fair, I should have realized it myself given what I know about this library. Anyway... I added a note in the readme about it.

<details>
<summary>For posterity, here are the various notes from the research process to understand why the build failed in CI but not locally.</summary>


Commands work on my machine

![image](https://github.com/user-attachments/assets/760efd56-cdc3-4fc1-b11f-270c6abcf959)
![image](https://github.com/user-attachments/assets/53a7fd70-6c47-425a-949c-3f5161485363)

But fail in CI because of:

```
❌ /opt/ci/builds/builder/automattic/gutenbergkit/Sources/GutenbergKit/Sources/EditorViewController.swift:123:38: type 'Bundle' has no member 'module'
   let reactAppURL = Bundle.module.url(forResource: "index", withExtension: "html", subdirectory: "Gutenberg")!
```

I remember seeing something about SPM and `Bundle` but can't recall exactly ATM.

---

Update: Still not sure what's going on, but I did notice this additional difference in behavior.

[In CI](https://buildkite.com/automattic/gutenbergkit/builds/23#01917c14-9821-4717-bde4-9b30f22b7013/360-365):

```
ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (2 targets)
    Target 'GutenbergKit' in project 'GutenbergKit'
        ➜ Explicit dependency on target 'GutenbergKit' in project 'GutenbergKit'
    Target 'GutenbergKit' in project 'GutenbergKit' (no dependencies)
```

On my machine:

```
ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (3 targets)
    Target 'GutenbergKit' in project 'GutenbergKit'
        ➜ Explicit dependency on target 'GutenbergKit' in project ' GutenbergKit'
        ➜ Explicit dependency on target 'GutenbergKit_GutenbergKit' in project 'GutenbergKit'
    Target 'GutenbergKit' in project 'GutenbergKit'
        ➜ Explicit dependency on target 'GutenbergKit_GutenbergKit' in project 'GutenbergKit'
    Target 'GutenbergKit_GutenbergKit' in project 'GutenbergKit' (no dependencies)
```

As far as I can tell, the Xcode and `swift` version are the same, and both machines are Apple Silicon ones.

I ensured I run the command on a clean slate, via `rm -rf .build .swiftpm DerivedData`.

The difference in logs continues from there. Once piped through `xcbeautify` we see...

In CI:

```
Resolving Package Graph
Resolved source packages
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:iOS Simulator, id:891BEEDE-F90E-4897-8706-CF1ED3439746, OS:17.5, name:iPhone 15 Plus }
{ platform:iOS Simulator, id:891BEEDE-F90E-4897-8706-CF1ED3439746, OS:17.5, name:iPhone 15 Plus }
[GutenbergKit] Write Auxiliary File GutenbergKit.modulemap
[GutenbergKit] Write Auxiliary File GutenbergKit-OutputFileMap.json
[GutenbergKit] Write Auxiliary File GutenbergKit.LinkFileList
[GutenbergKit] Write Auxiliary File GutenbergKit_const_extract_protocols.json
[GutenbergKit] Write Auxiliary File GutenbergKit.SwiftFileList
[GutenbergKit] Compiling EditorViewControllerDelegate.swift
[GutenbergKit] Compiling GBWebView.swift
[GutenbergKit] Compiling EditorViewController.swift
❌ /opt/ci/builds/builder/automattic/gutenbergkit/Sources/GutenbergKit/Sources/EditorViewController.swift:123:38: type 'Bundle' has no member 'module'
            let reactAppURL = Bundle.module.url(forResource: "index", withExtension: "html", subdirectory: "Gutenberg")!
                              ~~~~~~ ^~~~~~
❌ /opt/ci/builds/builder/automattic/gutenbergkit/Sources/GutenbergKit/Sources/EditorViewController.swift:124:75: type 'Bundle' has no member 'module'
            webView.loadFileURL(reactAppURL, allowingReadAccessTo: Bundle.module.resourceURL!)
                                                                   ~~~~~~ ^~~~~~
[GutenbergKit] Compiling EditorJSMessage.swift
[GutenbergKit] Compiling EditorBlockPicker.swift
[GutenbergKit] Compiling EditorNetworking.swift
[GutenbergKit] Compiling EditorTypes.swift
[GutenbergKit] Compiling AnyDecodable.swift
[GutenbergKit] Compiling EditorService.swift
[GutenbergKit] Compiling EditorBlock.swift
** BUILD FAILED **
```

On my machines:

```
➜ make build_swift_package
Resolving Package Graph
Resolved source packages
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:iOS Simulator, id:CEBA9115-EF7F-4037-ACD8-894EFD21496C, OS:17.5, name:iPhone 15 Plus }
{ platform:iOS Simulator, id:CEBA9115-EF7F-4037-ACD8-894EFD21496C, OS:17.5, name:iPhone 15 Plus }
[GutenbergKit_GutenbergKit] Copying Gutenberg
[GutenbergKit_GutenbergKit] Processing empty-GutenbergKit_GutenbergKit.plist
Signing GutenbergKit_GutenbergKit.bundle (in target 'GutenbergKit_GutenbergKit' from project 'GutenbergKit')
[GutenbergKit_GutenbergKit] Touching GutenbergKit_GutenbergKit.bundle
Build Succeeded
```

As you can tell, there's quite the difference in the files that are being compiled 🤔 

---

Update: Good news! I can replicate the behavior on a clean checkout. Now... what's the difference between a clean checkout and my local copy after I already deleted `.build` `.swiftpm` and `DerivedData`?

</details>