### PR TITLE
feat: Open editor canvas links

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -112,6 +112,15 @@ class GutenbergView : WebView {
 
                 return super.shouldInterceptRequest(view, request)
             }
+
+            override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+                url?.let {
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(it))
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    view?.context?.startActivity(intent)
+                }
+                return true
+            }
         }
 
         this.webChromeClient = object : WebChromeClient() {

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -250,7 +250,7 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     private func openMediaLibrary(_ config: OpenMediaLibraryAction) {
         delegate?.editor(self, didRequestMediaFromSiteMediaLibrary: config)
     }
-    
+
     public func setMediaUploadAttachment(_ media: String) {
         evaluate("editor.setMediaUploadAttachment(\(media));")
     }
@@ -365,6 +365,25 @@ private final class GutenbergEditorController: NSObject, WKNavigationDelegate, W
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         NSLog("didFailProvisionalNavigation: \(error)")
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        let gutenbergEditorURL = URL(string: ProcessInfo.processInfo.environment["GUTENBERG_EDITOR_URL"] ?? "")
+        let localIndexURL = Bundle.module.url(forResource: "index", withExtension: "html", subdirectory: "Gutenberg")
+        let localRemoteURL = Bundle.module.url(forResource: "remote", withExtension: "html", subdirectory: "Gutenberg")
+
+        if url == localIndexURL || url == localRemoteURL || url.host == gutenbergEditorURL?.host {
+            decisionHandler(.allow)
+        } else {
+            // Open the link in Safari
+            UIApplication.shared.open(url)
+            decisionHandler(.cancel)
+        }
     }
 
     // MARK: - WKScriptMessageHandler


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Open embedded links outside of the editor WebView—i.e., in the OS web browser
instead.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/Automattic/dotcom-forge/issues/9828.

This approach mimics the web editor experience. It also prevents odd UI states
and errors originating from navigating forward and backwards in the single
WebView that displays the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Leverage the `shouldOverrideUrlLoading` hook to handle URL opening in a new
browser intent.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add a link within Paragraph block.
1. Tap the link preview in the popover to navigate to the URL.
1. Verify the URL opens in the OS browser, not the editor in-app WebView.
1. Navigate back to the editor by pressing the hardware back button.
1. Verify the editor does not crash.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing UI changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing UI changes.
