### PR TITLE
perf: Avoid unnecessary editor assets requests

### DIFF
--- a/src/utils/remote-editor.js
+++ b/src/utils/remote-editor.js
@@ -10,6 +10,12 @@ import { getGBKit } from './bridge';
 import { error } from './logger';
 
 /**
+ * Cache for editor assets to avoid unnecessary network requests
+ * @type {Object|null}
+ */
+let editorAssetsCache = null;
+
+/**
  * @typedef {Object} EditorAssetConfig
  *
  * @property {string[]} allowedBlockTypes Array of allowed block types provided by the API.
@@ -29,30 +35,27 @@ export async function loadEditorAssets( {
 	disallowedPackages = [],
 } = {} ) {
 	try {
+		// Return cached response if available
+		if ( editorAssetsCache ) {
+			return processEditorAssets( editorAssetsCache, {
+				allowedPackages,
+				disallowedPackages,
+			} );
+		}
+
 		const { siteApiRoot, siteApiNamespace } = getGBKit();
 		// TODO: Load editor assets within the host app
-		const {
-			styles,
-			scripts,
-			allowed_block_types: allowedBlockTypes,
-		} = await apiFetch( {
+		const response = await apiFetch( {
 			url: `${ siteApiRoot }wpcom/v2/${ siteApiNamespace[ 0 ] }/editor-assets`,
 		} );
 
-		if ( allowedPackages.length > 0 ) {
-			// Only load allowed packages.
-			await loadAssets( [ ...styles, ...scripts ].join( '' ), {
-				allowedPackages,
-			} );
+		// Cache the response
+		editorAssetsCache = response;
 
-			return { allowedBlockTypes };
-		}
-
-		await loadAssets( [ ...styles, ...scripts ].join( '' ), {
+		return processEditorAssets( response, {
+			allowedPackages,
 			disallowedPackages,
 		} );
-
-		return { allowedBlockTypes };
 	} catch ( err ) {
 		error( 'Error loading editor assets', err );
 		// Fallback to the local editor and display a notice. Because the remote
@@ -60,6 +63,40 @@ export async function loadEditorAssets( {
 		// editor's scripts and styles for displaying the notice.
 		window.location.href = 'index.html?error=remote_editor_load_error';
 	}
+}
+
+/**
+ * Process editor assets and return the configuration
+ *
+ * @param {Object}   assets                     The assets to process
+ * @param {string[]} assets.styles              Array of style assets
+ * @param {string[]} assets.scripts             Array of script assets
+ * @param {string[]} assets.allowedBlockTypes   Array of allowed block types
+ * @param {Object}   options                    Processing options
+ * @param {string[]} options.allowedPackages    Array of allowed package names
+ * @param {string[]} options.disallowedPackages Array of disallowed package names
+ *
+ * @return {EditorAssetConfig} Processed editor configuration
+ */
+async function processEditorAssets(
+	assets,
+	{ allowedPackages = [], disallowedPackages = [] } = {}
+) {
+	const { styles, scripts, allowed_block_types: allowedBlockTypes } = assets;
+
+	if ( allowedPackages.length > 0 ) {
+		await loadAssets( [ ...styles, ...scripts ].join( '' ), {
+			allowedPackages,
+		} );
+
+		return { allowedBlockTypes };
+	}
+
+	await loadAssets( [ ...styles, ...scripts ].join( '' ), {
+		disallowedPackages,
+	} );
+
+	return { allowedBlockTypes };
 }
 
 /**

--- a/src/utils/remote-editor.js
+++ b/src/utils/remote-editor.js
@@ -13,7 +13,6 @@ import { error } from './logger';
  * @typedef {Object} EditorAssetConfig
  *
  * @property {string[]} allowedBlockTypes Array of allowed block types provided by the API.
- * @property {Object}   wpDependencies    WordPress dependencies, empty when allowedPackages is provided.
  */
 
 /**
@@ -23,7 +22,7 @@ import { error } from './logger';
  * @param {Array}  [options.allowedPackages]    Array of allowed package names to load.
  * @param {Array}  [options.disallowedPackages] Array of disallowed package names to load.
  *
- * @return {EditorAssetConfig} Allowed block types and WordPress dependencies.
+ * @return {EditorAssetConfig} Editor configuration provided by the API.
  */
 export async function loadEditorAssets( {
 	allowedPackages = [],
@@ -46,27 +45,14 @@ export async function loadEditorAssets( {
 				allowedPackages,
 			} );
 
-			return {
-				allowedBlockTypes,
-				wpDependencies: {},
-			};
+			return { allowedBlockTypes };
 		}
 
 		await loadAssets( [ ...styles, ...scripts ].join( '' ), {
 			disallowedPackages,
 		} );
 
-		return {
-			allowedBlockTypes,
-			wpDependencies: {
-				StrictMode: window.wp?.element?.StrictMode,
-				createRoot: window.wp?.element?.createRoot,
-				dispatch: window.wp?.data?.dispatch,
-				editorStore: window.wp?.editor?.store,
-				preferencesStore: window.wp?.preferences?.store,
-				registerCoreBlocks: window.wp?.blockLibrary?.registerCoreBlocks,
-			},
-		};
+		return { allowedBlockTypes };
 	} catch ( err ) {
 		error( 'Error loading editor assets', err );
 		// Fallback to the local editor and display a notice. Because the remote


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Rely upon a cache to avoid unnecessary network requests during editor initialization. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We invoke `loadEditorAssets` twice—once for i18n modules, and then again for all other `@wordpress` modules. The second invocation is performed immediately after the first, and there is no benefit for requesting a new response. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Cache the API endpoint response in memory. Long-term, we plan to cache the response and the assets themselves, which is explored in #107. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Test while using a build of the WordPress app with the Gutenberg/experimental editor `_plugins` debug flag enabled. 
2. Monitor your testing device's network activity. 
3. Open the remote or site-specific editor. 
4. Verify a single request to the editor assets endpoint is performed. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes. 
