### PR TITLE
Revert to AGP 8.7.3

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.8.1"
+agp = "8.7.3"
 kotlin = "1.9.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"


### PR DESCRIPTION
As a companion to [this WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/21917), this PR reverts AGP to v8.7.3. Please refer to that WPAndroid PR for details.