### PR TITLE
fix: Prevent inline image crash

### DIFF
--- a/src/components/editor/test/use-media-upload.test.jsx
+++ b/src/components/editor/test/use-media-upload.test.jsx
@@ -124,4 +124,21 @@ describe( 'useMediaUpload', () => {
 
 		expect( openMediaLibrary ).toHaveBeenCalled();
 	} );
+
+	it( 'should always provide a multiple argument to the openMediaLibrary callback', () => {
+		let FilterCallback;
+		addFilter.mockImplementation( ( name, namespace, callback ) => {
+			FilterCallback = callback();
+		} );
+
+		renderHook( () => useMediaUpload() );
+		render(
+			<FilterCallback
+				render={ ( { open } ) => open() }
+				onSelect={ vi.fn() }
+			/>
+		);
+
+		expect( openMediaLibrary ).toHaveBeenCalledWith( { multiple: false } );
+	} );
 } );

--- a/src/components/editor/test/use-media-upload.test.jsx
+++ b/src/components/editor/test/use-media-upload.test.jsx
@@ -126,14 +126,14 @@ describe( 'useMediaUpload', () => {
 	} );
 
 	it( 'should always provide a multiple argument to the openMediaLibrary callback', () => {
-		let FilterCallback;
+		let MediaUploadComponent;
 		addFilter.mockImplementation( ( name, namespace, callback ) => {
-			FilterCallback = callback();
+			MediaUploadComponent = callback();
 		} );
 
 		renderHook( () => useMediaUpload() );
 		render(
-			<FilterCallback
+			<MediaUploadComponent
 				render={ ( { open } ) => open() }
 				onSelect={ vi.fn() }
 			/>

--- a/src/components/editor/use-media-upload.js
+++ b/src/components/editor/use-media-upload.js
@@ -53,6 +53,8 @@ function MediaUpload( { render, ...config } ) {
  * @return {{open: ()=>void}} An object containing a function to open the Media Library.
  */
 function useNativeMediaLibrary( { onSelect, ...config } ) {
+	const { allowedTypes, multiple = false, value } = config;
+
 	useEffect( () => {
 		window.editor.setMediaUploadAttachment = ( attachment ) => {
 			onSelect( config.multiple ? attachment : attachment[ 0 ] );
@@ -63,7 +65,15 @@ function useNativeMediaLibrary( { onSelect, ...config } ) {
 		};
 	}, [ onSelect, config.multiple ] );
 
-	const open = useCallback( () => openMediaLibrary( config ), [ config ] );
+	const open = useCallback(
+		() =>
+			openMediaLibrary( {
+				allowedTypes,
+				multiple,
+				value,
+			} ),
+		[ allowedTypes, multiple, value ]
+	);
 
 	return { open };
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Mitigate native host crashes stemming from the absence of a `multiple`
parameter passed to `openMediaLibrary`. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-375. Fix JETPACK-IOS-1F5E.

The absence of this parameter conflicted with expected argument types in the
host app. It appears different contexts may exclude this value—e.g., when
inserting an inline image within a Paragraph block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Set a default `mutliple` value.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

> [!Tip]
> Test using the [WP-iOS prototype build](https://github.com/wordpress-mobile/WordPress-iOS/pull/24568#issuecomment-2913144985). 

1. Insert a Paragraph block.
1. Open the text formatting menu (tap the downward chevron in the block
   toolbar).
1. Tap _Inline image_.
1. Verify the app does not crash and one can insert an image via the media picker.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes.
