### PR TITLE
fix: Prevent sized images overflow

### DIFF
--- a/src/components/visual-editor/style.scss
+++ b/src/components/visual-editor/style.scss
@@ -48,6 +48,14 @@
 	display: none;
 }
 
+// Apply an admittedly problematic workaround for a bug in responsive images.
+// This should be removed once the bug is fixed in core.
+// https://github.com/WordPress/gutenberg/issues/38381#issuecomment-1099194060
+.gutenberg-kit-visual-editor .wp-block-image > div:first-child {
+	height: auto;
+	max-width: 100%;
+}
+
 .gutenberg-kit-visual-editor__toolbar {
 	align-items: center;
 	bottom: 0;

--- a/src/index.html
+++ b/src/index.html
@@ -8,8 +8,8 @@
 		/>
 		<title>Gutenberg</title>
 	</head>
-	<body>
-		<div id="root" class="root"></div>
+	<body class="gutenberg-kit">
+		<div id="root" class="gutenberg-kit-root"></div>
 		<script type="module" src="/index.jsx"></script>
 	</body>
 </html>

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,6 +1,6 @@
 @use "@wordpress/base-styles/variables" as wordpress;
 
-.root {
+.gutenberg-kit-root {
 	display: flex;
 	flex-direction: column;
 	height: 100vh;

--- a/src/remote.html
+++ b/src/remote.html
@@ -8,8 +8,8 @@
 		/>
 		<title>Gutenberg</title>
 	</head>
-	<body>
-		<div id="root" class="root"></div>
+	<body class="gutenberg-kit">
+		<div id="root" class="gutenberg-kit-root"></div>
 		<script type="module" src="/remote.jsx"></script>
 	</body>
 </html>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Prevent images with custom sizes from overflowing the editor width.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix #90. There is a bug in Gutenberg core causing images with custom sizes no
longer rendering in a responsive manner within the editor. This results in
unexpected horizontal overflow for smaller mobile device screens.

See: https://github.com/WordPress/gutenberg/issues/38381#issuecomment-1099893749

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
These changes apply an admittedly problematic workaround until a more robust
solution is shipped in Gutenberg core. The changes enforce responsive widths on
the `div` wrapping all Image block `img` elements.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See #90.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| - | - |
| <img width="380" alt="before" src="https://github.com/user-attachments/assets/a6e50f04-09f7-4edf-924a-3e0f4b3488cb" /> | <img width="380" alt="after" src="https://github.com/user-attachments/assets/87b5dcb2-8dc6-40a5-b500-fe4b3b98070e" /> |

