### PR TITLE
fix: Prevent block inserter horizontal overflow

### DIFF
--- a/src/components/visual-editor/style.scss
+++ b/src/components/visual-editor/style.scss
@@ -40,6 +40,15 @@
 	padding-right: 16px;
 }
 
+// Prevent horizontal scroll in the block inserter popover. This only appears to
+// occur on touch devices, not cursor devices.
+// TODO: Fix this in core and remove the styles.
+.gutenberg-kit-visual-editor
+	.block-editor-inserter__popover
+	.components-popover__content {
+	overflow-x: hidden !important; // `!important` required to override inline styles
+}
+
 // Hide the inline block appendar button, as its positioning and size is not
 // ideal for small screens
 .gutenberg-kit-visual-editor


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Prevent horizontal scrolling in the block inserter.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The horizontal scrollbar is unnecessary, as the intended content should
only scroll vertically. Fix CMM-345. Fix #121.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Override core-provided, inline styles for the popover component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the block inserter.
1. Explore various tabs and Attempt to scroll.
1. Verify content is accessible as expected, but horizontal scrolling does not
   occur.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Content navigation should remain the same as before.

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes.
