### PR TITLE
fix: Stabilize Android media uploads

### DIFF
--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -22,7 +22,6 @@ import android.webkit.WebViewClient
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
 import org.json.JSONObject
-import java.lang.ref.WeakReference
 
 const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
 
@@ -49,16 +48,16 @@ class GutenbergView : WebView {
     var editorDidBecomeAvailable: ((GutenbergView) -> Unit)? = null
     var filePathCallback: ValueCallback<Array<Uri?>?>? = null
     val pickImageRequestCode = 1
-    private var onFileChooserRequested: WeakReference<((Intent, Int) -> Unit)?>? = null
-    private var contentChangeListener: WeakReference<ContentChangeListener>? = null
+    private var onFileChooserRequested: ((Intent, Int) -> Unit)? = null
+    private var contentChangeListener: ContentChangeListener? = null
     private var editorDidBecomeAvailableListener: EditorAvailableListener? = null
 
     fun setContentChangeListener(listener: ContentChangeListener) {
-        contentChangeListener = WeakReference(listener)
+        contentChangeListener = listener
     }
 
     fun setOnFileChooserRequestedListener(listener: (Intent, Int) -> Unit) {
-        onFileChooserRequested = WeakReference(listener)
+        onFileChooserRequested = listener
     }
 
     fun setEditorDidBecomeAvailable(listener: EditorAvailableListener?) {
@@ -145,7 +144,7 @@ class GutenbergView : WebView {
                     intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
                 }
 
-                onFileChooserRequested?.get()?.let { callback ->
+                onFileChooserRequested?.let { callback ->
                     handler.post {
                         callback(Intent.createChooser(intent, "Select Files"), pickImageRequestCode)
                     }
@@ -298,7 +297,7 @@ class GutenbergView : WebView {
     fun onEditorContentChanged() {
         getTitleAndContent(object : TitleAndContentCallback {
             override fun onResult(title: String, content: String) {
-                contentChangeListener?.get()?.onContentChanged(title, content)
+                contentChangeListener?.onContentChanged(title, content)
             }
         }, false)
     }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -37,7 +37,7 @@ class GutenbergView : WebView {
     private var initialTitle: String = ""
     private var type: String = ""
     private var id: Int? = null
-    private var themeStyles: Boolean? = null
+    private var themeStyles: Boolean = false
     private var initialContent: String = ""
     private var siteApiRoot: String = ""
     private var siteApiNamespace: String = ""

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -3,7 +3,6 @@ package org.wordpress.gutenberg
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
@@ -94,22 +93,19 @@ class GutenbergView : WebView {
                 view: WebView?,
                 request: WebResourceRequest?
             ): WebResourceResponse? {
-                return if (request?.url != null) {
-                    assetLoader.shouldInterceptRequest(request.url)
-                } else {
-                    super.shouldInterceptRequest(view, request)
-                }
-            }
-
-            override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-                super.onPageStarted(view, url, favicon)
-
                 if (!hasSetEditorConfig && withConfig) {
                     handler.post {
                         var editorInitialConfig = getEditorConfiguration()
                         view?.evaluateJavascript(editorInitialConfig, null)
+
                     }
                     hasSetEditorConfig = true
+                }
+
+                return if (request?.url != null) {
+                    assetLoader.shouldInterceptRequest(request.url)
+                } else {
+                    super.shouldInterceptRequest(view, request)
                 }
             }
         }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -3,6 +3,7 @@ package org.wordpress.gutenberg
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
@@ -94,19 +95,22 @@ class GutenbergView : WebView {
                 view: WebView?,
                 request: WebResourceRequest?
             ): WebResourceResponse? {
-                if (!hasSetEditorConfig && withConfig) {
-                    handler.post {
-                        var editorInitialConfig = getEditorConfiguration()
-                        view?.evaluateJavascript(editorInitialConfig, null)
-
-                    }
-                    hasSetEditorConfig = true
-                }
-
                 return if (request?.url != null) {
                     assetLoader.shouldInterceptRequest(request.url)
                 } else {
                     super.shouldInterceptRequest(view, request)
+                }
+            }
+
+            override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                super.onPageStarted(view, url, favicon)
+
+                if (!hasSetEditorConfig && withConfig) {
+                    handler.post {
+                        var editorInitialConfig = getEditorConfiguration()
+                        view?.evaluateJavascript(editorInitialConfig, null)
+                    }
+                    hasSetEditorConfig = true
                 }
             }
         }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -25,7 +25,6 @@ import org.json.JSONObject
 const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
 
 class GutenbergView : WebView {
-
     private var isEditorLoaded = false
     private var didFireEditorLoaded = false
     private var assetLoader = WebViewAssetLoader.Builder()
@@ -43,7 +42,7 @@ class GutenbergView : WebView {
     private var lastUpdatedContent = ""
 
     private val handler = Handler(Looper.getMainLooper())
-    var editorDidBecomeAvailable: ((GutenbergView) -> Unit)? = null
+    private var editorDidBecomeAvailable: ((GutenbergView) -> Unit)? = null
     var filePathCallback: ValueCallback<Array<Uri?>?>? = null
     val pickImageRequestCode = 1
     private var onFileChooserRequested: ((Intent, Int) -> Unit)? = null

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -28,7 +28,6 @@ class GutenbergView : WebView {
 
     private var isEditorLoaded = false
     private var didFireEditorLoaded = false
-    private var hasSetEditorConfig = false
     private var assetLoader = WebViewAssetLoader.Builder()
         .addPathHandler("/assets/", AssetsPathHandler(this.context))
         .build()
@@ -72,7 +71,7 @@ class GutenbergView : WebView {
     )
 
     @SuppressLint("SetJavaScriptEnabled") // Without JavaScript we have no Gutenberg
-    fun initializeWebView(withConfig: Boolean = false) {
+    fun initializeWebView() {
         this.settings.javaScriptCanOpenWindowsAutomatically = true
         this.settings.javaScriptEnabled = true
         this.settings.domStorageEnabled = true
@@ -93,15 +92,6 @@ class GutenbergView : WebView {
                 view: WebView?,
                 request: WebResourceRequest?
             ): WebResourceResponse? {
-                if (!hasSetEditorConfig && withConfig) {
-                    handler.post {
-                        var editorInitialConfig = getEditorConfiguration()
-                        view?.evaluateJavascript(editorInitialConfig, null)
-
-                    }
-                    hasSetEditorConfig = true
-                }
-
                 return if (request?.url != null) {
                     assetLoader.shouldInterceptRequest(request.url)
                 } else {
@@ -169,7 +159,7 @@ class GutenbergView : WebView {
         this.siteApiNamespace = siteApiNamespace
         this.authHeader = authHeader
 
-        initializeWebView(true)
+        initializeWebView()
 
         // Production mode – load the assets from the app bundle – you'll need to copy
         // this value out of the `dist` directory after building GutenbergKit
@@ -192,27 +182,27 @@ class GutenbergView : WebView {
         return java.net.URLEncoder.encode(value, "UTF-8").replace("+", "%20")
     }
 
-    private fun getEditorConfiguration(): String {
+    @JavascriptInterface
+    fun getEditorConfiguration(): String {
         val escapedTitle = encodeForEditor(initialTitle)
         val escapedContent = encodeForEditor(initialContent)
 
-        val jsCode = """
-            window.GBKit = {
-                siteApiRoot: '$siteApiRoot',
-                siteApiNamespace: '$siteApiNamespace',
-                authHeader: '$authHeader',
-                themeStyles: $themeStyles,
+        val json = """
+            {
+                "siteApiRoot": "$siteApiRoot",
+                "siteApiNamespace": "$siteApiNamespace",
+                "authHeader": "$authHeader",
+                "themeStyles": $themeStyles,
                 ${if (id != null) """
-                post: {
-                    id: $id,
-                    title: '$escapedTitle',
-                    content: '$escapedContent'
-                },
+                "post": {
+                    "id": $id,
+                    "title": "$escapedTitle",
+                    "content": "$escapedContent"
+                }
                 """ else ""}
-            };
-            localStorage.setItem('GBKit', JSON.stringify(window.GBKit));
-        """.trimIndent()
-        return jsCode
+            }
+        """
+        return json
     }
 
     fun clearConfig() {

--- a/Demo-Android/gradle/libs.versions.toml
+++ b/Demo-Android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.2"
+agp = "8.5.1"
 kotlin = "1.9.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"

--- a/Demo-Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Demo-Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jul 16 13:10:05 MDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ReactApp/src/misc/store.js
+++ b/ReactApp/src/misc/store.js
@@ -12,15 +12,19 @@ export function getGBKit() {
 	// Android relies upon "pulling" the GBKit object from the native host, as it
 	// does not provide a way to inject JavaScript prior to the WebView loading.
 	if (window.editorDelegate) {
-		return JSON.parse(window.editorDelegate.getEditorConfiguration());
+		try {
+			return JSON.parse(window.editorDelegate.getEditorConfiguration());
+		} catch (error) {
+			console.error('Failed parsing GBKit from editorDelegate:', error);
+			return {};
+		}
 	}
 
-	const emptyObject = {};
 	try {
-		return JSON.parse(localStorage.getItem('GBKit')) || emptyObject;
+		return JSON.parse(localStorage.getItem('GBKit')) || {};
 	} catch (error) {
 		console.error('Failed parsing GBKit from localStorage:', error);
-		return emptyObject;
+		return {};
 	}
 }
 

--- a/ReactApp/src/misc/store.js
+++ b/ReactApp/src/misc/store.js
@@ -9,6 +9,12 @@ export function getGBKit() {
 		return window.GBKit;
 	}
 
+	// Android relies upon "pulling" the GBKit object from the native host, as it
+	// does not provide a way to inject JavaScript prior to the WebView loading.
+	if (window.editorDelegate) {
+		return JSON.parse(window.editorDelegate.getEditorConfiguration());
+	}
+
 	const emptyObject = {};
 	try {
 		return JSON.parse(localStorage.getItem('GBKit')) || emptyObject;


### PR DESCRIPTION
## Description

Relates to https://github.com/wordpress-mobile/WordPress-Android/pull/21223. 

Fix various instabilities in Android media uploads. Synchronize Gradle versions
with the WordPress-Android project.

## Testing Instructions

See https://github.com/wordpress-mobile/WordPress-Android/pull/21223. 
