### PR TITLE
feat: Sync featured images to host app

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -46,6 +46,7 @@ class GutenbergView : WebView {
     private var onFileChooserRequested: ((Intent, Int) -> Unit)? = null
     private var contentChangeListener: ContentChangeListener? = null
     private var historyChangeListener: HistoryChangeListener? = null
+    private var featuredImageChangeListener: FeaturedImageChangeListener? = null
     private var openMediaLibraryListener: OpenMediaLibraryListener? = null
     private var editorDidBecomeAvailableListener: EditorAvailableListener? = null
     private var logJsExceptionListener: LogJsExceptionListener? = null
@@ -65,6 +66,10 @@ class GutenbergView : WebView {
 
     fun setHistoryChangeListener(listener: HistoryChangeListener) {
         historyChangeListener = listener
+    }
+
+    fun setFeaturedImageChangeListener(listener: FeaturedImageChangeListener) {
+        featuredImageChangeListener = listener
     }
 
     fun setOpenMediaLibraryListener(listener: OpenMediaLibraryListener) {
@@ -333,6 +338,10 @@ class GutenbergView : WebView {
         fun onHistoryChanged(hasUndo: Boolean, hasRedo: Boolean)
     }
 
+    interface FeaturedImageChangeListener {
+        fun onFeaturedImageChanged(mediaID: Long)
+    }
+
     sealed class Value {
         data class Single(val value: Int): Value()
         data class Multiple(val values: IntArray): Value() {
@@ -432,6 +441,11 @@ class GutenbergView : WebView {
     }
 
     @JavascriptInterface
+    fun onEditorFeaturedImageChanged(mediaID: Long) {
+        featuredImageChangeListener?.onFeaturedImageChanged(mediaID)
+    }
+
+    @JavascriptInterface
     fun onBlocksChanged(isEmpty: Boolean) {
         if(isEmpty) {
             Log.i("GutenbergView", "BlocksChanged (empty)")
@@ -509,6 +523,7 @@ class GutenbergView : WebView {
         this.stopLoading()
         contentChangeListener = null
         historyChangeListener = null
+        featuredImageChangeListener = null
         editorDidBecomeAvailable = null
         filePathCallback = null
         onFileChooserRequested = null

--- a/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
@@ -29,6 +29,8 @@ struct EditorJSMessage {
         case onEditorContentChanged
         /// The editor history (undo, redo) changed.
         case onEditorHistoryChanged
+        /// The editor featured image changed.
+        case onEditorFeaturedImageChanged
         /// The editor logged an exception.
         case onEditorExceptionLogged
         /// The user tapped the inserter button.
@@ -44,5 +46,9 @@ struct EditorJSMessage {
     struct DidUpdateEditorHistoryBody: Decodable {
         let hasUndo: Bool
         let hasRedo: Bool
+    }
+
+    struct DidUpdateFeaturedImageBody: Decodable {
+        let mediaID: Int
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -304,6 +304,9 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
                 self.state.hasUndo = body.hasUndo
                 self.state.hasRedo = body.hasRedo
                 delegate?.editor(self, didUpdateHistoryState: state)
+            case .onEditorFeaturedImageChanged:
+                let body = try message.decode(EditorJSMessage.DidUpdateFeaturedImageBody.self)
+                delegate?.editor(self, didUpdateFeaturedImage: body.mediaID)
             case .onEditorExceptionLogged:
                 guard let exception = message.body as? [String: Any],
                   let editorException = GutenbergJSException(from: exception) else {

--- a/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
@@ -27,6 +27,9 @@ public protocol EditorViewControllerDelegate: AnyObject {
     /// Notifies the client about new history state.
     func editor(_ viewController: EditorViewController, didUpdateHistoryState state: EditorState)
 
+    /// Notifies the client about a new featured image.
+    func editor(_ viewController: EditorViewController, didUpdateFeaturedImage mediaID: Int)
+
     /// Notifies the client about an exception that occurred during the editor
     func editor(_ viewController: EditorViewController, didLogException error: GutenbergJSException)
 

--- a/src/components/editor/index.jsx
+++ b/src/components/editor/index.jsx
@@ -17,6 +17,7 @@ import { useHostExceptionLogging } from './use-host-exception-logging';
 import { useEditorSetup } from './use-editor-setup';
 import { useMediaUpload } from './use-media-upload';
 import TextEditor from '../text-editor';
+import { useSyncFeaturedImage } from './use-sync-featured-image';
 
 /**
  * @typedef {import('../utils/bridge').Post} Post
@@ -35,6 +36,7 @@ import TextEditor from '../text-editor';
 export default function Editor( { post, children, hideTitle } ) {
 	const editorRef = useRef( null );
 	useHostBridge( post, editorRef );
+	useSyncFeaturedImage();
 	useSyncHistoryControls();
 	useHostExceptionLogging();
 	useEditorSetup( post );

--- a/src/components/editor/use-sync-featured-image.js
+++ b/src/components/editor/use-sync-featured-image.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { onEditorFeaturedImageChanged } from '../../utils/bridge';
+
+/**
+ * Unidirectionally synchronizes the featured image with the host.
+ */
+export function useSyncFeaturedImage() {
+	const { featuredImageId } = useSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( editorStore );
+		return {
+			featuredImageId: getEditedPostAttribute( 'featured_media' ),
+		};
+	}, [] );
+
+	useEffect( () => {
+		if ( ! featuredImageId ) {
+			return;
+		}
+
+		onEditorFeaturedImageChanged( featuredImageId );
+	}, [ featuredImageId ] );
+}

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -60,6 +60,26 @@ export function onEditorHistoryChanged( hasUndo, hasRedo ) {
 }
 
 /**
+ * Notifies the native host that the featured image has changed.
+ *
+ * @param {number} [mediaID] The featured image ID.
+ *
+ * @return {void}
+ */
+export function onEditorFeaturedImageChanged( mediaID ) {
+	if ( window.editorDelegate ) {
+		window.editorDelegate.onEditorFeaturedImageChanged( mediaID );
+	}
+
+	if ( window.webkit ) {
+		window.webkit.messageHandlers.editorDelegate.postMessage( {
+			message: 'onEditorFeaturedImageChanged',
+			body: { mediaID },
+		} );
+	}
+}
+
+/**
  * Notifies the native host that blocks have changed.
  *
  * @param {boolean} [isEmpty=false] Whether the editor is empty.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Unidirectionally synchronize featured images to the host app.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close CMM-383. Enable host apps to persist and display the latest featured image for a post.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a new Hook that dispatches a new bridge event whenever the editor store
updates with a new featured image.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a post.
1. Add a couple of image blocks with attachments.
1. On one of the images, toggle the more menu at the end of the block toolbar
    (three-vertical dots).
1. Tap _Set as featured image_.
1. Open the more menu in the editor header navigation.
1. Tap _Post Settings_.
1. Verify the featured image is correct.
1. Repeat steps 3-7 with a different image in the post.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes.
