### PR TITLE
feat: Filter block types with allow list

### DIFF
--- a/src/remote.jsx
+++ b/src/remote.jsx
@@ -33,7 +33,11 @@ async function initalizeRemoteEditor() {
 		const { themeStyles, hideTitle, siteApiRoot, siteApiNamespace } =
 			getGBKit();
 		// TODO: Load editor assets within the host app
-		const { styles, scripts } = await apiFetch( {
+		const {
+			styles,
+			scripts,
+			allowed_block_types: allowedBlockTypes,
+		} = await apiFetch( {
 			url: `${ siteApiRoot }wpcom/v2/${ siteApiNamespace[ 0 ] }/editor-assets`,
 		} );
 		await loadAssets( [ ...styles, ...scripts ].join( '' ) );
@@ -67,7 +71,14 @@ async function initalizeRemoteEditor() {
 		const { default: Layout } = await import( './components/layout' );
 		const { createRoot, createElement, StrictMode } = window.wp.element;
 		const { registerCoreBlocks } = window.wp.blockLibrary;
+
 		registerCoreBlocks();
+		window.wp.blocks.getBlockTypes().forEach( ( block ) => {
+			if ( ! allowedBlockTypes.includes( block.name ) ) {
+				window.wp.blocks.unregisterBlockType( block.name );
+			}
+		} );
+
 		createRoot( document.getElementById( 'root' ) ).render(
 			createElement(
 				StrictMode,

--- a/src/remote.jsx
+++ b/src/remote.jsx
@@ -73,11 +73,13 @@ async function initalizeRemoteEditor() {
 		const { registerCoreBlocks } = window.wp.blockLibrary;
 
 		registerCoreBlocks();
-		window.wp.blocks.getBlockTypes().forEach( ( block ) => {
-			if ( ! allowedBlockTypes.includes( block.name ) ) {
-				window.wp.blocks.unregisterBlockType( block.name );
-			}
-		} );
+		if ( allowedBlockTypes ) {
+			window.wp.blocks.getBlockTypes().forEach( ( block ) => {
+				if ( ! allowedBlockTypes.includes( block.name ) ) {
+					window.wp.blocks.unregisterBlockType( block.name );
+				}
+			} );
+		}
 
 		createRoot( document.getElementById( 'root' ) ).render(
 			createElement(

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -238,6 +238,14 @@ export function waitForGBKit( timeoutMs = 3000 ) {
 		const startTime = Date.now();
 
 		const checkGBKit = () => {
+			if ( ! window.GBKit ) {
+				try {
+					window.GBKit = JSON.parse(
+						localStorage.getItem( 'GBKit' )
+					);
+				} catch ( error ) {}
+			}
+
 			if ( window.GBKit ) {
 				resolve( window.GBKit );
 				return;

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -238,14 +238,6 @@ export function waitForGBKit( timeoutMs = 3000 ) {
 		const startTime = Date.now();
 
 		const checkGBKit = () => {
-			if ( ! window.GBKit ) {
-				try {
-					window.GBKit = JSON.parse(
-						localStorage.getItem( 'GBKit' )
-					);
-				} catch ( error ) {}
-			}
-
 			if ( window.GBKit ) {
 				resolve( window.GBKit );
 				return;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related: 

- CMM-224-linear-issue
- https://github.com/Automattic/jetpack/pull/42835

## What?
<!-- In a few words, what is the PR actually doing? -->
Filter the available block types via an allow list fetched from the API
endpoint.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-224. Used for selectively enabling stable block types and/or removing
unnecessary or problematic assets.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Given block types are registered via the scripts loaded onto the page, we must
unregister each block type not within the allow list.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This small, conditional-wrapped change is likely safe to merge without additional testing. For posterity, the following are the explicit steps for testing:

1. In the Jetpack mobile app, enable the `Experimental block editor plugins` feature flag. 
2. Smoke test the editor and Jetpack blocks. The REST API endpoint currently allows all of the same block types as before, so there are no changes to observe. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes.
