### PR TITLE
feat: Mark content outside of popovers inert

### DIFF
--- a/patches/@wordpress+block-editor+14.17.0.patch
+++ b/patches/@wordpress+block-editor+14.17.0.patch
@@ -1,8 +1,13 @@
 diff --git a/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js b/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js
-index 78b9b8f..3c0049d 100644
+index 78b9b8f..9a8efb8 100644
 --- a/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js
 +++ b/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js
-@@ -191,6 +191,7 @@ class Inserter extends Component {
+@@ -187,10 +187,12 @@ class Inserter extends Component {
+         'is-quick': isQuick
+       }),
+       popoverProps: {
++        ...this.props.popoverProps,
+         position,
          shift: true
        },
        onToggle: this.onToggle,

--- a/patches/README.md
+++ b/patches/README.md
@@ -10,6 +10,7 @@ Existing patches should be described and justified here.
 
 -   Expose an `open` prop on the `Inserter` component, allowing toggling the inserter visibility via the quick inserter's "Browse all" button.
 -   Disable `stripExperimentalSettings` in the `BlockEditorProvider` component so that the Patterns and Media inserter tabs function.
+-   Allow setting popover props for the `Inserter` component, so we can improve the mobile screen reader experience by marking it as a modal dialog.
 
 ### `@wordpress/components`
 

--- a/src/components/editor-toolbar/aria-helper.js
+++ b/src/components/editor-toolbar/aria-helper.js
@@ -1,0 +1,75 @@
+/**
+ * This file was sourced from the Gutenberg project and converted from
+ * TypeScript to JavaScript.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/3f0a805c568f92622faf4b71b24eeb5f39b5bca8/packages/components/src/modal/aria-helper.ts
+ */
+
+const LIVE_REGION_ARIA_ROLES = new Set( [
+	'alert',
+	'status',
+	'log',
+	'marquee',
+	'timer',
+] );
+
+const hiddenElementsByDepth = [];
+
+/**
+ * Hides all elements in the body element from screen-readers except
+ * the provided element and elements that should not be hidden from
+ * screen-readers.
+ *
+ * The reason we do this is because `aria-modal="true"` currently is bugged
+ * in Safari, and support is spotty in other browsers overall. In the future
+ * we should consider removing these helper functions in favor of
+ * `aria-modal="true"`.
+ *
+ * @param {Element} modalElement The element that should not be hidden.
+ */
+export function modalize( modalElement ) {
+	const elements = Array.from( document.body.children );
+	const hiddenElements = [];
+	hiddenElementsByDepth.push( hiddenElements );
+	for ( const element of elements ) {
+		if ( element === modalElement ) {
+			continue;
+		}
+
+		if ( elementShouldBeHidden( element ) ) {
+			element.setAttribute( 'aria-hidden', 'true' );
+			hiddenElements.push( element );
+		}
+	}
+}
+/**
+ * Determines if the passed element should not be hidden from screen readers.
+ *
+ * @param {Element} element The element that should be checked.
+ *
+ * @return {boolean} Whether the element should not be hidden from screen-readers.
+ */
+export function elementShouldBeHidden( element ) {
+	const role = element.getAttribute( 'role' );
+	return ! (
+		element.tagName === 'SCRIPT' ||
+		element.hasAttribute( 'hidden' ) ||
+		element.hasAttribute( 'aria-hidden' ) ||
+		element.hasAttribute( 'aria-live' ) ||
+		( role && LIVE_REGION_ARIA_ROLES.has( role ) )
+	);
+}
+
+/**
+ * Accessibly reveals the elements hidden by the latest modal.
+ */
+export function unmodalize() {
+	const hiddenElements = hiddenElementsByDepth.pop();
+	if ( ! hiddenElements ) {
+		return;
+	}
+
+	for ( const element of hiddenElements ) {
+		element.removeAttribute( 'aria-hidden' );
+	}
+}

--- a/src/components/editor-toolbar/index.jsx
+++ b/src/components/editor-toolbar/index.jsx
@@ -25,6 +25,7 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import './style.scss';
+import { useModalize } from './use-modalize';
 
 /**
  * Renders the editor toolbar containing block-related actions.
@@ -49,6 +50,9 @@ const EditorToolbar = ( { className } ) => {
 	}, [] );
 	const { setIsInserterOpened } = useDispatch( editorStore );
 
+	useModalize( isInserterOpened );
+	useModalize( isBlockInspectorShown );
+
 	function openSettings() {
 		setBlockInspectorShown( true );
 	}
@@ -68,6 +72,10 @@ const EditorToolbar = ( { className } ) => {
 			>
 				<ToolbarGroup>
 					<Inserter
+						popoverProps={ {
+							'aria-modal': true,
+							role: 'dialog',
+						} }
 						open={ isInserterOpened }
 						onToggle={ setIsInserterOpened }
 					/>
@@ -91,6 +99,9 @@ const EditorToolbar = ( { className } ) => {
 					className="block-settings-menu"
 					variant="unstyled"
 					placement="overlay"
+					aria-modal
+					onClose={ onCloseSettings }
+					role="dialog"
 				>
 					<>
 						<div className="block-settings-menu__header">

--- a/src/components/editor-toolbar/index.jsx
+++ b/src/components/editor-toolbar/index.jsx
@@ -63,7 +63,7 @@ const EditorToolbar = ( { className } ) => {
 
 	function onFocusOutside( event ) {
 		// Do not close the menu if the focus is inside the menu--e.g., a button
-		// opening a adjacent popover.
+		// opening an adjacent popover.
 		if ( event.target.closest( '.block-settings-menu' ) ) {
 			return;
 		}

--- a/src/components/editor-toolbar/index.jsx
+++ b/src/components/editor-toolbar/index.jsx
@@ -61,6 +61,16 @@ const EditorToolbar = ( { className } ) => {
 		setBlockInspectorShown( false );
 	}
 
+	function onFocusOutside( event ) {
+		// Do not close the menu if the focus is inside the menu--e.g., a button
+		// opening a adjacent popover.
+		if ( event.target.closest( '.block-settings-menu' ) ) {
+			return;
+		}
+
+		setBlockInspectorShown( false );
+	}
+
 	const classes = clsx( 'gutenberg-kit-editor-toolbar', className );
 
 	return (
@@ -101,6 +111,7 @@ const EditorToolbar = ( { className } ) => {
 					placement="overlay"
 					aria-modal
 					onClose={ onCloseSettings }
+					onFocusOutside={ onFocusOutside }
 					role="dialog"
 				>
 					<>

--- a/src/components/editor-toolbar/use-modalize.js
+++ b/src/components/editor-toolbar/use-modalize.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as ariaHelper from './aria-helper';
+
+/** @typedef {import('@wordpress/element').RefObject} RefObject */
+
+/**
+ * Conditionally applies the `aria-hidden` attribute to all direct decendents of
+ * the body element, except for the element provided.
+ *
+ * @param {boolean}   isModalVisible A boolean indicating whether the modal is visible.
+ * @param {RefObject} elementRef     A reference to the DOM element to be modalized.
+ */
+export function useModalize( isModalVisible, elementRef = defaultPopover() ) {
+	useEffect( () => {
+		if ( isModalVisible ) {
+			ariaHelper.modalize( elementRef.current );
+		} else {
+			ariaHelper.unmodalize();
+		}
+	}, [ elementRef, isModalVisible ] );
+}
+
+const popoverFallbackContainerRef = { current: null };
+
+/**
+ * Retrieves or initializes the fallback container for popovers.
+ *
+ * This function checks if the `popoverFallbackContainerRef` is already defined.
+ * If not, it attempts to find an element with the class name
+ * 'components-popover__fallback-container' in the document and assigns it to
+ * `popoverFallbackContainerRef`. It then returns an object with the current
+ * `popoverFallbackContainerRef`.
+ *
+ * @return {Object} An object containing the current `popoverFallbackContainerRef`.
+ */
+function defaultPopover() {
+	if ( popoverFallbackContainerRef.current ) {
+		return popoverFallbackContainerRef;
+	}
+
+	popoverFallbackContainerRef.current = document.getElementById(
+		'popover-fallback-container'
+	);
+
+	return popoverFallbackContainerRef;
+}

--- a/src/components/editor/style.scss
+++ b/src/components/editor/style.scss
@@ -1,4 +1,3 @@
-$baseline-interactive-font-size: 17px;
 $min-menu-item-touch-target-size: 42px;
 
 .gutenberg-kit-editor {
@@ -9,10 +8,6 @@ $min-menu-item-touch-target-size: 42px;
 // Simplify layout calculcations and mirror the `edit-post` package
 .gutenberg-kit-editor * {
 	box-sizing: border-box;
-}
-
-.gutenberg-kit-editor .components-button {
-	font-size: $baseline-interactive-font-size;
 }
 
 .gutenberg-kit-editor .components-dropdown-menu__menu-item,

--- a/src/components/visual-editor/index.jsx
+++ b/src/components/visual-editor/index.jsx
@@ -153,8 +153,6 @@ function VisualEditor( { hideTitle } ) {
 			</BlockCanvas>
 
 			<EditorToolbar className="gutenberg-kit-visual-editor__toolbar" />
-
-			<Popover.Slot />
 		</div>
 	);
 }

--- a/src/components/visual-editor/index.jsx
+++ b/src/components/visual-editor/index.jsx
@@ -12,7 +12,6 @@ import {
 	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { Popover } from '@wordpress/components';
 import { store as editorStore, PostTitle } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
 import { store as editPostStore } from '@wordpress/edit-post';

--- a/src/index.html
+++ b/src/index.html
@@ -11,5 +11,9 @@
 	<body class="gutenberg-kit wp-embed-responsive">
 		<div id="root" class="gutenberg-kit-root"></div>
 		<script type="module" src="/index.jsx"></script>
+		<div
+			id="popover-fallback-container"
+			class="components-popover__fallback-container"
+		></div>
 	</body>
 </html>

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,5 +1,7 @@
 @use "@wordpress/base-styles/variables" as wordpress;
 
+$baseline-interactive-font-size: 17px;
+
 // Reasonable defaults used when theme styles are unavailable
 :root {
 	--wp--style--global--content-size: 645px;
@@ -19,6 +21,10 @@
 .gutenberg-kit {
 	.block-editor-inserter__menu .block-editor-tabbed-sidebar__close-button {
 		display: none;
+	}
+
+	.components-button {
+		font-size: $baseline-interactive-font-size;
 	}
 
 	/* Popover */

--- a/src/remote.html
+++ b/src/remote.html
@@ -11,5 +11,9 @@
 	<body class="gutenberg-kit wp-embed-responsive">
 		<div id="root" class="gutenberg-kit-root"></div>
 		<script type="module" src="/remote.jsx"></script>
+		<div
+			id="popover-fallback-container"
+			class="components-popover__fallback-container"
+		></div>
 	</body>
 </html>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Mark content outside of the block inserter and block inspector [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close #86. Close CMM-192. Without this, screen readers unexpectedly navigate content that is visually
hidden by the modal popovers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
For the block inserter and block inspector:

- Enable modal ARIA attribute.
- Apply the dialog role.
- Mark content outside of the popover as inert.
- Enable closing via VoiceOver's two-finger scrub.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
> [!Tip]
> Test using the WP-iOS [prototype build](https://github.com/wordpress-mobile/WordPress-iOS/pull/24571#issuecomment-2923031781). 

**1: Content outside of popover is inert** [^1]
1. Enable [VoiceOver](https://support.apple.com/guide/iphone/turn-on-and-practice-voiceover-iph3e2e415f/ios).
1. Open the block inserter.
1. Activate the Media tab.
1. [Swipe up with two fingers](https://support.apple.com/guide/iphone/use-voiceover-gestures-iph3e2e2281/ios#:~:text=Two%2Dfinger%20swipe%20up).
1. Verify the screen reader does not announce HTML content behind the
   dialog—e.g., block canvas content.

[^1]: This also applies to Android TalkBack, but testing Android with these steps is not possible due to an existing bug: https://github.com/WordPress/gutenberg/issues/70277. 

**2: Dismiss dialogs with iOS' two-finger scrub**
1. Enable [VoiceOver](https://support.apple.com/guide/iphone/turn-on-and-practice-voiceover-iph3e2e415f/ios).
1. Open the block inserter.
1. Perform a [two-finger scrub](https://support.apple.com/guide/iphone/use-voiceover-gestures-iph3e2e2281/ios#:~:text=Two%2Dfinger%20scrub%20(move%20two%20fingers%20back%20and%20forth%20three%20times%20quickly%2C%20making%20a%20“z”)).
1. Verify the dialog is dismissed.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Listed in testing instructions.

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes.
