### PR TITLE
fix: Android presents file picker for File block upload

### DIFF
--- a/android/Gutenberg/build.gradle.kts
+++ b/android/Gutenberg/build.gradle.kts
@@ -59,6 +59,9 @@ dependencies {
     implementation(libs.gson)
 
     testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.robolectric)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -209,35 +209,25 @@ class GutenbergView : WebView {
             ): Boolean {
                 filePathCallback = newFilePathCallback
                 val allowMultiple = fileChooserParams?.mode == FileChooserParams.MODE_OPEN_MULTIPLE
-                val mimeTypes = if (fileChooserParams?.acceptTypes == null ||
-                    (fileChooserParams.acceptTypes.size == 1 && fileChooserParams.acceptTypes[0] == "")) {
-                    arrayOf("*/*")
-                } else {
-                    fileChooserParams.acceptTypes
+                // Only accept MIME types if they are not empty strings
+                val mimeTypes = fileChooserParams?.acceptTypes?.takeUnless { it.size == 1 && it[0].isEmpty() }
+
+                val intent = Intent(Intent.ACTION_GET_CONTENT)
+                intent.setType("*/*")
+                intent.addCategory(Intent.CATEGORY_OPENABLE)
+
+                if (mimeTypes != null) {
+                    intent.setType(mimeTypes[0])
+                    intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
                 }
 
-                val intents = mutableListOf<Intent>()
-
-                val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    type = mimeTypes[0] // Use first MIME type as primary
-                    putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
-                    if (allowMultiple) {
-                        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
-                    }
+                if (allowMultiple) {
+                    intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
                 }
-                intents.add(intent)
 
                 onFileChooserRequested?.let { callback ->
                     handler.post {
-                        try {
-                            val chooserIntent = Intent.createChooser(intents[0], "Select Files")
-                            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intents.subList(1, intents.size).toTypedArray())
-                            callback(chooserIntent, pickImageRequestCode)
-                            Log.d("GutenbergView", "File chooser intent sent successfully")
-                        } catch (e: Exception) {
-                            Log.e("GutenbergView", "Error launching file chooser", e)
-                        }
+                        callback(Intent.createChooser(intent, "Select Files"), pickImageRequestCode)
                     }
                 }
                 return true

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -209,17 +209,13 @@ class GutenbergView : WebView {
             ): Boolean {
                 filePathCallback = newFilePathCallback
                 val allowMultiple = fileChooserParams?.mode == FileChooserParams.MODE_OPEN_MULTIPLE
-                // Only accept MIME types if they are not empty strings
-                val mimeTypes = fileChooserParams?.acceptTypes?.takeUnless { it.size == 1 && it[0].isEmpty() }
+                // Only use `acceptTypes` if it is not merely an empty string
+                val mimeTypes = fileChooserParams?.acceptTypes?.takeUnless { it.size == 1 && it[0].isEmpty() } ?: arrayOf("*/*")
 
                 val intent = Intent(Intent.ACTION_GET_CONTENT)
-                intent.setType("*/*")
+                intent.setType(mimeTypes[0])
+                intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
                 intent.addCategory(Intent.CATEGORY_OPENABLE)
-
-                if (mimeTypes != null) {
-                    intent.setType(mimeTypes[0])
-                    intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
-                }
 
                 if (allowMultiple) {
                     intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -209,23 +209,35 @@ class GutenbergView : WebView {
             ): Boolean {
                 filePathCallback = newFilePathCallback
                 val allowMultiple = fileChooserParams?.mode == FileChooserParams.MODE_OPEN_MULTIPLE
-                val mimeTypes = fileChooserParams?.acceptTypes
-
-                val intent = Intent(Intent.ACTION_PICK).apply {
-                    type = "*/*"  // Default to all types
+                val mimeTypes = if (fileChooserParams?.acceptTypes == null ||
+                    (fileChooserParams.acceptTypes.size == 1 && fileChooserParams.acceptTypes[0] == "")) {
+                    arrayOf("*/*")
+                } else {
+                    fileChooserParams.acceptTypes
                 }
 
-                if (!mimeTypes.isNullOrEmpty()) {
-                    intent.type = mimeTypes.joinToString("|")
-                }
+                val intents = mutableListOf<Intent>()
 
-                if (allowMultiple) {
-                    intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+                    addCategory(Intent.CATEGORY_OPENABLE)
+                    type = mimeTypes[0] // Use first MIME type as primary
+                    putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
+                    if (allowMultiple) {
+                        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                    }
                 }
+                intents.add(intent)
 
                 onFileChooserRequested?.let { callback ->
                     handler.post {
-                        callback(Intent.createChooser(intent, "Select Files"), pickImageRequestCode)
+                        try {
+                            val chooserIntent = Intent.createChooser(intents[0], "Select Files")
+                            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intents.subList(1, intents.size).toTypedArray())
+                            callback(chooserIntent, pickImageRequestCode)
+                            Log.d("GutenbergView", "File chooser intent sent successfully")
+                        } catch (e: Exception) {
+                            Log.e("GutenbergView", "Error launching file chooser", e)
+                        }
                     }
                 }
                 return true

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
@@ -1,0 +1,150 @@
+package org.wordpress.gutenberg
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Looper
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class GutenbergViewTest {
+    @Mock
+    private lateinit var mockWebView: WebView
+
+    @Mock
+    private lateinit var mockFilePathCallback: ValueCallback<Array<Uri?>?>
+
+    @Mock
+    private lateinit var mockFileChooserParams: WebChromeClient.FileChooserParams
+
+    private lateinit var gutenbergView: GutenbergView
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        gutenbergView = GutenbergView(RuntimeEnvironment.getApplication())
+        gutenbergView.initializeWebView()
+    }
+
+    @Test
+    fun `onShowFileChooser sets up file chooser with single file selection`() {
+        // Given
+        val latch = CountDownLatch(1)
+        var capturedIntent: Intent? = null
+
+        gutenbergView.setOnFileChooserRequestedListener { intent, _ ->
+            capturedIntent = intent
+            latch.countDown()
+        }
+
+        // When
+        gutenbergView.webChromeClient?.onShowFileChooser(
+            mockWebView,
+            mockFilePathCallback,
+            mockFileChooserParams
+        )
+
+        // Process any pending runnables
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        // Wait for the callback to be executed
+        latch.await(1, TimeUnit.SECONDS)
+
+        // Then
+        assertTrue("Intent should not be null", capturedIntent != null)
+        assertTrue("Intent should be a chooser", capturedIntent?.action == Intent.ACTION_CHOOSER)
+
+        // Get the original intent from the chooser
+        val originalIntent = capturedIntent?.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+        assertTrue("Original intent should not be null", originalIntent != null)
+        assertTrue("Original intent action should be ACTION_GET_CONTENT",
+            originalIntent?.action == Intent.ACTION_GET_CONTENT)
+        assertTrue("Original intent should have CATEGORY_OPENABLE",
+            originalIntent?.hasCategory(Intent.CATEGORY_OPENABLE) == true)
+        assertEquals("Pick image request code should be 1",
+            1, gutenbergView.pickImageRequestCode)
+    }
+
+    @Test
+    fun `onShowFileChooser sets up file chooser with multiple file selection`() {
+        // Given
+        val latch = CountDownLatch(1)
+        var capturedIntent: Intent? = null
+
+        gutenbergView.setOnFileChooserRequestedListener { intent, _ ->
+            capturedIntent = intent
+            latch.countDown()
+        }
+
+        // When
+        `when`(mockFileChooserParams.mode).thenReturn(WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE)
+        gutenbergView.webChromeClient?.onShowFileChooser(
+            mockWebView,
+            mockFilePathCallback,
+            mockFileChooserParams
+        )
+
+        // Process any pending runnables
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        // Wait for the callback to be executed
+        latch.await(1, TimeUnit.SECONDS)
+
+        // Then
+        assertTrue("Intent should not be null", capturedIntent != null)
+        assertTrue("Intent should be a chooser", capturedIntent?.action == Intent.ACTION_CHOOSER)
+
+        // Get the original intent from the chooser
+        val originalIntent = capturedIntent?.getParcelableExtra<Intent>(Intent.EXTRA_INTENT)
+        assertTrue("Original intent should not be null", originalIntent != null)
+        assertTrue("Original intent should allow multiple selection",
+            originalIntent?.getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false) == true)
+    }
+
+    @Test
+    fun `onShowFileChooser stores file path callback`() {
+        // When
+        gutenbergView.webChromeClient?.onShowFileChooser(
+            mockWebView,
+            mockFilePathCallback,
+            mockFileChooserParams
+        )
+
+        // Then
+        assertEquals("File path callback should be stored",
+            mockFilePathCallback, gutenbergView.filePathCallback)
+    }
+
+    @Test
+    fun `resetFilePathCallback clears the callback`() {
+        // Given
+        gutenbergView.webChromeClient?.onShowFileChooser(
+            mockWebView,
+            mockFilePathCallback,
+            mockFileChooserParams
+        )
+
+        // When
+        gutenbergView.resetFilePathCallback()
+
+        // Then
+        assertEquals("File path callback should be null after reset",
+            null, gutenbergView.filePathCallback)
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ activity = "1.9.0"
 constraintlayout = "2.1.4"
 webkit = "1.11.0"
 gson = "2.8.9"
+mockito = "4.1.0"
+robolectric = "4.14.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -23,9 +25,11 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
+mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Present the OS file picker when attempting to upload within the File block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix the inability to upload files. Fix CMM-344. Fix #124. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use `ACTION_GET_CONTENT` rather than `ACTION_PICK`, as it appears to be a more
robust and appropriate intent for the use case.

Avoid passing along the empty `acceptedTypes` values from the web
implementation—e.g., `[""]`. It is not clear why this empty value is passed along. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
**1: File block allows uploading files**
1. Insert a File block.
1. Tap Upload.
1. Verify the file uploads and attaches to the block.

**2. Image/Video blocks filter by the appropriate MIME type**
1. Insert a block with a specific file type--e.g, Image.
1. Tap Upload.
1. Verify the correct file types are available for selection, not other file
   types.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
N/A
