### PR TITLE
build: Improve source map accuracy

### DIFF
--- a/ReactApp/package-lock.json
+++ b/ReactApp/package-lock.json
@@ -31,6 +31,7 @@
 				"eslint-plugin-react": "^7.34.1",
 				"eslint-plugin-react-hooks": "^4.6.0",
 				"eslint-plugin-react-refresh": "^0.4.6",
+				"magic-string": "^0.30.11",
 				"prettier": "^3.3.2",
 				"vite": "^5.2.0"
 			}
@@ -1120,9 +1121,9 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
@@ -6077,6 +6078,15 @@
 			"dev": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.11",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+			"integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
 		},
 		"node_modules/memize": {

--- a/ReactApp/package.json
+++ b/ReactApp/package.json
@@ -36,6 +36,7 @@
 		"eslint-plugin-react": "^7.34.1",
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"eslint-plugin-react-refresh": "^0.4.6",
+		"magic-string": "^0.30.11",
 		"prettier": "^3.3.2",
 		"vite": "^5.2.0"
 	}


### PR DESCRIPTION
## Description

Leverage the seemingly well-established [`magic-string`](https://github.com/rich-harris/magic-string) package to ensure accurate source maps, improving the debugging experience. 

| Before | After |
| - | - |
| <img width="659" alt="before" src="https://github.com/user-attachments/assets/9df9aca4-16b8-48cb-8c10-46e8fead5a92"> | <img width="657" alt="after" src="https://github.com/user-attachments/assets/cd2e83ad-4067-44d9-8109-bfbf0176ccf0"> |

## Testing Instructions

Not completely necessary for this developer-centric feature, but the following showcases the difference. 

1. Open the remote editor in Chrome. 
2. Open the developer tools and open the `Editor.jsx` file in the Source tab. 
3. Add a breakpoint. 
4. Refresh the page. 
5. Verify the developer tools displays the accurate inline values (e.g., variable assignment values). 