### PR TITLE
fix: Prevent unsupported block overflow

### DIFF
--- a/src/components/visual-editor/style.scss
+++ b/src/components/visual-editor/style.scss
@@ -56,6 +56,17 @@
 	max-width: 100%;
 }
 
+// Ensure unsupported blocks do not overflow the block canvas
+.gutenberg-kit-visual-editor .wp-block-missing {
+	max-width: 100%;
+	overflow: hidden;
+}
+
+.gutenberg-kit-visual-editor .wp-block-missing img {
+	height: auto;
+	max-width: 100%;
+}
+
 .gutenberg-kit-visual-editor__toolbar {
 	align-items: center;
 	bottom: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Constrain the contents of unsupported blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix #78. Unsupported blocks largely render as non-styled HTML. This can result
in content with large dimensions overflowing the block canvas, particularly on
smaller devices.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Apply maximum widths to unsupported blocks and their descendent images.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See #78.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
| Before | After | 
| - | - |
| <img width="380" alt="before" src="https://github.com/user-attachments/assets/aafbd39f-5e64-43a8-af2f-e187160abfd4" /> | <img width="380" alt="after" src="https://github.com/user-attachments/assets/448cc98c-9fd0-4cc5-bea4-5734445dd5fd" /> |


