### PR TITLE
build: Update `@wordpress/block-editor` patch

### DIFF
--- a/patches/@wordpress+block-editor+14.17.0.patch
+++ b/patches/@wordpress+block-editor+14.17.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js b/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js
-index aa2e9a5..f2d8481 100644
+index 78b9b8f..3c0049d 100644
 --- a/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js
 +++ b/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js
-@@ -192,6 +192,7 @@ class Inserter extends Component {
+@@ -191,6 +191,7 @@ class Inserter extends Component {
          shift: true
        },
        onToggle: this.onToggle,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update `@wordpress/block-editor` patch.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Address the following warning logged while running `npm install`:

<details>

<summary>Warning log</summary>

```
patch-package 8.0.0
Applying patches...
@wordpress/block-editor@14.11.0 ✔

Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    @wordpress/block-editor@14.11.0

  applied to

    @wordpress/block-editor@14.17.0

  At path

    node_modules/@wordpress/block-editor

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package @wordpress/block-editor

  to update the version in the patch file name and make this warning go away.

---
patch-package finished with 1 warning(s).
```

</details>

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Run `npx patch-package @wordpress/block-editor`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A, no user-facing changes.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
