### PR TITLE
fix: Reinstate editor singleton registry

### DIFF
--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -145,7 +145,11 @@ function Editor({ post }) {
 	return (
 		hasLoadedPost && (
 			<div className="editor__container">
-				<EditorProvider post={currentPost} settings={settings}>
+				<EditorProvider
+					post={currentPost}
+					settings={settings}
+					useSubRegistry={false}
+				>
 					<BlockCanvas
 						shouldIframe={false}
 						height="auto"

--- a/ReactApp/src/components/Editor.jsx
+++ b/ReactApp/src/components/Editor.jsx
@@ -12,7 +12,6 @@ import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { parse, serialize } from '@wordpress/blocks';
 import {
-	store as editorStore,
 	mediaUpload,
 	EditorProvider,
 	EditorSnackbars,
@@ -77,14 +76,12 @@ function Editor({ post }) {
 	const {
 		blockPatterns,
 		currentPost,
-		editorSettings,
 		hasLoadedPost,
 		hasUploadPermissions,
 		reusableBlocks,
 	} = useSelect((select) => {
 		const { getEntityRecord, getEntityRecords, hasFinishedResolution } =
 			select(coreStore);
-		const { getEditorSettings } = select(editorStore);
 		const user = getEntityRecord('root', 'user', post.author);
 		const currentPost = getEntityRecord('postType', post.type, post.id);
 		const hasLoadedPost = post?.id
@@ -98,7 +95,6 @@ function Editor({ post }) {
 		return {
 			blockPatterns: select(coreStore).getBlockPatterns(),
 			currentPost,
-			editorSettings: getEditorSettings(),
 			hasLoadedPost,
 			hasUploadPermissions: user?.capabilities?.upload_files ?? true,
 			reusableBlocks: getEntityRecords('postType', 'wp_block'),
@@ -132,13 +128,12 @@ function Editor({ post }) {
 
 	const settings = useMemo(
 		() => ({
-			...editorSettings,
 			hasFixedToolbar: true,
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalReusableBlocks: reusableBlocks,
 			__experimentalBlockPatterns: blockPatterns,
 		}),
-		[blockPatterns, editorSettings, hasUploadPermissions, reusableBlocks]
+		[blockPatterns, hasUploadPermissions, reusableBlocks]
 	);
 
 	const styles = useEditorStyles();


### PR DESCRIPTION
## Description
Reinstate disabling the editor sub-registry so that a singleton registry is
used. This allows third-party blocks to query the block editor state.

Additionally, remove what appears to be a redundant invocation of
`getEditorSettings` that may have been erroneously left in place during
https://github.com/wordpress-mobile/GutenbergKit/pull/24. It appears the `EditorProvider` already [invokes](https://github.com/WordPress/gutenberg/blob/219065c3be5881a68a8667fda9c04c7b7f546763/packages/editor/src/components/provider/index.js#L178) `getEditorSettings`.

## Testing Instructions

Verify the editor — local or remote — launches without errors.

Verify Jetpack AI queries that require block content succeed; e.g., requesting
Jetpack AI modify an existing block.
