### PR TITLE
Add cookie support

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/EditorConfiguration.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/EditorConfiguration.kt
@@ -61,8 +61,9 @@ open class EditorConfiguration constructor(
     val authHeader: String,
     val webViewGlobals: List<WebViewGlobal>,
     val editorSettings: String?,
-    val locale: String?
-) : Parcelable {
+    val locale: String?,
+    val cookies: Map<String, String>
+): Parcelable {
     companion object {
         @JvmStatic
         fun builder(): Builder = Builder()
@@ -84,6 +85,7 @@ open class EditorConfiguration constructor(
         private var webViewGlobals: List<WebViewGlobal> = emptyList()
         private var editorSettings: String? = null
         private var locale: String? = "en"
+        private var cookies: Map<String, String> = mapOf()
 
         fun setTitle(title: String) = apply { this.title = title }
         fun setContent(content: String) = apply { this.content = content }
@@ -100,6 +102,7 @@ open class EditorConfiguration constructor(
         fun setWebViewGlobals(webViewGlobals: List<WebViewGlobal>) = apply { this.webViewGlobals = webViewGlobals }
         fun setEditorSettings(editorSettings: String?) = apply { this.editorSettings = editorSettings }
         fun setLocale(locale: String?) = apply { this.locale = locale }
+        fun setCookies(cookies: Map<String, String>) = apply { this.cookies = cookies }
 
         fun build(): EditorConfiguration = EditorConfiguration(
             title = title,
@@ -116,7 +119,8 @@ open class EditorConfiguration constructor(
             authHeader = authHeader,
             webViewGlobals = webViewGlobals,
             editorSettings = editorSettings,
-            locale = locale
+            locale = locale,
+            cookies = cookies
         )
     }
 
@@ -141,6 +145,7 @@ open class EditorConfiguration constructor(
         if (webViewGlobals != other.webViewGlobals) return false
         if (editorSettings != other.editorSettings) return false
         if (locale != other.locale) return false
+        if (cookies != other.cookies) return false
 
         return true
     }
@@ -161,6 +166,7 @@ open class EditorConfiguration constructor(
         result = 31 * result + webViewGlobals.hashCode()
         result = 31 * result + (editorSettings?.hashCode() ?: 0)
         result = 31 * result + (locale?.hashCode() ?: 0)
+        result = 31 * result + cookies.hashCode()
         return result
     }
 }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -11,12 +11,14 @@ import android.util.AttributeSet
 import android.util.Log
 import android.view.View
 import android.webkit.ConsoleMessage
+import android.webkit.CookieManager
 import android.webkit.JavascriptInterface
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
+import android.webkit.WebStorage
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.webkit.WebViewAssetLoader
@@ -250,9 +252,24 @@ class GutenbergView : WebView {
         } else {
             ASSET_URL
         }
-        this.loadUrl(editorUrl)
 
-        Log.i("GutenbergView", "Startup Complete")
+        WebStorage.getInstance().deleteAllData()
+        this.clearCache(true)
+        // All cookies are third-party cookies because the root of this document
+        // lives under `https://appassets.androidplatform.net`
+        CookieManager.getInstance().setAcceptThirdPartyCookies(this, true);
+
+        // Erase all local cookies before loading the URL – we don't want to persist
+        // anything between uses – otherwise we might send the wrong cookies
+        CookieManager.getInstance().removeAllCookies {
+            CookieManager.getInstance().flush()
+            for(cookie in configuration.cookies) {
+                CookieManager.getInstance().setCookie(cookie.key, cookie.value)
+            }
+            this.loadUrl(editorUrl)
+
+            Log.i("GutenbergView", "Startup Complete")
+        }
     }
 
     private fun setGlobalJavaScriptVariables() {

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.example.gutenbergkit
 
 import android.os.Bundle
-import android.util.Log
 import android.webkit.WebView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
@@ -39,6 +38,7 @@ class MainActivity : AppCompatActivity() {
             .setNamespaceExcludedPaths(arrayOf())
             .setAuthHeader("")
             .setWebViewGlobals(emptyList())
+            .setCookies(emptyMap())
             .build()
 
         gbView.start(config)

--- a/ios/Demo-iOS/Sources/EditorView.swift
+++ b/ios/Demo-iOS/Sources/EditorView.swift
@@ -2,7 +2,11 @@ import SwiftUI
 import GutenbergKit
 
 struct EditorView: View {
-    var configuration: EditorConfiguration
+    private let configuration: EditorConfiguration
+
+    init(configuration: EditorConfiguration) {
+        self.configuration = configuration
+    }
 
     var body: some View {
         _EditorView(configuration: configuration)
@@ -69,7 +73,11 @@ struct EditorView: View {
 }
 
 private struct _EditorView: UIViewControllerRepresentable {
-    let configuration: EditorConfiguration
+    private let configuration: EditorConfiguration
+
+    init(editorURL: URL? = nil, configuration: EditorConfiguration) {
+        self.configuration = configuration
+    }
 
     func makeUIViewController(context: Context) -> EditorViewController {
         let viewController = EditorViewController(configuration: configuration)

--- a/ios/Sources/GutenbergKit/Sources/EditorConfiguration.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorConfiguration.swift
@@ -22,6 +22,7 @@ public struct EditorConfiguration {
     /// The locale to use for translations
     public var locale = "en"
     public var editorAssetsEndpoint: URL?
+    public var cookies: [HTTPCookie] = []
 
     public init(title: String = "", content: String = "") {
         self.title = title

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -37,6 +37,12 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         config.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
         config.setValue(true, forKey: "allowUniversalAccessFromFileURLs")
 
+        // The editor shouldn't try to persist cookies – we want complete control over how they're handled
+        config.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+        for cookie in configuration.cookies {
+            config.websiteDataStore.httpCookieStore.setCookie(cookie)
+        }
+
         // Set-up communications with the editor.
         config.userContentController.add(controller, name: "editorDelegate")
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds the ability to set cookies that'll be used by the editor. 

## Why?
Ref CMM-235. Close CMM-450. This will make it easy to support private sites for WP.com where the assets require authentication.

## How?
Properly routes cookies to where they need to go.

At the moment, there's nothing fancy here – the developer has to know how to properly construct the cookie. We can make this more ergonomic later, if we want.

## Testing Instructions
### For iOS:

1. Update `ContentView.swift`'s `init` method to read:

```swift
    init(configuration: EditorConfiguration = .default) {
        var mutableCopy = configuration
        let cookie = HTTPCookie(properties: [
            .domain: "wpmobilep2.wordpress.com",
            .path: "/",
            .name: "wordpress_logged_in",
            .value: "[redacted]",
            .secure: true,
        ])!
        mutableCopy.cookies.append(cookie)
        self.configuration = mutableCopy
    }
```
2. Replace `[redacted]` with the value of the cookie sent when requesting 
https://wpmobilep2.wordpress.com/wp-content/uploads/2025/05/screenshot-2025-05-20-at-3.35.11e280afpm.jpeg from your browser.
3. Run the demo app and insert the image listed above.
4. It should show up.
5. Comment out the cookie injection, try again, note it doesn't work.

### For Android:

1. Update `MainActivity`'s `setCookies` call to:

```kotlin
            .setCookies(mapOf(
                "https://wpmobilep2.wordpress.com" to "wordpress_logged_in=[redacted]; domain=wpmobilep2.wordpress.com; SameSite=None; Secure; HttpOnly"
            ))
```

2. Replace `[redacted]` with the value of the cookie sent when requesting 
https://wpmobilep2.wordpress.com/wp-content/uploads/2025/05/screenshot-2025-05-20-at-3.35.11e280afpm.jpeg from your browser.
3. Run the demo app and insert the image listed above.
4. It should show up.
5. Comment out the cookie injection, try again, note it doesn't work.
