### PR TITLE
fix: Gradient background error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9189,9 +9189,9 @@
 			"license": "ISC"
 		},
 		"node_modules/gradient-parser": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
-			"integrity": "sha512-+uPlcVbjrKOnTzvz0MjTj7BfACj8OmxIa1moIjJV7btvhUMSJk0D47RfDCgDrZE3dYMz9Cf5xKJwnrKLjUq0KQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.0.2.tgz",
+			"integrity": "sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==",
 			"engines": {
 				"node": ">=0.10.0"
 			}

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
 		"prettier": "^3.4.2",
 		"sass-embedded": "^1.83.4",
 		"vite": "^6.0.11"
+	},
+	"overrides": {
+		"gradient-parser": "^1.0.2"
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix a `can't find variable result` error when setting a background gradient for
a block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes #67. The error prevents setting a background gradient, resulting in a broken block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The current `gradient-parser` version used by `@wordpress/components`
contains error-generating code for certain environments. While it is
unclear which specific environments, it does appear to occur for this
project's build environment.

See: https://github.com/rafaelcaricio/gradient-parser/pull/11

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Insert a Group block. 
1. Open the block settings.
1. Select the style tab.
1. Set a gradient background for the block.
1. Verify the gradient is set and displayed, without an error in the console.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
