### PR TITLE
docs: Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,61 @@
+---
+name: Bug report
+description: Report a bug with the WordPress block editor for mobile apps
+labels: ['bug']
+---
+
+<!--
+Please fill out ALL required sections. Bug reports with missing information will
+be closed.
+
+Before submitting a bug report:
+
+- Check if the bug has already been fixed by updating WordPress and/or Gutenberg.
+- Check if the bug is caused by a plugin by deactivating all plugins except Gutenberg.
+- Check if the bug is caused by a theme by activating a default theme e.g. Twenty Twenty.
+- Check if the bug has already been reported by searching https://github.com/WordPress/gutenberg/issues.
+
+If this is a security issue, please report it in HackerOne instead:
+https://hackerone.com/wordpress
+-->
+
+## Description
+
+<!-- Please write a brief description of the bug. -->
+
+## Step-by-step reproduction instructions
+
+<!--
+Please list the steps needed to reproduce the bug. For example:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+-->
+
+## Expected behaviour
+
+<!-- Please describe what you expected to happen. -->
+
+## Actual behaviour
+
+<!-- Please describe what actually happened. -->
+
+## Screenshots or screen recording (optional)
+
+<!--
+If possible, please upload a screenshot or screen recording which demonstrates
+the bug.
+-->
+
+## WordPress information
+
+-   WordPress version: <!-- e.g. "5.8.0". Find this in Tools → Site Health → Info → WordPress -->
+-   Gutenberg version: <!-- e.g. "9.4.0" or "Not installed" -->
+-   Are all plugins except Gutenberg deactivated? <!-- "Yes" or "No" -->
+-   Are you using a default theme (e.g. Twenty Twenty-One)? <!-- "Yes" or "No" -->
+
+## Device information
+
+-   Device: <!-- e.g. "Pixel 4" or "iPhone 11" -->
+-   Operating system: <!-- e.g. "Android 11.0" or "iOS 14.0" -->
+-   WordPress app version: <!-- e.g. "16.3" or branch name / git commit hash -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Propose an idea for a feature or an enhancement
+labels: 'enhancement'
+---
+
+## What problem does this address?
+
+<!--
+Please describe if this feature or enhancement is related to a current problem
+or pain point. For example, "I'm always frustrated when ..." or "It is currently
+difficult to ...".
+-->
+
+## What is your proposed solution?
+
+<!--
+Please outline the feature or enhancement that you want and how it addresses any
+problem identified above.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
+https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
+
+## What?
+
+<!-- In a few words, what is the PR actually doing? -->
+
+## Why?
+
+<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
+
+## How?
+
+<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
+
+## Testing Instructions
+
+<!-- Please include step by step instructions on how to test this PR. -->
+<!-- 1. Open a post or page. -->
+<!-- 2. Insert a heading block. -->
+<!-- 3. etc. -->
+
+### Acessibility Testing Instructions
+
+<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
+
+## Screenshots or screencast <!-- if applicable -->


### PR DESCRIPTION
## Description
Add templates to align with Gutenberg project practices and improve
consistency in issues and commits.

## Testing Instructions
N/A, no user-facing changes.
