### PR TITLE
fix: Rely upon the WebView for completing non-intercepted requests

### DIFF
--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergRequestInterceptor.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergRequestInterceptor.kt
@@ -5,11 +5,11 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 
 public interface GutenbergRequestInterceptor {
-    fun modifyRequest(view: WebView, request: WebResourceRequest): WebResourceResponse?
+    fun modifyRequest(request: WebResourceRequest): WebResourceResponse?
 }
 
 class DefaultGutenbergRequestInterceptor: GutenbergRequestInterceptor {
-    override fun modifyRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
+    override fun modifyRequest(request: WebResourceRequest): WebResourceResponse? {
         return null
     }
 }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergRequestInterceptor.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergRequestInterceptor.kt
@@ -1,13 +1,15 @@
 package org.wordpress.gutenberg
 
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
 
 public interface GutenbergRequestInterceptor {
-    fun interceptRequest(request: WebResourceRequest): WebResourceRequest
+    fun modifyRequest(view: WebView, request: WebResourceRequest): WebResourceResponse?
 }
 
 class DefaultGutenbergRequestInterceptor: GutenbergRequestInterceptor {
-    override fun interceptRequest(request: WebResourceRequest): WebResourceRequest {
-        return request
+    override fun modifyRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
+        return null
     }
 }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergRequestInterceptor.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergRequestInterceptor.kt
@@ -2,14 +2,18 @@ package org.wordpress.gutenberg
 
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
-import android.webkit.WebView
 
 public interface GutenbergRequestInterceptor {
-    fun modifyRequest(request: WebResourceRequest): WebResourceResponse?
+    fun canIntercept(request: WebResourceRequest): Boolean
+    fun handleRequest(request: WebResourceRequest): WebResourceResponse?
 }
 
 class DefaultGutenbergRequestInterceptor: GutenbergRequestInterceptor {
-    override fun modifyRequest(request: WebResourceRequest): WebResourceResponse? {
+    override fun canIntercept(request: WebResourceRequest): Boolean {
+        return false
+    }
+
+    override fun handleRequest(request: WebResourceRequest): WebResourceResponse? {
         return null
     }
 }

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -95,7 +95,7 @@ class GutenbergView : WebView {
                 view: WebView,
                 request: WebResourceRequest
             ): WebResourceResponse? {
-                val requestResponse = requestInterceptor.modifyRequest(view, request);
+                val requestResponse = requestInterceptor.modifyRequest(view, request)
 
                 if (requestResponse != null) {
                     return requestResponse

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -20,11 +20,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
-import okhttp3.Headers.Companion.toHeaders
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
-import okio.IOException
 import org.json.JSONObject
 
 const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
@@ -53,12 +49,9 @@ class GutenbergView : WebView {
 
     var requestInterceptor: GutenbergRequestInterceptor = DefaultGutenbergRequestInterceptor()
 
-
     private var onFileChooserRequested: ((Intent, Int) -> Unit)? = null
     private var contentChangeListener: ContentChangeListener? = null
     private var editorDidBecomeAvailableListener: EditorAvailableListener? = null
-
-    private val httpClient = OkHttpClient()
 
     fun setContentChangeListener(listener: ContentChangeListener) {
         contentChangeListener = listener

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -20,7 +20,6 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
-import okhttp3.OkHttpClient
 import org.json.JSONObject
 
 const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -94,7 +94,7 @@ class GutenbergView : WebView {
                 view: WebView,
                 request: WebResourceRequest
             ): WebResourceResponse? {
-                val requestResponse = requestInterceptor.modifyRequest(view, request)
+                val requestResponse = requestInterceptor.modifyRequest(request)
 
                 if (requestResponse != null) {
                     return requestResponse

--- a/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/Demo-Android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -94,12 +94,12 @@ class GutenbergView : WebView {
                 view: WebView,
                 request: WebResourceRequest
             ): WebResourceResponse? {
-                val requestResponse = requestInterceptor.modifyRequest(request)
-
-                if (requestResponse != null) {
-                    return requestResponse
+                if (request.url == null) {
+                    return super.shouldInterceptRequest(view, request)
                 } else if (request.url.host?.contains("appassets.androidplatform.net") == true) {
                     return assetLoader.shouldInterceptRequest(request.url)
+                } else if (requestInterceptor.canIntercept(request)) {
+                    return requestInterceptor.handleRequest(request)
                 }
 
                 return super.shouldInterceptRequest(view, request)


### PR DESCRIPTION
## Related

- https://github.com/Automattic/dotcom-forge/issues/9446
- https://github.com/wordpress-mobile/WordPress-Android/pull/21331
- https://github.com/wordpress-mobile/GutenbergKit/pull/30

## Description

Previously, a manual request was created for _all_ requests. This was
unnecessary and resulted in header values being unexpectedly discarded.

## Testing Instructions

> [!Tip]
> Test using the WPAndroid [prototype build](https://github.com/wordpress-mobile/WordPress-Android/pull/21331#issuecomment-2430588801). 

1. Open the editor for a private WPCOM site.
1. Add an Image block.
1. Upload an image for the block.
1. Verify the image successfully uploads and renders within the editor.
1. Close and re-open the editor.
1. Verify the image successfully renders in the editor.
