### PR TITLE
fix: Allow copying content on error

### DIFF
--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -17,7 +17,7 @@ import Editor from './editor';
  */
 export default function Layout(props) {
 	return (
-		<ErrorBoundary>
+		<ErrorBoundary canCopyContent>
 			<Editor {...props}>
 				<EditorSnackbars />
 			</Editor>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allow copying the current post content whenever the editor experiences an error.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This feature was erroneously disabled during previous dependency
upgrades. We now need to pass an explicit prop.

https://github.com/WordPress/gutenberg/pull/64245

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Pass the `canCopyContent` prop in the top-level error boundary.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Introduce an intentional error.
1. Verify the "copy contents" button is present.

<details><summary>Intentional error diff</summary>
<p>

```diff
diff --git a/src/components/editor/index.jsx b/src/components/editor/index.jsx
index 906b07a..2c15f8a 100644
--- a/src/components/editor/index.jsx
+++ b/src/components/editor/index.jsx
@@ -69,6 +69,7 @@ export default function Editor({ post, children }) {
 
 	return (
 		<div className="gutenberg-kit-editor" ref={editorRef}>
+			{intentionalError}
 			<EditorLoadNotice className="gutenberg-kit-editor__load-notice" />
 			<BlockEditorProvider
 				value={postBlocks}

```

</p>
</details> 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| - | - |
| <img width="380" alt="before" src="https://github.com/user-attachments/assets/7c13aaa1-ef98-4bd2-94ec-0a30d605aef8" /> | <img width="380" alt="after" src="https://github.com/user-attachments/assets/a36b4c8a-9c3f-47c8-a6c0-8c0835ff6ec9" /> | 
