### PR TITLE
docs: Clarify media upload activity indicator

### DIFF
--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -40,14 +40,14 @@
 -   **Steps:**
     -   Add an Image block.
     -   Tap "Choose from device" and select an image.
--   **Expected Outcome:** Image uploads and displays in the block. Upload progress is shown if needed.
+-   **Expected Outcome:** Image uploads and displays in the block. An activity indicator is shown while the image is uploading.
 
 ### S.6. Upload an video
 
 -   **Steps:**
     -   Add a Video block.
     -   Tap "Choose from device" and select a video.
--   **Expected Outcome:** Video uploads and displays in the block. Upload progress is shown if needed.
+-   **Expected Outcome:** Video uploads and displays in the block. An activity indicator is shown while the video is uploading.
 
 ### S.7. Reorder blocks
 
@@ -103,7 +103,7 @@
 -   **Steps:**
     -   Add a Gallery block, upload multiple images.
     -   Add captions to gallery and individual images, apply formatting.
--   **Expected Outcome:** Images upload with progress indicators; captions and formatting display as expected.
+-   **Expected Outcome:** An activity indicator is shown while the images are uploading. Captions and formatting display as expected.
 
 ### F.6. Pattern insertion
 
@@ -118,7 +118,7 @@ Known issue: [Audio block unable to upload expected file formats](https://github
 -   **Steps:**
     -   Add an Audio block.
     -   Tap "Choose from device" and select an audio file.
--   **Expected Outcome:** Audio uploads and displays in the block. Progress indicator is shown if needed.
+-   **Expected Outcome:** Audio uploads and displays in the block. An activity indicator is shown while the audio is uploading.
 
 ### F.8. Upload a file
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Clarify that media uploads display an activity indicator, not a progress bar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Mitigate confusion while testing.

## How?
Update test case documentation.
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A, no user-facing changes.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
