### PR TITLE
fix: Mitigate Android text composition oddities

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -360,7 +360,7 @@ class GutenbergView : WebView {
         fun onLogJsException(exception: GutenbergJsException)
     }
 
-    fun getTitleAndContent(originalContent: CharSequence, callback: TitleAndContentCallback, completeComposition: Boolean = true) {
+    fun getTitleAndContent(originalContent: CharSequence, callback: TitleAndContentCallback, completeComposition: Boolean = false) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Remove default of ending text composition when requesting title and content.

Related: https://github.com/wordpress-mobile/WordPress-Android/pull/21883

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Ref CMM-353. Ref CMM-199. 

Fix #103. Fix #130. 

Forcibly ending text composition led to odd outcomes--e.g., erroneously
dismissing the inline inserter, resetting editor history stack. 

It was originally added to ensure the latest text in the editor is
captured before providing it to the host app for persistence. This
appears necessary for Samsung device keyboards only. For the time being,
text may be lost on these devices if the user does not first blur the
text input before saving or exiting the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Flip the default parameter value.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See https://github.com/wordpress-mobile/WordPress-Android/pull/21883.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes.
