### PR TITLE
fix: Scrolling along edges breaks text editing

### DIFF
--- a/patches/@wordpress+rich-text+7.22.0.patch
+++ b/patches/@wordpress+rich-text+7.22.0.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@wordpress/rich-text/build-module/component/event-listeners/prevent-focus-capture.js b/node_modules/@wordpress/rich-text/build-module/component/event-listeners/prevent-focus-capture.js
+index 3b885f5..c2ea3d0 100644
+--- a/node_modules/@wordpress/rich-text/build-module/component/event-listeners/prevent-focus-capture.js
++++ b/node_modules/@wordpress/rich-text/build-module/component/event-listeners/prevent-focus-capture.js
+@@ -36,9 +36,11 @@ export function preventFocusCapture() {
+     }
+     defaultView.addEventListener('pointerdown', onPointerDown);
+     defaultView.addEventListener('pointerup', onPointerUp);
++    defaultView.addEventListener('pointercancel', onPointerUp);
+     return () => {
+       defaultView.removeEventListener('pointerdown', onPointerDown);
+       defaultView.removeEventListener('pointerup', onPointerUp);
++      defaultView.removeEventListener('pointercancel', onPointerUp);
+     };
+   };
+ }

--- a/patches/README.md
+++ b/patches/README.md
@@ -10,3 +10,7 @@ Existing patches should be described and justified here.
 
 -   Expose an `open` prop on the `Inserter` component, allowing toggling the inserter visibility via the quick inserter's "Browse all" button.
 -   Disable `stripExperimentalSettings` in the `BlockEditorProvider` component so that the Patterns and Media inserter tabs function.
+
+### `@wordpress/rich-text`
+
+-   Fix `preventFocusCapture` causing uneditable text blocks on touch devices when scrolling by swiping outside of the block canvas--e.g., along the edge of the screen.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix perpetually disabled text blocks after scrolling the editor by swiping
outside of the block canvas container.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-356. The inability to edit text is unexpected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Existing Gutenberg `preventFocusCapture` logic relies upon `pointerdown`
and `pointerup` events for temporarily disabling all text blocks
`contenteditable` status. This is done to mitigate issues with block
selection for `flex` elements.

However, `pointerup` events are not always triggered on touch devices
when a touch turns into a swipe. When you scroll with your finger
outside of the block canvas, the `pointerup` callback is never invoked.
Scrolling twice or more leads to a stale `value` in the callback, and a
state where `contenteditable` is perpetually disabled.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post with a few text blocks.
1. Scroll by swiping alongside the edge of the display—i.e., outside of the
   block canvas that contains the blocks.
1. Perform the previous step at least once more.
1. Attempt to focus a text block and modify its content.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes.
