### PR TITLE
fix: Catch null content errors

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -41,8 +41,8 @@ class GutenbergView : WebView {
     private var siteApiRoot: String = ""
     private var siteApiNamespace: String = ""
     private var authHeader: String = ""
-    private var lastUpdatedTitle = ""
-    private var lastUpdatedContent = ""
+    private var lastUpdatedTitle: CharSequence? = null
+    private var lastUpdatedContent: CharSequence? = null
 
     private val handler = Handler(Looper.getMainLooper())
     private var editorDidBecomeAvailable: ((GutenbergView) -> Unit)? = null
@@ -276,7 +276,7 @@ class GutenbergView : WebView {
     }
 
     interface TitleAndContentCallback {
-        fun onResult(title: String, content: String)
+        fun onResult(title: CharSequence, content: CharSequence)
     }
 
     interface ContentChangeListener {
@@ -314,17 +314,22 @@ class GutenbergView : WebView {
         fun onLogJsException(exception: GutenbergJsException)
     }
 
-    fun getTitleAndContent(callback: TitleAndContentCallback, completeComposition: Boolean = true) {
+    fun getTitleAndContent(originalContent: CharSequence, callback: TitleAndContentCallback, completeComposition: Boolean = true) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
         handler.post {
             this.evaluateJavascript("editor.getTitleAndContent($completeComposition);") { result ->
-                val jsonObject = JSONObject(result)
-                lastUpdatedTitle = jsonObject.optString("title", "")
-                lastUpdatedContent = jsonObject.optString("content", "")
-                callback.onResult(lastUpdatedTitle, lastUpdatedContent)
+                try {
+                    val jsonObject = JSONObject(result)
+                    lastUpdatedTitle = jsonObject.getString("title")
+                    lastUpdatedContent = jsonObject.getString("content")
+                } catch (e: JSONException) {
+                    Log.e("GutenbergView", "Received invalid JSON from editor.getTitleAndContent")
+                }
+
+                callback.onResult(lastUpdatedTitle ?: "", lastUpdatedContent ?: originalContent)
             }
         }
     }
@@ -362,11 +367,7 @@ class GutenbergView : WebView {
 
     @JavascriptInterface
     fun onEditorContentChanged() {
-        getTitleAndContent(object : TitleAndContentCallback {
-            override fun onResult(title: String, content: String) {
-                contentChangeListener?.onContentChanged()
-            }
-        }, false)
+        contentChangeListener?.onContentChanged()
     }
 
     @JavascriptInterface


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related: 

* https://github.com/wordpress-mobile/GutenbergKit/issues/74
* https://github.com/wordpress-mobile/WordPress-Android/pull/21673

## What?
<!-- In a few words, what is the PR actually doing? -->
Prevent editor crashes caused by null content values.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix https://github.com/wordpress-mobile/GutenbergKit/issues/74. The crashes are disruptive.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
There are contexts where the JavaScript runtime appears to send null
values to the host app. It could be performance related, but we should
catch the errors nonetheless.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Test saving title and content changes in the editor—save/update button, back button, quit app, etc. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
