### PR TITLE
fix: Embed renders

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -387,22 +387,13 @@ private final class GutenbergEditorController: NSObject, WKNavigationDelegate, W
             return
         }
 
-        if url.isFileURL || // Local editor file
-            url.scheme == "about" || // Empty request
-            url.scheme == "blob" || // Blob URL, used by inserter iframes
-            url.scheme == "data" || // Data URL, used by inserter iframes
-            url.host == editorURL?.host || // Local development server
-            url.host == "public-api.wordpress.com" || // WordPress.com REST API
-            (url.host == URL(string: configuration.siteURL)?.host &&
-             (url.path.contains("/wp-json/") || url.query?.contains("rest_route=") == true)) // WordPress REST API
-        {
-            decisionHandler(.allow)
-            return
+        if navigationAction.navigationType == .linkActivated {
+            // Open the request in OS browser
+            UIApplication.shared.open(url)
+            decisionHandler(.cancel)
         }
 
-        // Open the request in OS browser
-        UIApplication.shared.open(url)
-        decisionHandler(.cancel)
+        decisionHandler(.allow)
     }
 
     // MARK: - WKScriptMessageHandler

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
 		/>
 		<title>Gutenberg</title>
 	</head>
-	<body class="gutenberg-kit">
+	<body class="gutenberg-kit wp-embed-responsive">
 		<div id="root" class="gutenberg-kit-root"></div>
 		<script type="module" src="/index.jsx"></script>
 	</body>

--- a/src/remote.html
+++ b/src/remote.html
@@ -8,7 +8,7 @@
 		/>
 		<title>Gutenberg</title>
 	</head>
-	<body class="gutenberg-kit">
+	<body class="gutenberg-kit wp-embed-responsive">
 		<div id="root" class="gutenberg-kit-root"></div>
 		<script type="module" src="/remote.jsx"></script>
 	</body>

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { getQueryArg } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ export function initializeApiFetch() {
 	apiFetch.use( createHeadersMiddleware( authHeader ) );
 	apiFetch.use( filterEndpointsMiddleware );
 	apiFetch.use( mediaUploadMiddleware );
+	apiFetch.use( transformOEmbedApiResponse );
 	apiFetch.use( apiFetch.createPreloadingMiddleware( preloadData ) );
 }
 
@@ -125,6 +127,66 @@ function mediaUploadMiddleware( options, next ) {
 	}
 
 	return next( options );
+}
+
+/**
+ * Remove the wrapping element from the oEmbed response, as it breaks
+ * Gutenberg's sizing styles.
+ *
+ * @type {APIFetchMiddleware}
+ *
+ * @todo Hoist this host-specific logic to the host app.
+ */
+function transformOEmbedApiResponse( options, next ) {
+	if ( options.path && options.path.indexOf( 'oembed' ) !== -1 ) {
+		const url = getQueryArg( options.path, 'url' );
+		const response = next( options, next );
+
+		/**
+		 * Creates an embed response emulating core's fallback link.
+		 */
+		function createFallbackResponse() {
+			const link = document.createElement( 'a' );
+			link.href = url;
+			link.innerText = url;
+			return {
+				html: link.outerHTML,
+				type: 'rich',
+				provider_name: 'Embed',
+			};
+		}
+
+		return new Promise( ( resolve ) => {
+			response
+				.then( ( data ) => {
+					if ( data.html ) {
+						/**
+						 * Removes wrappers from YouTube, Vimeo, Dailymotion, TED block, e.g.
+						 * <span class="embed-youtube">, <div class="embed-vimeo">, <div class="embed-dailymotion">, <div class="embed-ted">
+						 * and return just the <iframe> child directly to allow wide & full width sizing.
+						 */
+						const doc =
+							document.implementation.createHTMLDocument( '' );
+						doc.body.innerHTML = data.html;
+						const selectors = [
+							'[class="embed-youtube"]',
+							'[class="embed-vimeo"]',
+							'[class="embed-dailymotion"]',
+							'[class="embed-ted"]',
+						].join( ',' );
+						const wrapper = doc.querySelector( selectors );
+						data.html = wrapper ? wrapper.innerHTML : data.html;
+					}
+
+					resolve( data );
+				} )
+				.catch( () => {
+					resolve( createFallbackResponse() );
+				} );
+		} );
+	}
+
+	return next( options, next );
 }
 
 /**

--- a/vite.config.remote.js
+++ b/vite.config.remote.js
@@ -99,7 +99,8 @@ function wordPressExternals() {
 
 				if (
 					! externalDefinition ||
-					/@wordpress\/(api-fetch|i18n|url)/.test( id )
+					/@wordpress\/(api-fetch|i18n|url)/.test( id ) ||
+					/@wordpress\/(api-fetch|i18n|url)/.test( module )
 				) {
 					continue; // Exclude the module from externalization
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix broken embed rendering.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Embeds unexpectedly launched the iOS browser rather than rendering.
Additionally, embed sizing was incorrect due to missing `body` class and
wrapping elements.

Fix CMM-287. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Update iOS WebView request handling logic to only open link-activation requests
in the OS browser.

Add required `body` class for responsive embeds. See https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#responsive-embedded-content.

Add host-specific logic for removing wrapping elements from embed renders.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
> [!Tip]
> When testing iOS, use the prototype build: https://github.com/wordpress-mobile/WordPress-iOS/pull/24556

**1: Embeds can be created**
1. Insert an Embed block. 
1. Paste a YouTube URL (or other embed URL) into the input.
1. Verify the embed renders as expected.

**2: Opening a post with an embed renders the embed**
1. Open a post with an existing embed. 
2. Verify the embed renders as expected, the OS browser is not launched. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes.
