### PR TITLE
Simplify `sed` usage in shared pipeline var

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -4,10 +4,10 @@
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
 # The ~> modifier is not currently used, but we check for it just in case
-XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
+XCODE_VERSION=$(sed 's/^~> *//' .xcode-version)
 CI_TOOLKIT_PLUGIN_VERSION="3.5.1"
 NVM_PLUGIN_VERSION='0.3.0'
 
-export IMAGE_ID="$XCODE_VERSION"
+export IMAGE_ID="xcode-$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"
 export NVM_PLUGIN="automattic/nvm#$NVM_PLUGIN_VERSION"


### PR DESCRIPTION
Followup to https://github.com/wordpress-mobile/GutenbergKit/pull/18#discussion_r1725765895 which I didn't have a chance to apply before merging. 

@AliSoftware I like the new pattern and will try to remember to update all the repos I land in to use it.