### PR TITLE
docs: Fix GitHub template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
-description: Report a bug with the WordPress block editor for mobile apps
-labels: ['bug']
+about: Report a bug with the WordPress block editor for mobile apps
+labels: 'bug'
 ---
 
 <!--


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix the GitHub bug template.

## Why?

Markdown templates must include an `about` key.

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository

## How?

Add an `about` key.

## Testing Instructions

N/A, no user-facing changes.

### Acessibility Testing Instructions

N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->

N/A, no user-facing changes.

