### PR TITLE
refactor: Simplify content change bridge listener

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -314,13 +314,13 @@ class GutenbergView : WebView {
         fun onLogJsException(exception: GutenbergJsException)
     }
 
-    fun getTitleAndContent(callback: TitleAndContentCallback, clearFocus: Boolean = true) {
+    fun getTitleAndContent(callback: TitleAndContentCallback, completeComposition: Boolean = true) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
         handler.post {
-            this.evaluateJavascript("editor.getTitleAndContent($clearFocus);") { result ->
+            this.evaluateJavascript("editor.getTitleAndContent($completeComposition);") { result ->
                 val jsonObject = JSONObject(result)
                 lastUpdatedTitle = jsonObject.optString("title", "")
                 lastUpdatedContent = jsonObject.optString("content", "")

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -280,7 +280,7 @@ class GutenbergView : WebView {
     }
 
     interface ContentChangeListener {
-        fun onContentChanged(title: String, content: String)
+        fun onContentChanged()
     }
 
     interface HistoryChangeListener {
@@ -364,7 +364,7 @@ class GutenbergView : WebView {
     fun onEditorContentChanged() {
         getTitleAndContent(object : TitleAndContentCallback {
             override fun onResult(title: String, content: String) {
-                contentChangeListener?.onContentChanged(title, content)
+                contentChangeListener?.onContentChanged()
             }
         }, false)
     }

--- a/src/components/editor/index.jsx
+++ b/src/components/editor/index.jsx
@@ -5,6 +5,7 @@ import { useEntityBlockEditor } from '@wordpress/core-data';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -39,8 +40,9 @@ const { ExperimentalBlockEditorProvider: BlockEditorProvider } = unlock(
  * @return {JSX.Element} The rendered App component.
  */
 export default function Editor({ post, children }) {
+	const editorRef = useRef(null);
+	useHostBridge(post, editorRef);
 	useSyncHistoryControls();
-	useHostBridge(post);
 	useHostExceptionLogging();
 	useEditorSetup(post);
 	useMediaUpload();
@@ -66,7 +68,7 @@ export default function Editor({ post, children }) {
 	}, []);
 
 	return (
-		<div className="gutenberg-kit-editor">
+		<div className="gutenberg-kit-editor" ref={editorRef}>
 			<EditorLoadNotice className="gutenberg-kit-editor__load-notice" />
 			<BlockEditorProvider
 				value={postBlocks}

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -13,7 +13,7 @@ import { onEditorContentChanged } from '../../utils/bridge';
 
 window.editor = window.editor || {};
 
-export function useHostBridge(post) {
+export function useHostBridge(post, editorRef) {
 	const { editEntityRecord } = useDispatch(coreStore);
 	const { undo, redo, switchEditorMode } = useDispatch(editorStore);
 	const { getEditedPostAttribute, getEditedPostContent } =
@@ -37,7 +37,7 @@ export function useHostBridge(post) {
 
 		window.editor.getContent = (completeComposition = false) => {
 			if (completeComposition) {
-				endComposition();
+				endComposition(editorRef.current);
 			}
 
 			return getEditedPostContent();
@@ -45,7 +45,7 @@ export function useHostBridge(post) {
 
 		window.editor.getTitleAndContent = (completeComposition = false) => {
 			if (completeComposition) {
-				endComposition();
+				endComposition(editorRef.current);
 			}
 
 			return {
@@ -79,6 +79,7 @@ export function useHostBridge(post) {
 			delete window.editor.switchEditorMode;
 		};
 	}, [
+		editorRef,
 		editContent,
 		getEditedPostAttribute,
 		getEditedPostContent,
@@ -110,13 +111,12 @@ export function useHostBridge(post) {
  * `contenteditable` element. This is used to ensure that the latest composition
  * text is persisted to the DOM before reading its value in the host.
  *
- * @todo Address the disabled eslint rule `@wordpress/no-global-active-element`.
+ * @param {Element} element The element in which to end the composition.
  *
  * @return {void}
  */
-function endComposition() {
-	// eslint-disable-next-line @wordpress/no-global-active-element
-	const activeElement = document.activeElement;
+function endComposition(element) {
+	const activeElement = element?.ownerDocument.activeElement;
 
 	if (activeElement && activeElement.contentEditable === 'true') {
 		const compositionEvent = new Event('compositionend');

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -35,17 +35,17 @@ export function useHostBridge(post) {
 			editContent({ title: decodeURIComponent(title) });
 		};
 
-		window.editor.getContent = (blurInput = false) => {
-			if (blurInput) {
-				blurEditor();
+		window.editor.getContent = (completeComposition = false) => {
+			if (completeComposition) {
+				endComposition();
 			}
 
 			return getEditedPostContent();
 		};
 
-		window.editor.getTitleAndContent = (blurInput = false) => {
-			if (blurInput) {
-				blurEditor();
+		window.editor.getTitleAndContent = (completeComposition = false) => {
+			if (completeComposition) {
+				endComposition();
 			}
 
 			return {
@@ -106,20 +106,20 @@ export function useHostBridge(post) {
 }
 
 /**
- * Blurs the currently active paragraph element in the document.
- *
- * This function checks if the currently active element is a paragraph (`<p>`).
- * If it is, the function removes focus from that element.
+ * Ends the current text composition on the active element, if it is a
+ * `contenteditable` element. This is used to ensure that the latest composition
+ * text is persisted to the DOM before reading its value in the host.
  *
  * @todo Address the disabled eslint rule `@wordpress/no-global-active-element`.
  *
  * @return {void}
  */
-function blurEditor() {
+function endComposition() {
 	// eslint-disable-next-line @wordpress/no-global-active-element
 	const activeElement = document.activeElement;
 
-	if (activeElement && activeElement.tagName === 'P') {
-		activeElement.blur();
+	if (activeElement && activeElement.contentEditable === 'true') {
+		const compositionEvent = new Event('compositionend');
+		activeElement.dispatchEvent(compositionEvent);
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related: https://github.com/wordpress-mobile/WordPress-Android/pull/21663

## What?
<!-- In a few words, what is the PR actually doing? -->
Simplify the content change listener signature.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. The JavaScript implementation does send the title and content values,
   so the method signature is misleading.
2. The host app is expected to retrieve the title and content whenever
   it decides to persist the latest changes. The `onContentChange` event
   is intended to notify the host of new content.

This aligns GutenbergKit with the approach used for the Gutenberg Mobile
and Aztec editors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove the misleading title and content parameters.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See: https://github.com/wordpress-mobile/WordPress-Android/pull/21663

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
