### PR TITLE
feat: Communicate editor load event to host app

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -311,6 +311,7 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
 
         let duration = CFAbsoluteTimeGetCurrent() - timestampInit
         print("gutenbergkit-measure_editor-first-render:", duration)
+        delegate?.editorDidLoad(self)
 
         // TODO: refactor (perform initial setup with a single JS call)
         Task { @MainActor in

--- a/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 public protocol EditorViewControllerDelegate: AnyObject {
+    /// Called when the editor loads.
+    func editorDidLoad(_ viewContoller: EditorViewController)
+
     /// Gets called when the editor is loaded and the initial content is displayed.
     ///
     /// - parameter content: Content serialized according to the editor's settings.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
## What?
<!-- In a few words, what is the PR actually doing? -->
Add a bridge method for communicating the editor load event to the host app.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Allow the host app to act upon the editor load event.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Expose a editor load bridge method.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See:

* https://github.com/wordpress-mobile/WordPress-iOS/pull/23955
* https://github.com/wordpress-mobile/WordPress-Android/pull/21564

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
