### PR TITLE
fix: Remove duplicative iOS content decoding

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -188,7 +188,7 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         guard _isEditorRendered else { return }
 
         let escapedString = content.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
-        evaluate("editor.setContent(decodeURIComponent('\(escapedString)'));", isCritical: true)
+        evaluate("editor.setContent('\(escapedString)');", isCritical: true)
     }
 
     /// Returns the current editor content.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Addressing iOS errors when saving certain block content—e.g., Column blocks
with percentage widths.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/Automattic/dotcom-forge/issues/9277.

When Android support was introduced in https://github.com/wordpress-mobile/GutenbergKit/pull/23, The JavaScript logic was 
modified so that it performed decoding itself. The iOS logic was not updated 
for this change, which resulted in duplicative decoding runs that could
result in errors—e.g., decoding Column blocks with percentage widths.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove duplicative iOS content decoding.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new post.
1. Insert a Columns block.
1. Modify the width of at least one column to a percentage-based width.
1. Save the post.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
