### PR TITLE
fix: Replace unsupported editor architecture

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -115,6 +115,12 @@ class GutenbergView : WebView {
 
             override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
                 url?.let {
+                    // Allow the WebView to handle `blob:` requests, which are utilized in the block
+                    // inserter's Patterns tab
+                    if (it.startsWith("blob:")) {
+                        return false
+                    }
+
                     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(it))
                     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     view?.context?.startActivity(intent)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "gutenberg-kit",
 			"version": "0.0.0",
+			"hasInstallScript": true,
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.10",
 				"@wordpress/block-editor": "^14.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"eslint": "^8.57",
 				"eslint-plugin-react-refresh": "^0.4",
 				"magic-string": "^0.30",
+				"patch-package": "^8.0.0",
 				"prettier": "^3.3",
 				"vite": "^5.4"
 			}
@@ -5693,6 +5694,13 @@
 			"license": "Apache-2.0",
 			"peer": true
 		},
+		"node_modules/@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/acorn": {
 			"version": "8.14.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -5989,6 +5997,16 @@
 			"integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
 		},
 		"node_modules/autosize": {
 			"version": "4.0.4",
@@ -6298,6 +6316,59 @@
 				"upper-case-first": "^2.0.2"
 			}
 		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chalk/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/chalk/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/chalk/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/change-case": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
@@ -6327,6 +6398,22 @@
 			"peer": true,
 			"engines": {
 				"node": ">=6.0"
+			}
+		},
+		"node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/client-zip": {
@@ -7585,59 +7672,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/eslint/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/eslint/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/eslint/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/eslint/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/eslint/node_modules/doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -7667,16 +7701,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/eslint/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/eslint/node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -7685,19 +7709,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/eslint/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -7903,6 +7914,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/find-yarn-workspace-root": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"micromatch": "^4.0.2"
+			}
+		},
 		"node_modules/flat-cache": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -7958,6 +7979,22 @@
 				"react-dom": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -8219,8 +8256,7 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/gradient-parser": {
 			"version": "0.1.5",
@@ -8245,6 +8281,16 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/has-property-descriptors": {
@@ -8621,6 +8667,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -8896,6 +8958,19 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/isarray": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -8951,17 +9026,6 @@
 			},
 			"engines": {
 				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/jest-worker/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/jest-worker/node_modules/supports-color": {
@@ -9042,6 +9106,25 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-stable-stringify": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
+			"integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"isarray": "^2.0.5",
+				"jsonify": "^0.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -9069,6 +9152,29 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+			"integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+			"dev": true,
+			"license": "Public Domain",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/jsx-ast-utils": {
 			"version": "3.3.5",
 			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -9093,6 +9199,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"node_modules/language-subtag-registry": {
@@ -9553,6 +9669,23 @@
 				"wrappy": "1"
 			}
 		},
+		"node_modules/open": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+			"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0",
+				"is-wsl": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -9569,6 +9702,16 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/p-limit": {
@@ -9666,6 +9809,87 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/patch-package": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+			"integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@yarnpkg/lockfile": "^1.1.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^3.7.0",
+				"cross-spawn": "^7.0.3",
+				"find-yarn-workspace-root": "^2.0.0",
+				"fs-extra": "^9.0.0",
+				"json-stable-stringify": "^1.0.2",
+				"klaw-sync": "^6.0.0",
+				"minimist": "^1.2.6",
+				"open": "^7.4.2",
+				"rimraf": "^2.6.3",
+				"semver": "^7.5.3",
+				"slash": "^2.0.0",
+				"tmp": "^0.0.33",
+				"yaml": "^2.2.2"
+			},
+			"bin": {
+				"patch-package": "index.js"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">5"
+			}
+		},
+		"node_modules/patch-package/node_modules/rimraf": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			}
+		},
+		"node_modules/patch-package/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/patch-package/node_modules/slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/patch-package/node_modules/yaml": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+			"integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/path-case": {
@@ -10899,6 +11123,19 @@
 			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
 			"license": "MIT"
 		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -11016,6 +11253,19 @@
 			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
 			"license": "MIT"
+		},
+		"node_modules/tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"os-tmpdir": "~1.0.2"
+			},
+			"engines": {
+				"node": ">=0.6.0"
+			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -11280,6 +11530,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"eslint": "^8.57",
 		"eslint-plugin-react-refresh": "^0.4",
 		"magic-string": "^0.30",
+		"patch-package": "^8.0.0",
 		"prettier": "^3.3",
 		"vite": "^5.4"
 	}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"build": "vite --emptyOutDir build && vite build --emptyOutDir=false --config vite.config.remote.js",
 		"lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
 		"format": "prettier --write .",
+		"postinstall": "patch-package",
 		"preview": "vite preview --host"
 	},
 	"dependencies": {

--- a/patches/@wordpress+editor+14.10.0.patch
+++ b/patches/@wordpress+editor+14.10.0.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/@wordpress/editor/build-module/private-apis.js b/node_modules/@wordpress/editor/build-module/private-apis.js
+index eb169ff..2b8528b 100644
+--- a/node_modules/@wordpress/editor/build-module/private-apis.js
++++ b/node_modules/@wordpress/editor/build-module/private-apis.js
+@@ -9,6 +9,7 @@ import * as interfaceApis from '@wordpress/interface';
+ import { lock } from './lock-unlock';
+ import { EntitiesSavedStatesExtensible } from './components/entities-saved-states';
+ import EditorContentSlotFill from './components/editor-interface/content-slot-fill';
++import useBlockEditorSettings from './components/provider/use-block-editor-settings';
+ import BackButton from './components/header/back-button';
+ import CreateTemplatePartModal from './components/create-template-part-modal';
+ import Editor from './components/editor';
+@@ -43,6 +44,7 @@ lock(privateApis, {
+   ResizableEditor,
+   registerCoreBlockBindingsSources,
+   // This is a temporary private API while we're updating the site editor to use EditorProvider.
++  useBlockEditorSettings,
+   interfaceStore,
+   ...remainingInterfaceApis
+ });

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,11 @@
+# Dependency patches
+
+Sometimes there are problems with dependencies that can be solved by patching them. Gutenberg uses [patch-package](https://www.npmjs.com/package/patch-package) to patch npm dependencies when they're installed.
+
+Existing patches should be described and justified here.
+
+## Patches
+
+### `@wordpress/editor`
+
+Revert https://github.com/WordPress/gutenberg/pull/64892 and export the private `useBlockEditorSettings` API as it is required for GutenbergKit's use of the block editor settings. This can be removed once GutenbergKit resides in the Gutenberg repository, where we can access all the necessary APIs—both public and private.

--- a/src/components/editor.jsx
+++ b/src/components/editor.jsx
@@ -12,12 +12,12 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 import {
 	store as editorStore,
 	mediaUpload,
-	EditorProvider,
 	EditorSnackbars,
 	PostTitle,
+	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
 import { useDispatch, useSelect, subscribe } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { store as coreStore, useEntityBlockEditor } from '@wordpress/core-data';
 
 // Default styles that are needed for the editor.
 import '@wordpress/components/build-style/style.css';
@@ -52,7 +52,11 @@ import { useMediaUpload } from '../hooks/use-media-upload';
 // Current editor (assumes can be only one instance).
 const editor = {};
 
-const { ExperimentalBlockCanvas: BlockCanvas } = unlock(blockEditorPrivateApis);
+const { useBlockEditorSettings } = unlock(editorPrivateApis);
+const {
+	ExperimentalBlockEditorProvider: BlockEditorProvider,
+	ExperimentalBlockCanvas: BlockCanvas,
+} = unlock(blockEditorPrivateApis);
 
 /**
  * Editor component for managing and editing post content.
@@ -63,7 +67,6 @@ const { ExperimentalBlockCanvas: BlockCanvas } = unlock(blockEditorPrivateApis);
  * @return {JSX.Element} The rendered Editor component.
  */
 function Editor({ post }) {
-	const editorPostTitleRef = useRef();
 	const postTitleRef = useRef(post.title);
 	const postContentRef = useRef(post.content);
 	const { addEntities, editEntityRecord, receiveEntityRecords } =
@@ -71,12 +74,14 @@ function Editor({ post }) {
 	const { setEditedPost } = useDispatch(editorStore);
 	const { getEditedPostAttribute, getEditedPostContent } =
 		useSelect(editorStore);
+	const { setupEditor } = useDispatch(editorStore);
 
 	useEffect(() => {
 		window.editor = editor;
 		addEntities(postTypeEntities);
 		receiveEntityRecords('postType', post.type, post);
 
+		setupEditor(post, {});
 		registerCoreBlocks();
 
 		editorLoaded();
@@ -94,37 +99,33 @@ function Editor({ post }) {
 
 	const {
 		blockPatterns,
-		currentPost,
-		hasLoadedPost,
+		editorSettings,
 		hasUploadPermissions,
+		isEditorReady,
 		reusableBlocks,
 	} = useSelect(
 		(select) => {
-			const { getEntityRecord, getEntityRecords, hasFinishedResolution } =
-				select(coreStore);
+			const { getEntityRecord, getEntityRecords } = select(coreStore);
+			const { __unstableIsEditorReady, getEditorSettings } =
+				select(editorStore);
 			const user = getEntityRecord('root', 'user', post.author);
-			const _currentPost = getEntityRecord(
-				'postType',
-				post.type,
-				post.id
-			);
-			const _hasLoadedPost = post?.id
-				? hasFinishedResolution('getEntityRecord', [
-						'postType',
-						post.type,
-						post.id,
-					])
-				: true;
+			const _isEditorReady = post?.id ? __unstableIsEditorReady() : true;
 
 			return {
+				isEditorReady: _isEditorReady,
+				editorSettings: getEditorSettings(),
 				blockPatterns: select(coreStore).getBlockPatterns(),
-				currentPost: _currentPost,
-				hasLoadedPost: _hasLoadedPost,
 				hasUploadPermissions: user?.capabilities?.upload_files ?? true,
 				reusableBlocks: getEntityRecords('postType', 'wp_block'),
 			};
 		},
-		[post.author, post.id, post.type]
+		[post.author, post.id]
+	);
+
+	const [postBlocks, onInput, onChange] = useEntityBlockEditor(
+		'postType',
+		post.type,
+		{ id: post.id }
 	);
 
 	useEffect(() => {
@@ -170,44 +171,53 @@ function Editor({ post }) {
 		};
 	};
 
+	const blockEditorSettings = useBlockEditorSettings(
+		editorSettings,
+		post.type,
+		post.id,
+		'visual'
+	);
+
 	const settings = useMemo(
 		() => ({
+			...blockEditorSettings,
 			hasFixedToolbar: true,
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalReusableBlocks: reusableBlocks,
 			__experimentalBlockPatterns: blockPatterns,
 		}),
-		[blockPatterns, hasUploadPermissions, reusableBlocks]
+		[
+			blockEditorSettings,
+			blockPatterns,
+			hasUploadPermissions,
+			reusableBlocks,
+		]
 	);
 
 	const styles = useEditorStyles();
 	useMediaUpload();
 
 	return (
-		hasLoadedPost && (
-			<div className="editor__container">
-				<EditorProvider
-					post={currentPost}
-					settings={settings}
-					useSubRegistry={false}
-				>
-					<BlockCanvas
-						shouldIframe={false}
-						height="auto"
-						styles={styles}
-					>
-						<div className="editor-visual-editor__post-title-wrapper">
-							<PostTitle ref={editorPostTitleRef} />
-						</div>
-						<BlockList />
-					</BlockCanvas>
-					<EditorToolbar />
+		<div className="editor__container">
+			<BlockEditorProvider
+				value={postBlocks}
+				onInput={onInput}
+				onChange={onChange}
+				settings={settings}
+				useSubRegistry={false}
+			>
+				<BlockCanvas shouldIframe={false} height="auto" styles={styles}>
+					<div className="editor-visual-editor__post-title-wrapper">
+						{isEditorReady && <PostTitle ref={postTitleRef} />}
+					</div>
+					<BlockList />
+				</BlockCanvas>
+				{isEditorReady && <EditorToolbar />}
 
-					<Popover.Slot />
-					<EditorSnackbars />
-				</EditorProvider>
-			</div>
-		)
+				<Popover.Slot />
+				<EditorSnackbars />
+			</BlockEditorProvider>
+		</div>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Replace our current editor architecture with the approach recommended in the Gutenberg Framework [documentation](https://wordpress.org/gutenberg-framework/docs/intro).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/Automattic/dotcom-forge/issues/10026. 

After merging https://github.com/wordpress-mobile/GutenbergKit/pull/24, several regressions were introduced. Namely, the block toolbar would unexpectedly empty when moving the mouse cursor after typing into a rich text field.

Additionally, the Patterns and Media tabs in the block inserter have not worked since the previous change, as it no longer had access to private APIs enabling their operation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replace our usage of `EditorProvider` with `BlockEditor` provider, as well as reintroduce the necessary supporting code for managing the post content state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
**1 - Formatting options remain present within the block toolbar**
1. Start the development server. 
1. Open the editor in your desktop browser.
1. Insert a Paragraph block.
1. Type a couple of words into the block. 
1. Move your mouse cursor.
1. Verify the block toolbar remains populated with rich text formatting
   options—e.g., bold, italic, etc.

**2 - The Patterns/Media tab populate with content from the current site**
1. Start the development server. 
1. Open the editor within the WordPress mobile app.
1. Open the block inserter.
1. Tap the Patterns/Media tab.
1. Verify the tab is populated with content from the current site.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
