### PR TITLE
Feature: Android - Add initial Editor params

### DIFF
--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -168,7 +168,11 @@ class GutenbergView : WebView {
         this.evaluateJavascript("editor.setTitle('$newTitle');", null)
     }
 
-    fun getTitleAndContent(callback: (title: String, content: String) -> Unit) {
+    interface TitleAndContentCallback {
+        fun onResult(title: String, content: String)
+    }
+
+    fun getTitleAndContent(callback: TitleAndContentCallback) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
@@ -177,7 +181,7 @@ class GutenbergView : WebView {
             val jsonObject = JSONObject(result)
             val title = jsonObject.getString("title")
             val content = jsonObject.getString("content")
-            callback(title, content)
+            callback.onResult(title, content)
         }
     }
 

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -71,24 +71,7 @@ class GutenbergView : WebView {
     )
 
     @SuppressLint("SetJavaScriptEnabled") // Without JavaScript we have no Gutenberg
-    fun start(
-        siteApiRoot: String = "",
-        siteApiNamespace: String = "",
-        authHeader: String = "",
-        themeStyles: Boolean = false,
-        postId: Int? = null,
-        postType: String = "",
-        postTitle: String = "",
-        postContent: String = ""
-    ) {
-        id = postId
-        type = postType
-        initialTitle = postTitle
-        initialContent = postContent
-        this.themeStyles = themeStyles
-        this.siteApiRoot = siteApiRoot
-        this.siteApiNamespace = siteApiNamespace
-        this.authHeader = authHeader
+    fun initializeWebView() {
         this.settings.javaScriptCanOpenWindowsAutomatically = true
         this.settings.javaScriptEnabled = true
         this.settings.domStorageEnabled = true;
@@ -164,6 +147,28 @@ class GutenbergView : WebView {
                 return true
             }
         }
+    }
+
+    fun start(
+        siteApiRoot: String = "",
+        siteApiNamespace: String = "",
+        authHeader: String = "",
+        themeStyles: Boolean = false,
+        postId: Int? = null,
+        postType: String = "",
+        postTitle: String = "",
+        postContent: String = ""
+    ) {
+        id = postId
+        type = postType
+        initialTitle = postTitle
+        initialContent = postContent
+        this.themeStyles = themeStyles
+        this.siteApiRoot = siteApiRoot
+        this.siteApiNamespace = siteApiNamespace
+        this.authHeader = authHeader
+
+        initializeWebView()
 
         // Production mode – load the assets from the app bundle – you'll need to copy
         // this value out of the `dist` directory after building GutenbergKit
@@ -329,8 +334,7 @@ object GutenbergWebViewPool {
 
     private fun createAndPreloadWebView(context: Context): GutenbergView {
         val webView = GutenbergView(context)
-        webView.settings.javaScriptEnabled = true
-        webView.settings.domStorageEnabled = true
+        webView.initializeWebView()
         webView.loadUrl(ASSET_URL)
         return webView
     }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -170,9 +170,6 @@ class GutenbergView : WebView {
         this.siteApiRoot = siteApiRoot
         this.siteApiNamespace = siteApiNamespace
         this.authHeader = authHeader
-        isEditorLoaded = false
-        didFireEditorLoaded = false
-        hasSetEditorConfig = false
 
         initializeWebView(true)
 
@@ -364,7 +361,7 @@ object GutenbergWebViewPool {
         webView.stopLoading()
         webView.clearConfig()
         webView.removeAllViews()
-        webView.loadUrl("about:blank")
+        webView.destroy()
         preloadedWebView = null
     }
 }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -212,6 +212,7 @@ class GutenbergView : WebView {
                 val jsonObject = JSONObject(result)
                 val title = jsonObject.optString("title", "")
                 val content = jsonObject.optString("content", "")
+                Log.d("Gutenberg", "JSON data: $jsonObject")
                 callback.onResult(title, content)
             }
         }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -180,8 +180,8 @@ class GutenbergView : WebView {
         Handler(Looper.getMainLooper()).post {
             this.evaluateJavascript("editor.getTitleAndContent();") { result ->
                 val jsonObject = JSONObject(result)
-                val title = jsonObject.getString("title")
-                val content = jsonObject.getString("content")
+                val title = jsonObject.optString("title", "")
+                val content = jsonObject.optString("content", "")
                 callback.onResult(title, content)
             }
         }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -262,24 +262,18 @@ class GutenbergView : WebView {
         fun onEditorAvailable(view: GutenbergView?)
     }
 
-    fun getTitleAndContent(callback: TitleAndContentCallback, clearFocus: Boolean = true) {
+    fun getTitleAndContent(callback: TitleAndContentCallback) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
 
         handler.post {
-            // Clearing the focus is necessary to resolve any pending text composition,
-            // ensuring the editor provides the latest content.
-            if (clearFocus) {
-                this.clearFocus()
-            }
-
             if (this.isDestroyed) {
                 callback.onResult(lastUpdatedTitle, lastUpdatedContent)
             }
 
-            this.evaluateJavascript("editor.getTitleAndContent();") { result ->
+            this.evaluateJavascript("editor.getTitleAndContent(true);") { result ->
                 val jsonObject = JSONObject(result)
                 lastUpdatedTitle = jsonObject.optString("title", "")
                 lastUpdatedContent = jsonObject.optString("content", "")
@@ -313,7 +307,7 @@ class GutenbergView : WebView {
             override fun onResult(title: String, content: String) {
                 contentChangeListener?.get()?.onContentChanged(title, content)
             }
-        }, false)
+        })
     }
 
     @JavascriptInterface

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.AttributeSet
 import android.util.Log
+import android.view.View
 import android.webkit.ConsoleMessage
 import android.webkit.JavascriptInterface
 import android.webkit.ValueCallback
@@ -87,6 +88,7 @@ class GutenbergView : WebView {
         this.settings.javaScriptEnabled = true
         this.settings.domStorageEnabled = true;
         this.addJavascriptInterface(this, "editorDelegate")
+        this.visibility = View.GONE
 
         this.webViewClient = object : WebViewClient() {
             override fun onReceivedError(
@@ -250,6 +252,12 @@ class GutenbergView : WebView {
             if(!didFireEditorLoaded) {
                 this.editorDidBecomeAvailable?.let { it(this) }
                 this.didFireEditorLoaded = true
+                this.visibility = View.VISIBLE
+                this.alpha = 0f
+                this.animate()
+                    .alpha(1f)
+                    .setDuration(500)
+                    .start()
             }
         }
     }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -256,7 +256,7 @@ class GutenbergView : WebView {
                 this.alpha = 0f
                 this.animate()
                     .alpha(1f)
-                    .setDuration(500)
+                    .setDuration(200)
                     .start()
             }
         }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -209,6 +209,7 @@ class GutenbergView : WebView {
         }
         Handler(Looper.getMainLooper()).post {
             this.evaluateJavascript("editor.getTitleAndContent();") { result ->
+                Log.d("GutenbergView", "Result: $result")
                 val jsonObject = JSONObject(result)
                 val title = jsonObject.optString("title", "")
                 val content = jsonObject.optString("content", "")

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -262,7 +262,7 @@ class GutenbergView : WebView {
         fun onEditorAvailable(view: GutenbergView?)
     }
 
-    fun getTitleAndContent(callback: TitleAndContentCallback) {
+    fun getTitleAndContent(callback: TitleAndContentCallback, clearFocus: Boolean = true) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
@@ -273,7 +273,8 @@ class GutenbergView : WebView {
                 callback.onResult(lastUpdatedTitle, lastUpdatedContent)
             }
 
-            this.evaluateJavascript("editor.getTitleAndContent(true);") { result ->
+            // Pass the value of clearFocus into the JavaScript call
+            this.evaluateJavascript("editor.getTitleAndContent($clearFocus);") { result ->
                 val jsonObject = JSONObject(result)
                 lastUpdatedTitle = jsonObject.optString("title", "")
                 lastUpdatedContent = jsonObject.optString("content", "")
@@ -307,7 +308,7 @@ class GutenbergView : WebView {
             override fun onResult(title: String, content: String) {
                 contentChangeListener?.get()?.onContentChanged(title, content)
             }
-        })
+        }, false)
     }
 
     @JavascriptInterface

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -75,7 +75,7 @@ class GutenbergView : WebView {
     )
 
     @SuppressLint("SetJavaScriptEnabled") // Without JavaScript we have no Gutenberg
-    fun initializeWebView() {
+    fun initializeWebView(withConfig: Boolean = false) {
         this.settings.javaScriptCanOpenWindowsAutomatically = true
         this.settings.javaScriptEnabled = true
         this.settings.domStorageEnabled = true;
@@ -96,7 +96,7 @@ class GutenbergView : WebView {
                 view: WebView?,
                 request: WebResourceRequest?
             ): WebResourceResponse? {
-                if (!hasSetEditorConfig) {
+                if (!hasSetEditorConfig && withConfig) {
                     Log.d("Gutenberg", "----------- Setting editor config")
                     handler.post {
                         var editorInitialConfig = getEditorConfiguration()
@@ -175,8 +175,8 @@ class GutenbergView : WebView {
         isEditorLoaded = false
         didFireEditorLoaded = false
         hasSetEditorConfig = false
-        
-        initializeWebView()
+
+        initializeWebView(true)
 
         // Production mode – load the assets from the app bundle – you'll need to copy
         // this value out of the `dist` directory after building GutenbergKit

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -214,6 +214,10 @@ class GutenbergView : WebView {
         return jsCode
     }
 
+    fun clearConfig() {
+        this.evaluateJavascript("localStorage.clear();", null)
+    }
+
     fun setContent(newContent: String) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
@@ -313,6 +317,7 @@ class GutenbergView : WebView {
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
+        clearConfig()
         contentChangeListener = null
         editorDidBecomeAvailable = null
         filePathCallback = null
@@ -342,6 +347,7 @@ object GutenbergWebViewPool {
     @JvmStatic
     fun recycleWebView(webView: GutenbergView) {
         webView.stopLoading()
+        webView.clearConfig()
         webView.removeAllViews()
         webView.loadUrl("about:blank")
         preloadedWebView = null

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -27,6 +27,7 @@ const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
 
 class GutenbergView : WebView {
 
+    var isPreloading = false
     private var isEditorLoaded = false
     private var didFireEditorLoaded = false
     private var hasSetEditorConfig = false
@@ -94,6 +95,7 @@ class GutenbergView : WebView {
         this.settings.domStorageEnabled = true;
         this.addJavascriptInterface(this, "editorDelegate")
         this.visibility = View.GONE
+        isPreloading = false
 
         this.webViewClient = object : WebViewClient() {
             override fun onReceivedError(
@@ -262,6 +264,10 @@ class GutenbergView : WebView {
 
     @JavascriptInterface
     fun onEditorLoaded() {
+        if (isPreloading) {
+            Log.d("GutenbergView", "Is preloading")
+            return
+        }
         Log.i("GutenbergView", "EditorLoaded received in native code")
         isEditorLoaded = true
         handler.post {
@@ -332,6 +338,7 @@ object GutenbergWebViewPool {
         webView.settings.javaScriptEnabled = true
         webView.settings.domStorageEnabled = true
         webView.loadUrl(ASSET_URL)
+        webView.isPreloading = true
         return webView
     }
 
@@ -341,5 +348,6 @@ object GutenbergWebViewPool {
         webView.removeAllViews()
         webView.loadUrl("about:blank")
         preloadedWebView = null
+        webView.isPreloading = false
     }
 }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -182,9 +182,7 @@ class GutenbergView : WebView {
         // this value out of the `dist` directory after building GutenbergKit
         //
         // This URL maps to the `assets` directory in this module
-        val timestamp = System.currentTimeMillis()
-        val newUrl = "$ASSET_URL?_t=$timestamp"
-        this.loadUrl(newUrl)
+        this.loadUrl(ASSET_URL)
 
         // Dev mode – you can connect the app to a local dev server and have it refresh as
         // changes are made. To start the server, run `make dev-server` in the project root
@@ -288,9 +286,12 @@ class GutenbergView : WebView {
     @JavascriptInterface
     fun onEditorLoaded() {
         Log.i("GutenbergView", "EditorLoaded received in native code")
+        Log.i("GutenbergView", "didFireEditorLoaded: $didFireEditorLoaded")
+
         isEditorLoaded = true
         handler.post {
             if(!didFireEditorLoaded) {
+                Log.i("GutenbergView", "Showing editor with animation")
                 editorDidBecomeAvailableListener?.onEditorAvailable(this)
                 this.editorDidBecomeAvailable?.let { it(this) }
                 this.didFireEditorLoaded = true

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -16,6 +16,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
+import org.json.JSONObject
 
 class GutenbergView : WebView {
 
@@ -152,14 +153,32 @@ class GutenbergView : WebView {
     }
 
     fun setContent(newContent: String) {
-        Log.i("GutenbergView", "Setting content to $newContent")
-
         if(!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
-
         this.evaluateJavascript("editor.setContent('$newContent');", null)
+    }
+
+    fun setTitle(newTitle: String) {
+        if(!isEditorLoaded) {
+            Log.e("GutenbergView", "You can't change the editor content until it has loaded")
+            return
+        }
+        this.evaluateJavascript("editor.setTitle('$newTitle');", null)
+    }
+
+    fun getTitleAndContent(callback: (title: String, content: String) -> Unit) {
+        if (!isEditorLoaded) {
+            Log.e("GutenbergView", "You can't change the editor content until it has loaded")
+            return
+        }
+        this.evaluateJavascript("editor.getTitleAndContent();") { result ->
+            val jsonObject = JSONObject(result)
+            val title = jsonObject.getString("title")
+            val content = jsonObject.getString("content")
+            callback(title, content)
+        }
     }
 
     @JavascriptInterface

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -95,7 +95,6 @@ class GutenbergView : WebView {
                 request: WebResourceRequest?
             ): WebResourceResponse? {
                 if (!hasSetEditorConfig && withConfig) {
-                    Log.d("Gutenberg", "----------- Setting editor config")
                     handler.post {
                         var editorInitialConfig = getEditorConfiguration()
                         view?.evaluateJavascript(editorInitialConfig, null)
@@ -276,12 +275,9 @@ class GutenbergView : WebView {
     @JavascriptInterface
     fun onEditorLoaded() {
         Log.i("GutenbergView", "EditorLoaded received in native code")
-        Log.i("GutenbergView", "didFireEditorLoaded: $didFireEditorLoaded")
-
         isEditorLoaded = true
         handler.post {
             if(!didFireEditorLoaded) {
-                Log.i("GutenbergView", "Showing editor with animation")
                 editorDidBecomeAvailableListener?.onEditorAvailable(this)
                 this.editorDidBecomeAvailable?.let { it(this) }
                 this.didFireEditorLoaded = true
@@ -323,7 +319,6 @@ class GutenbergView : WebView {
     }
 
     override fun onDetachedFromWindow() {
-        Log.i("GutenbergView", "onDetachedFromWindow")
         super.onDetachedFromWindow()
         clearConfig()
         this.stopLoading()
@@ -341,10 +336,8 @@ object GutenbergWebViewPool {
     @JvmStatic
     fun getPreloadedWebView(context: Context): GutenbergView {
         if (preloadedWebView == null) {
-            Log.i("GutenbergView", "Creating WebView")
             preloadedWebView = createAndPreloadWebView(context)
         }
-        Log.i("GutenbergView", "Reusing WebView")
         return preloadedWebView!!
     }
 
@@ -357,7 +350,6 @@ object GutenbergWebViewPool {
 
     @JvmStatic
     fun recycleWebView(webView: GutenbergView) {
-        Log.i("GutenbergView", "Recycle WebView")
         webView.stopLoading()
         webView.clearConfig()
         webView.removeAllViews()

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -212,7 +212,6 @@ class GutenbergView : WebView {
                 val jsonObject = JSONObject(result)
                 val title = jsonObject.optString("title", "")
                 val content = jsonObject.optString("content", "")
-                Log.d("Gutenberg", "JSON data: $jsonObject")
                 callback.onResult(title, content)
             }
         }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -215,7 +215,12 @@ class GutenbergView : WebView {
     }
 
     fun clearConfig() {
-        this.evaluateJavascript("localStorage.clear();", null)
+        val jsCode = """
+            delete window.GBKit;
+            localStorage.removeItem('GBKit');
+        """.trimIndent()
+
+        this.evaluateJavascript(jsCode, null)
     }
 
     fun setContent(newContent: String) {

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -262,7 +262,6 @@ class GutenbergView : WebView {
             return
         }
         handler.post {
-            // Pass the value of clearFocus into the JavaScript call
             this.evaluateJavascript("editor.getTitleAndContent($clearFocus);") { result ->
                 val jsonObject = JSONObject(result)
                 lastUpdatedTitle = jsonObject.optString("title", "")

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -21,6 +21,8 @@ import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
 import org.json.JSONObject
 
+const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
+
 class GutenbergView : WebView {
 
     private var isEditorLoaded = false
@@ -146,7 +148,7 @@ class GutenbergView : WebView {
         // this value out of the `dist` directory after building GutenbergKit
         //
         // This URL maps to the `assets` directory in this module
-        this.loadUrl("https://appassets.androidplatform.net/assets/index.html")
+        this.loadUrl(ASSET_URL)
 
         // Dev mode – you can connect the app to a local dev server and have it refresh as
         // changes are made. To start the server, run `make dev-server` in the project root
@@ -248,5 +250,29 @@ class GutenbergView : WebView {
 
     fun resetFilePathCallback() {
         filePathCallback = null
+    }
+}
+
+object GutenbergWebViewPool {
+    private var preloadedWebView: GutenbergView? = null
+
+    fun getPreloadedWebView(context: Context): GutenbergView {
+        if (preloadedWebView == null) {
+            preloadedWebView = createAndPreloadWebView(context)
+        }
+        return preloadedWebView!!
+    }
+
+    private fun createAndPreloadWebView(context: Context): GutenbergView {
+        val webView = GutenbergView(context)
+        webView.settings.javaScriptEnabled = true
+        webView.settings.domStorageEnabled = true
+        webView.loadUrl(ASSET_URL)
+        return webView
+    }
+
+    fun recycleWebView(webView: GutenbergView) {
+        webView.stopLoading()
+        preloadedWebView = null
     }
 }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -27,8 +27,6 @@ const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
 
 class GutenbergView : WebView {
 
-    private var isDestroyed = false
-
     private var isEditorLoaded = false
     private var didFireEditorLoaded = false
     private var hasSetEditorConfig = false
@@ -78,7 +76,7 @@ class GutenbergView : WebView {
     fun initializeWebView(withConfig: Boolean = false) {
         this.settings.javaScriptCanOpenWindowsAutomatically = true
         this.settings.javaScriptEnabled = true
-        this.settings.domStorageEnabled = true;
+        this.settings.domStorageEnabled = true
         this.addJavascriptInterface(this, "editorDelegate")
         this.visibility = View.GONE
 
@@ -267,12 +265,7 @@ class GutenbergView : WebView {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
-
         handler.post {
-            if (this.isDestroyed) {
-                callback.onResult(lastUpdatedTitle, lastUpdatedContent)
-            }
-
             // Pass the value of clearFocus into the JavaScript call
             this.evaluateJavascript("editor.getTitleAndContent($clearFocus);") { result ->
                 val jsonObject = JSONObject(result)
@@ -333,9 +326,10 @@ class GutenbergView : WebView {
     }
 
     override fun onDetachedFromWindow() {
+        Log.i("GutenbergView", "onDetachedFromWindow")
         super.onDetachedFromWindow()
-        isDestroyed = true
         clearConfig()
+        this.stopLoading()
         contentChangeListener = null
         editorDidBecomeAvailable = null
         filePathCallback = null
@@ -350,8 +344,10 @@ object GutenbergWebViewPool {
     @JvmStatic
     fun getPreloadedWebView(context: Context): GutenbergView {
         if (preloadedWebView == null) {
+            Log.i("GutenbergView", "Creating WebView")
             preloadedWebView = createAndPreloadWebView(context)
         }
+        Log.i("GutenbergView", "Reusing WebView")
         return preloadedWebView!!
     }
 
@@ -364,6 +360,7 @@ object GutenbergWebViewPool {
 
     @JvmStatic
     fun recycleWebView(webView: GutenbergView) {
+        Log.i("GutenbergView", "Recycle WebView")
         webView.stopLoading()
         webView.clearConfig()
         webView.removeAllViews()

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -48,6 +48,7 @@ class GutenbergView : WebView {
     val pickImageRequestCode = 1
     private var onFileChooserRequested: WeakReference<((Intent, Int) -> Unit)?>? = null
     private var contentChangeListener: WeakReference<ContentChangeListener>? = null
+    private var editorDidBecomeAvailableListener: WeakReference<EditorAvailableListener>? = null
 
     fun setContentChangeListener(listener: ContentChangeListener) {
         contentChangeListener = WeakReference(listener)
@@ -55,6 +56,10 @@ class GutenbergView : WebView {
 
     fun setOnFileChooserRequestedListener(listener: (Intent, Int) -> Unit) {
         onFileChooserRequested = WeakReference(listener)
+    }
+
+    fun setEditorDidBecomeAvailable(listener: EditorAvailableListener?) {
+        editorDidBecomeAvailableListener = WeakReference(listener)
     }
 
     constructor(context: Context) : super(context)
@@ -224,6 +229,10 @@ class GutenbergView : WebView {
         fun onContentChanged(title: String, content: String)
     }
 
+    interface EditorAvailableListener {
+        fun onEditorAvailable(view: GutenbergView?)
+    }
+
     fun getTitleAndContent(callback: TitleAndContentCallback, clearFocus: Boolean = true) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
@@ -250,6 +259,7 @@ class GutenbergView : WebView {
         isEditorLoaded = true
         handler.post {
             if(!didFireEditorLoaded) {
+                editorDidBecomeAvailableListener?.get()?.onEditorAvailable(this)
                 this.editorDidBecomeAvailable?.let { it(this) }
                 this.didFireEditorLoaded = true
                 this.visibility = View.VISIBLE

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -172,7 +172,10 @@ class GutenbergView : WebView {
         this.siteApiRoot = siteApiRoot
         this.siteApiNamespace = siteApiNamespace
         this.authHeader = authHeader
-
+        isEditorLoaded = false
+        didFireEditorLoaded = false
+        hasSetEditorConfig = false
+        
         initializeWebView()
 
         // Production mode – load the assets from the app bundle – you'll need to copy
@@ -220,9 +223,6 @@ class GutenbergView : WebView {
     }
 
     fun clearConfig() {
-        isEditorLoaded = false
-        didFireEditorLoaded = false
-        hasSetEditorConfig = false
         val jsCode = """
             delete window.GBKit;
             localStorage.removeItem('GBKit');

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -256,6 +256,7 @@ class GutenbergView : WebView {
 object GutenbergWebViewPool {
     private var preloadedWebView: GutenbergView? = null
 
+    @JvmStatic
     fun getPreloadedWebView(context: Context): GutenbergView {
         if (preloadedWebView == null) {
             preloadedWebView = createAndPreloadWebView(context)
@@ -271,6 +272,7 @@ object GutenbergWebViewPool {
         return webView
     }
 
+    @JvmStatic
     fun recycleWebView(webView: GutenbergView) {
         webView.stopLoading()
         preloadedWebView = null

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -207,8 +207,10 @@ class GutenbergView : WebView {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
-        this.clearFocus()
         Handler(Looper.getMainLooper()).post {
+            // Clearing the focus is necessary to resolve any pending text composition,
+            // ensuring the editor provides the latest content.
+            this.clearFocus()
             this.evaluateJavascript("editor.getTitleAndContent();") { result ->
                 val jsonObject = JSONObject(result)
                 val title = jsonObject.optString("title", "")

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -27,6 +27,8 @@ const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
 
 class GutenbergView : WebView {
 
+    private var isDestroyed = false
+
     private var isEditorLoaded = false
     private var didFireEditorLoaded = false
     private var hasSetEditorConfig = false
@@ -260,6 +262,12 @@ class GutenbergView : WebView {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
+
+        if (this.isDestroyed) {
+            Log.e("GutenbergView", "WebView is no longer instantiated, cannot evaluate JavaScript")
+            return
+        }
+
         handler.post {
             // Clearing the focus is necessary to resolve any pending text composition,
             // ensuring the editor provides the latest content.
@@ -323,6 +331,7 @@ class GutenbergView : WebView {
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
+        isDestroyed = true
         clearConfig()
         contentChangeListener = null
         editorDidBecomeAvailable = null

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -207,9 +207,9 @@ class GutenbergView : WebView {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
+        this.clearFocus()
         Handler(Looper.getMainLooper()).post {
             this.evaluateJavascript("editor.getTitleAndContent();") { result ->
-                Log.d("GutenbergView", "Result: $result")
                 val jsonObject = JSONObject(result)
                 val title = jsonObject.optString("title", "")
                 val content = jsonObject.optString("content", "")

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -220,6 +220,9 @@ class GutenbergView : WebView {
     }
 
     fun clearConfig() {
+        isEditorLoaded = false
+        didFireEditorLoaded = false
+        hasSetEditorConfig = false
         val jsCode = """
             delete window.GBKit;
             localStorage.removeItem('GBKit');

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -182,9 +182,13 @@ class GutenbergView : WebView {
         Log.i("GutenbergView", "Startup Complete")
     }
 
+    private fun encodeForEditor(value: String): String {
+        return java.net.URLEncoder.encode(value, "UTF-8").replace("+", "%20")
+    }
+
     private fun getEditorConfiguration(): String {
-        val escapedTitle = java.net.URLEncoder.encode(initialTitle, "UTF-8").replace("+", "%20")
-        val escapedContent = java.net.URLEncoder.encode(initialContent, "UTF-8").replace("+", "%20")
+        val escapedTitle = encodeForEditor(initialTitle)
+        val escapedContent = encodeForEditor(initialContent)
 
         val jsCode = """
             window.GBKit = {
@@ -206,19 +210,22 @@ class GutenbergView : WebView {
     }
 
     fun setContent(newContent: String) {
-        if(!isEditorLoaded) {
+        if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
-        this.evaluateJavascript("editor.setContent('$newContent');", null)
+        val encodedContent = encodeForEditor(newContent)
+        this.evaluateJavascript("editor.setContent('$encodedContent');", null)
     }
 
+
     fun setTitle(newTitle: String) {
-        if(!isEditorLoaded) {
+        if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
-        this.evaluateJavascript("editor.setTitle('$newTitle');", null)
+        val encodedTitle = encodeForEditor(newTitle)
+        this.evaluateJavascript("editor.setTitle('$encodedTitle');", null)
     }
 
     interface TitleAndContentCallback {

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -182,7 +182,9 @@ class GutenbergView : WebView {
         // this value out of the `dist` directory after building GutenbergKit
         //
         // This URL maps to the `assets` directory in this module
-        this.loadUrl(ASSET_URL)
+        val timestamp = System.currentTimeMillis()
+        val newUrl = "$ASSET_URL?_t=$timestamp"
+        this.loadUrl(newUrl)
 
         // Dev mode – you can connect the app to a local dev server and have it refresh as
         // changes are made. To start the server, run `make dev-server` in the project root

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -177,11 +177,13 @@ class GutenbergView : WebView {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
-        this.evaluateJavascript("editor.getTitleAndContent();") { result ->
-            val jsonObject = JSONObject(result)
-            val title = jsonObject.getString("title")
-            val content = jsonObject.getString("content")
-            callback.onResult(title, content)
+        Handler(Looper.getMainLooper()).post {
+            this.evaluateJavascript("editor.getTitleAndContent();") { result ->
+                val jsonObject = JSONObject(result)
+                val title = jsonObject.getString("title")
+                val content = jsonObject.getString("content")
+                callback.onResult(title, content)
+            }
         }
     }
 

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -93,6 +93,7 @@ class GutenbergView : WebView {
                 request: WebResourceRequest?
             ): WebResourceResponse? {
                 if (!hasSetEditorConfig) {
+                    Log.d("Gutenberg", "----------- Setting editor config")
                     handler.post {
                         var editorInitialConfig = getEditorConfiguration()
                         view?.evaluateJavascript(editorInitialConfig, null)

--- a/Demo-Android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/Demo-Android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -24,12 +24,17 @@ class MainActivity : AppCompatActivity() {
 
         WebView.setWebContentsDebuggingEnabled(true)
 
-        Log.i("GutenbergView", "onCreate")
-
         val gbView = findViewById<GutenbergView>(R.id.gutenbergView)
-        gbView.editorDidBecomeAvailable = { editor ->
-            editor.setContent("<!-- wp:paragraph --><p>This is the new content</p><!-- /wp:paragraph -->")
-        }
-        gbView.start()
+
+        gbView.start(
+            "",
+            "",
+            "",
+            false,
+            null,
+            "post",
+            "",
+            ""
+        )
     }
 }

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -55,18 +55,14 @@ let editor = {};
 const { ExperimentalBlockCanvas: BlockCanvas } = unlock(blockEditorPrivateApis);
 
 function Editor({ post }) {
-	const [blocks, setBlocks] = useState([]);
 	const [_isCodeEditorEnabled, setCodeEditorEnabled] = useState(false);
 	const titleRef = useRef();
-	const {
-		addEntities,
-		editEntityRecord,
-		getEditedEntityRecord,
-		receiveEntityRecords,
-	} = useDispatch(coreStore);
+	const { addEntities, editEntityRecord, receiveEntityRecords } =
+		useDispatch(coreStore);
+	const { setEditedPost } = useDispatch(editorStore);
 	const { getEditedPostAttribute, getEditedPostContent } =
 		useSelect(editorStore);
-	const { setEditedPost } = unlock(useDispatch(editorStore));
+	const { getEditedEntityRecord } = useSelect(coreStore);
 
 	useEffect(() => {
 		window.editor = editor;

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -54,7 +54,10 @@ function Editor({ post }) {
 	const [blocks, setBlocks] = useState([]);
 	const [_isCodeEditorEnabled, setCodeEditorEnabled] = useState(false);
 	const titleRef = useRef();
-	const { addEntities, receiveEntityRecords } = useDispatch(coreStore);
+	const { addEntities, editEntityRecord, receiveEntityRecords } =
+		useDispatch(coreStore);
+	const { getEditedPostAttribute } = useSelect(editorStore);
+	const { setEditedPost } = unlock(useDispatch(editorStore));
 
 	useEffect(() => {
 		window.editor = editor;
@@ -64,6 +67,8 @@ function Editor({ post }) {
 		registerCoreBlocks();
 
 		editorLoaded();
+		// Temp, check why this isn't being called in the provider.
+		setEditedPost(post.type, post.id);
 
 		return () => {
 			window.editor = {};
@@ -116,14 +121,29 @@ function Editor({ post }) {
 		// onBlocksChanged(isEmpty);
 	}
 
+	function editContent(edits) {
+		editEntityRecord('postType', post.type, post.id, edits);
+	}
+
 	editor.setContent = (content) => {
-		setBlocks(parse(content));
+		editContent({ content });
+	};
+
+	editor.setTitle = (title) => {
+		editContent({ title });
 	};
 
 	editor.setInitialContent = (content) => {
 		const blocks = parse(content);
 		didChangeBlocks(blocks); // TODO: redesign this
 		return serialize(blocks); // It's used for tracking changes
+	};
+
+	editor.getTitleAndContent = () => {
+		return {
+			title: getEditedPostAttribute('title'),
+			content: getEditedPostAttribute('content'),
+		};
 	};
 
 	editor.getContent = () => serialize(blocks);

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -56,7 +56,8 @@ function Editor({ post }) {
 	const titleRef = useRef();
 	const { addEntities, editEntityRecord, receiveEntityRecords } =
 		useDispatch(coreStore);
-	const { getEditedPostAttribute } = useSelect(editorStore);
+	const { getEditedPostAttribute, getEditedPostContent } =
+		useSelect(editorStore);
 	const { setEditedPost } = unlock(useDispatch(editorStore));
 
 	useEffect(() => {
@@ -142,7 +143,7 @@ function Editor({ post }) {
 	editor.getTitleAndContent = () => {
 		return {
 			title: getEditedPostAttribute('title'),
-			content: getEditedPostAttribute('content'),
+			content: getEditedPostContent(),
 		};
 	};
 

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -8,11 +8,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import { Popover } from '@wordpress/components';
-import {
-	getBlockTypes,
-	unregisterBlockType,
-	__unstableSerializeAndClean,
-} from '@wordpress/blocks';
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { parse, serialize } from '@wordpress/blocks';
 import {
@@ -62,7 +58,6 @@ function Editor({ post }) {
 	const { setEditedPost } = useDispatch(editorStore);
 	const { getEditedPostAttribute, getEditedPostContent } =
 		useSelect(editorStore);
-	const { getEditedEntityRecord } = useSelect(coreStore);
 
 	useEffect(() => {
 		window.editor = editor;
@@ -145,23 +140,13 @@ function Editor({ post }) {
 	};
 
 	editor.getContent = () => {
-		const record = getEditedEntityRecord('postType', post.type, post.id);
-		if (record) {
-			if (typeof record.content === 'function') {
-				return record.content(record);
-			} else if (record.blocks) {
-				return __unstableSerializeAndClean(record.blocks);
-			} else if (record.content) {
-				return record.content;
-			}
-		}
+		return getEditedPostContent();
 	};
 
 	editor.getTitleAndContent = () => {
 		return {
 			title: getEditedPostAttribute('title'),
 			content: getEditedPostContent(),
-			contentNew: editor.getContent(),
 		};
 	};
 

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -38,7 +38,11 @@ import '@wordpress/format-library/build-style/style.css';
 
 // Internal imports
 import EditorToolbar from './EditorToolbar';
-import { editorLoaded, onEditorContentChanged } from '../misc/Helpers';
+import {
+	blurEditor,
+	editorLoaded,
+	onEditorContentChanged,
+} from '../misc/Helpers';
 import { postTypeEntities } from '../misc/post-type-entities';
 import { useEditorStyles } from './hooks/use-editor-styles';
 import { unlock } from './lock-unlock';
@@ -138,11 +142,17 @@ function Editor({ post }) {
 		editContent({ title: decodeURIComponent(title) });
 	};
 
-	editor.getContent = () => {
+	editor.getContent = (blurInput = false) => {
+		if (blurInput) {
+			blurEditor();
+		}
 		return getEditedPostContent();
 	};
 
-	editor.getTitleAndContent = () => {
+	editor.getTitleAndContent = (blurInput = false) => {
+		if (blurInput) {
+			blurEditor();
+		}
 		return {
 			title: getEditedPostAttribute('title'),
 			content: getEditedPostContent(),

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -134,11 +134,11 @@ function Editor({ post }) {
 	}
 
 	editor.setContent = (content) => {
-		editContent({ content });
+		editContent({ content: decodeURIComponent(content) });
 	};
 
 	editor.setTitle = (title) => {
-		editContent({ title });
+		editContent({ title: decodeURIComponent(title) });
 	};
 
 	editor.getContent = () => {

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -11,6 +11,7 @@ import { Popover } from '@wordpress/components';
 import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import {
+	store as editorStore,
 	mediaUpload,
 	EditorProvider,
 	EditorSnackbars,

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -113,7 +113,7 @@ function Editor({ post }) {
 	}, []);
 
 	useEffect(() => {
-		const unsubscribe = subscribe(() => {
+		return subscribe(() => {
 			const { title, content } = editor.getTitleAndContent();
 			if (
 				title !== postTitleRef.current ||
@@ -124,10 +124,6 @@ function Editor({ post }) {
 				postContentRef.current = content;
 			}
 		});
-
-		return () => {
-			unsubscribe();
-		};
 	}, []);
 
 	function editContent(edits) {

--- a/ReactApp/src/misc/Helpers.js
+++ b/ReactApp/src/misc/Helpers.js
@@ -11,6 +11,18 @@ export function editorLoaded() {
 	}
 }
 
+export function onEditorContentChanged() {
+	if (window.editorDelegate) {
+		window.editorDelegate.onEditorContentChanged();
+	}
+
+	if (window.webkit) {
+		window.webkit.messageHandlers.editorDelegate.postMessage({
+			message: 'onEditorContentChanged',
+		});
+	}
+}
+
 export function onBlocksChanged(isEmpty = false) {
 	if (window.editorDelegate) {
 		window.editorDelegate.onBlocksChanged(isEmpty);

--- a/ReactApp/src/misc/Helpers.js
+++ b/ReactApp/src/misc/Helpers.js
@@ -49,6 +49,14 @@ export function showBlockPicker() {
 	}
 }
 
+export function blurEditor() {
+	const activeElement = document.activeElement;
+
+	if (activeElement && activeElement.tagName === 'P') {
+		activeElement.blur();
+	}
+}
+
 // FIXME: this was an attempt to fix an existing issue in Gutenberg , but it does it only
 // https://a8c.slack.com/archives/D0740HYKLUX/p1719841410651649
 //

--- a/ReactApp/src/misc/api-fetch-setup.js
+++ b/ReactApp/src/misc/api-fetch-setup.js
@@ -150,19 +150,14 @@ function filterEndpointsMiddleware(options, next) {
  * removes the 'post' field if its value is '-1', which is used for draft posts.
  */
 function mediaUploadMiddleware(options, next) {
-	if (options.path.startsWith('/wp/v2/media') && options.method === 'POST') {
-		if (options.body instanceof FormData) {
-			const newFormData = new FormData();
-
-			options.body.forEach((value, key) => {
-				if (key === 'post' && value === '-1') {
-					return;
-				}
-				newFormData.append(key, value);
-			});
-
-			options.body = newFormData;
-		}
+	if (
+		options.path.startsWith('/wp/v2/media') &&
+		options.method === 'POST' &&
+		options.body instanceof FormData &&
+		options.body.get('post') === '-1'
+	) {
+		options.body.delete('post');
 	}
+
 	return next(options);
 }

--- a/ReactApp/src/misc/api-fetch-setup.js
+++ b/ReactApp/src/misc/api-fetch-setup.js
@@ -22,6 +22,7 @@ export function initializeApiFetch() {
 	apiFetch.use(apiPathModifierMiddleware);
 	apiFetch.use(createHeadersMiddleware(authHeader));
 	apiFetch.use(filterEndpointsMiddleware);
+	apiFetch.use(mediaUploadMiddleware);
 
 	// Preload some endpoints to return data needed for some components
 	// Like PostTitle.
@@ -138,6 +139,30 @@ function filterEndpointsMiddleware(options, next) {
 
 	if (isDisabled) {
 		return Promise.resolve([]);
+	}
+	return next(options);
+}
+
+/**
+ * Middleware to modify media upload requests.
+ *
+ * This middleware intercepts requests to the media endpoint and conditionally
+ * removes the 'post' field if its value is '-1', which is used for draft posts.
+ */
+function mediaUploadMiddleware(options, next) {
+	if (options.path.startsWith('/wp/v2/media') && options.method === 'POST') {
+		if (options.body instanceof FormData) {
+			const newFormData = new FormData();
+
+			options.body.forEach((value, key) => {
+				if (key === 'post' && value === '-1') {
+					return;
+				}
+				newFormData.append(key, value);
+			});
+
+			options.body = newFormData;
+		}
 	}
 	return next(options);
 }


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/WordPress-Android/pull/21223

This PR adds the initial editor parameters for Android, following the approach we used on iOS.

It enables the `domStorageEnabled` feature for the WebView, allowing the use of the `localStorage` API.

Unfortunately, on Android, there is nothing similar to iOS's `addUserScript` to inject the editor's configuration. Therefore, we inject the configuration as soon as we receive the first request from the WebView. In this case, it happens when the `index.html` file is requested, triggering a call to `getEditorConfiguration` to inject the configuration.

## To test
> [!NOTE]  
> Use the following [WordPress Android build](https://github.com/wordpress-mobile/WordPress-Android/pull/21223#issuecomment-2341311367).
> All testing instructions are in the PR linked above.