### PR TITLE
Add Android Request Interception

### DIFF
--- a/Demo-Android/Gutenberg/build.gradle.kts
+++ b/Demo-Android/Gutenberg/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.androidx.webkit)
+    implementation(platform(libs.okhttp.bom))
+    implementation(libs.okhttp)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/Demo-Android/Gutenberg/build.gradle.kts
+++ b/Demo-Android/Gutenberg/build.gradle.kts
@@ -39,8 +39,6 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.androidx.webkit)
-    implementation(platform(libs.okhttp.bom))
-    implementation(libs.okhttp)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergRequestInterceptor.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergRequestInterceptor.kt
@@ -1,0 +1,13 @@
+package org.wordpress.gutenberg
+
+import android.webkit.WebResourceRequest
+
+public interface GutenbergRequestInterceptor {
+    fun interceptRequest(request: WebResourceRequest): WebResourceRequest
+}
+
+class DefaultGutenbergRequestInterceptor: GutenbergRequestInterceptor {
+    override fun interceptRequest(request: WebResourceRequest): WebResourceRequest {
+        return request
+    }
+}

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergRequestInterceptor.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergRequestInterceptor.kt
@@ -1,13 +1,19 @@
 package org.wordpress.gutenberg
 
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 
 public interface GutenbergRequestInterceptor {
-    fun interceptRequest(request: WebResourceRequest): WebResourceRequest
+    fun canIntercept(request: WebResourceRequest): Boolean
+    fun handleRequest(request: WebResourceRequest): WebResourceResponse?
 }
 
 class DefaultGutenbergRequestInterceptor: GutenbergRequestInterceptor {
-    override fun interceptRequest(request: WebResourceRequest): WebResourceRequest {
-        return request
+    override fun canIntercept(request: WebResourceRequest): Boolean {
+        return false
+    }
+
+    override fun handleRequest(request: WebResourceRequest): WebResourceResponse? {
+        return null
     }
 }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -20,6 +20,11 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
+import okhttp3.Headers.Companion.toHeaders
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okio.IOException
 import org.json.JSONObject
 
 const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
@@ -45,9 +50,15 @@ class GutenbergView : WebView {
     private var editorDidBecomeAvailable: ((GutenbergView) -> Unit)? = null
     var filePathCallback: ValueCallback<Array<Uri?>?>? = null
     val pickImageRequestCode = 1
+
+    var requestInterceptor: GutenbergRequestInterceptor = DefaultGutenbergRequestInterceptor()
+
+
     private var onFileChooserRequested: ((Intent, Int) -> Unit)? = null
     private var contentChangeListener: ContentChangeListener? = null
     private var editorDidBecomeAvailableListener: EditorAvailableListener? = null
+
+    private val httpClient = OkHttpClient()
 
     fun setContentChangeListener(listener: ContentChangeListener) {
         contentChangeListener = listener
@@ -91,10 +102,34 @@ class GutenbergView : WebView {
                 view: WebView?,
                 request: WebResourceRequest?
             ): WebResourceResponse? {
-                return if (request?.url != null) {
-                    assetLoader.shouldInterceptRequest(request.url)
+                if (request?.url == null) {
+                    return super.shouldInterceptRequest(view, request)
+                } else if(request.url.host?.contains("appassets.androidplatform.net") == true) {
+                    return assetLoader.shouldInterceptRequest(request.url)
                 } else {
-                    super.shouldInterceptRequest(view, request)
+                    val modifiedRequest = requestInterceptor.interceptRequest(request)
+
+                    try {
+                        val okHttpRequest = Request.Builder()
+                            .url(modifiedRequest.url!!.toString())
+                            .headers(modifiedRequest.requestHeaders.toHeaders())
+                            .build()
+
+                        val response: Response = httpClient.newCall(okHttpRequest).execute()
+
+                        val body = if(response.body != null) { response.body!! } else { return null }
+                        val contentType = if(body.contentType() != null) { body.contentType() } else { return null }
+
+                        return WebResourceResponse(
+                            contentType.toString(),
+                            response.header("content-encoding", null),
+                            body.byteStream()
+                        )
+                    } catch (e: IOException) {
+                        // We don't need to handle this ourselves, just tell the WebView that
+                        // we weren't able to fetch the resource
+                        return null;
+                    }
                 }
             }
         }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -128,7 +128,7 @@ class GutenbergView : WebView {
                     } catch (e: IOException) {
                         // We don't need to handle this ourselves, just tell the WebView that
                         // we weren't able to fetch the resource
-                        return null;
+                        return null
                     }
                 }
             }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -20,11 +20,6 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
-import okhttp3.Headers.Companion.toHeaders
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
-import okio.IOException
 import org.json.JSONObject
 
 const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
@@ -53,12 +48,9 @@ class GutenbergView : WebView {
 
     var requestInterceptor: GutenbergRequestInterceptor = DefaultGutenbergRequestInterceptor()
 
-
     private var onFileChooserRequested: ((Intent, Int) -> Unit)? = null
     private var contentChangeListener: ContentChangeListener? = null
     private var editorDidBecomeAvailableListener: EditorAvailableListener? = null
-
-    private val httpClient = OkHttpClient()
 
     fun setContentChangeListener(listener: ContentChangeListener) {
         contentChangeListener = listener
@@ -99,38 +91,18 @@ class GutenbergView : WebView {
             }
 
             override fun shouldInterceptRequest(
-                view: WebView?,
-                request: WebResourceRequest?
+                view: WebView,
+                request: WebResourceRequest
             ): WebResourceResponse? {
-                if (request?.url == null) {
+                if (request.url == null) {
                     return super.shouldInterceptRequest(view, request)
-                } else if(request.url.host?.contains("appassets.androidplatform.net") == true) {
+                } else if (request.url.host?.contains("appassets.androidplatform.net") == true) {
                     return assetLoader.shouldInterceptRequest(request.url)
-                } else {
-                    val modifiedRequest = requestInterceptor.interceptRequest(request)
-
-                    try {
-                        val okHttpRequest = Request.Builder()
-                            .url(modifiedRequest.url!!.toString())
-                            .headers(modifiedRequest.requestHeaders.toHeaders())
-                            .build()
-
-                        val response: Response = httpClient.newCall(okHttpRequest).execute()
-
-                        val body = if(response.body != null) { response.body!! } else { return null }
-                        val contentType = if(body.contentType() != null) { body.contentType() } else { return null }
-
-                        return WebResourceResponse(
-                            contentType.toString(),
-                            response.header("content-encoding", null),
-                            body.byteStream()
-                        )
-                    } catch (e: IOException) {
-                        // We don't need to handle this ourselves, just tell the WebView that
-                        // we weren't able to fetch the resource
-                        return null
-                    }
+                } else if (requestInterceptor.canIntercept(request)) {
+                    return requestInterceptor.handleRequest(request)
                 }
+
+                return super.shouldInterceptRequest(view, request)
             }
         }
 

--- a/Demo-Android/gradle/libs.versions.toml
+++ b/Demo-Android/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ appcompat = "1.7.0"
 material = "1.12.0"
 activity = "1.9.0"
 constraintlayout = "2.1.4"
+okhttp = "4.12.0"
 webkit = "1.11.0"
 
 [libraries]
@@ -21,6 +22,8 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/Demo-Android/gradle/libs.versions.toml
+++ b/Demo-Android/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ appcompat = "1.7.0"
 material = "1.12.0"
 activity = "1.9.0"
 constraintlayout = "2.1.4"
-okhttp = "4.12.0"
 webkit = "1.11.0"
 
 [libraries]
@@ -22,8 +21,6 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This initial implementation allows us to inject authentication at runtime if needed.

You can test it by making the demo app activity conform to `GutenbergRequestInterceptor`, then adding:
```

    override fun interceptRequest(request: WebResourceRequest): WebResourceRequest {

        if (request.url.host.isNullOrEmpty()) {
            return request
        }

        if (!request.url.host!!.contains("wordpress.com")) {
            return request
        }

        request.requestHeaders["Authorization"] =
            "Bearer [redacted – replace this string]"

        return request
    }
```

Once you've added a bearer token, copy the URL to an image on a private blog, and insert a new image block with that URL. The editor will now display it.