### PR TITLE
test: Assert iOS WebView globals configuration

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorConfiguration.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorConfiguration.swift
@@ -28,10 +28,10 @@ public struct WebViewGlobal {
     let name: String
     let value: WebViewGlobalValue
 
-    public init(name: String, value: WebViewGlobalValue) {
+    public init(name: String, value: WebViewGlobalValue) throws {
         // Validate name is a valid JavaScript identifier
         guard Self.isValidJavaScriptIdentifier(name) else {
-            preconditionFailure("Invalid JavaScript identifier: \(name)")
+            throw WebViewGlobalError.invalidIdentifier(name)
         }
         self.name = name
         self.value = value
@@ -41,6 +41,10 @@ public struct WebViewGlobal {
         // Add validation logic for JavaScript identifiers
         return name.range(of: "^[a-zA-Z_$][a-zA-Z0-9_$]*$", options: .regularExpression) != nil
     }
+}
+
+public enum WebViewGlobalError: Error {
+    case invalidIdentifier(String)
 }
 
 public enum WebViewGlobalValue {

--- a/ios/Tests/GutenbergKitTests/EditorConfigurationTests.swift
+++ b/ios/Tests/GutenbergKitTests/EditorConfigurationTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import GutenbergKit
+
+final class EditorConfigurationTests: XCTestCase {
+
+    // MARK: - WebViewGlobal Tests
+
+    func testValidJavaScriptIdentifiers() {
+        let validIdentifiers = [
+            "myVar",
+            "_privateVar",
+            "$jQuery",
+            "myVar123",
+            "MY_CONSTANT",
+            "a",
+            "A"
+        ]
+
+        for identifier in validIdentifiers {
+            XCTAssertNoThrow(try WebViewGlobal(name: identifier, value: .string("test")))
+        }
+    }
+
+    func testInvalidJavaScriptIdentifiers() {
+        let invalidIdentifiers = [
+            "123invalid",
+            "my-var",
+            "my.var",
+            "my var",
+            "",
+            "my@var",
+            "my#var"
+        ]
+
+        for identifier in invalidIdentifiers {
+            XCTAssertThrowsError(try WebViewGlobal(name: identifier, value: .string("test")))
+        }
+    }
+
+    // MARK: - WebViewGlobalValue Tests
+
+    func testStringValueConversion() {
+        let testCases = [
+            ("simple", "\"simple\""),
+            ("with \"quotes\"", "\"with \\\"quotes\\\"\""),
+            ("with\nnewline", "\"with\\nnewline\""),
+            ("with\ttab", "\"with\\ttab\""),
+            ("with\rreturn", "\"with\\rreturn\""),
+            ("with\u{8}backspace", "\"with\\bbackspace\""),
+            ("with\u{12}formfeed", "\"with\\fformfeed\"")
+        ]
+
+        for (input, expected) in testCases {
+            let value = WebViewGlobalValue.string(input)
+            XCTAssertEqual(value.toJavaScript(), expected)
+        }
+    }
+
+    func testNumberValueConversion() {
+        let testCases = [
+            (42.0, "42.0"),
+            (-3.14, "-3.14"),
+            (0.0, "0.0"),
+            (1.0, "1.0")
+        ]
+
+        for (input, expected) in testCases {
+            let value = WebViewGlobalValue.number(input)
+            XCTAssertEqual(value.toJavaScript(), expected)
+        }
+    }
+
+    func testBooleanValueConversion() {
+        XCTAssertEqual(WebViewGlobalValue.boolean(true).toJavaScript(), "true")
+        XCTAssertEqual(WebViewGlobalValue.boolean(false).toJavaScript(), "false")
+    }
+
+    func testNullValueConversion() {
+        XCTAssertEqual(WebViewGlobalValue.null.toJavaScript(), "null")
+    }
+
+    func testObjectValueConversion() {
+        let object = WebViewGlobalValue.object([
+            "name": .string("test"),
+            "count": .number(42),
+            "active": .boolean(true),
+            "nested": .object([
+                "value": .string("nested")
+            ])
+        ])
+
+        let actual = object.toJavaScript()
+        let expected = "{\"name\": \"test\",\"active\": true,\"count\": 42.0,\"nested\": {\"value\": \"nested\"}}"
+
+        guard let actualData = actual.data(using: .utf8),
+              let expectedData = expected.data(using: .utf8),
+              let actualJSON = try? JSONSerialization.jsonObject(with: actualData) as? [String: Any],
+              let expectedJSON = try? JSONSerialization.jsonObject(with: expectedData) as? [String: Any] else {
+            XCTFail("Failed to parse JSON")
+            return
+        }
+
+        XCTAssertEqual(actualJSON as NSDictionary, expectedJSON as NSDictionary)
+    }
+
+    func testArrayValueConversion() {
+        let array = WebViewGlobalValue.array([
+            .string("test"),
+            .number(42),
+            .boolean(true),
+            .null
+        ])
+
+        let expected = "[\"test\",42.0,true,null]"
+        XCTAssertEqual(array.toJavaScript(), expected)
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Assert iOS WebView global configuration. Close CMM-284.

Related: https://github.com/wordpress-mobile/WordPress-iOS/pull/24485

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Avoid regressions within the regex and string manipulation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add automated unit tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A, no user-facing changes.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
