### PR TITLE
fix: Localize remote editor

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -23,32 +23,33 @@ import './index.scss';
 import EditorLoadError from './components/editor-load-error';
 import { error } from './utils/logger';
 
-try {
-	await awaitGBKitGlobal();
-	initializeApiFetch();
-	await configureLocale();
+// Rely upon promises rather than async/await to avoid timeouts caused by
+// circular dependencies. Addressing the circular dependencies is quite
+// challenging due to Vite's preload helpers and bugs in `manualChunks`
+// configuration.
+//
+// See:
+// - https://github.com/vitejs/vite/issues/18551
+// - https://github.com/vitejs/vite/issues/13952
+// - https://github.com/vitejs/vite/issues/5189#issuecomment-2175410148
+awaitGBKitGlobal()
+	.then( initializeApiAndLocale )
+	.then( importEditor )
+	.then( initializeEditor )
+	.catch( handleError );
 
-	// Ensure the correct translation strings are used by postponing the import
-	// of `@wordpress` packages until after the locale is set.
-	//
-	// @TODO: A circular dependency prevents the use of async/await. Ideally, we
-	// address the circular dependency using Rollup's `manualChunks`. However, a
-	// very specific configuration is necessary to ensure that no circular
-	// dependencies are created--includeing from injected Vite helpers.
-	//
-	// See:
-	// - https://github.com/vitejs/vite/issues/18551
-	// - https://github.com/vitejs/vite/issues/13952
-	// - https://github.com/vitejs/vite/issues/5189#issuecomment-2175410148
-	import( './utils/editor' )
-		.then( ( { initializeEditor } ) => {
-			initializeEditor();
-		} )
-		.catch( ( err ) => {
-			handleError( err );
-		} );
-} catch ( err ) {
-	handleError( err );
+function initializeApiAndLocale() {
+	initializeApiFetch();
+	return configureLocale();
+}
+
+function importEditor() {
+	return import( './utils/editor' );
+}
+
+function initializeEditor( editorModule ) {
+	const { initializeEditor: _initializeEditor } = editorModule;
+	_initializeEditor();
 }
 
 function handleError( err ) {

--- a/src/remote.jsx
+++ b/src/remote.jsx
@@ -27,6 +27,15 @@ window.wp.apiFetch = apiFetch;
 
 const I18N_PACKAGES = [ 'i18n', 'hooks' ];
 
+// Rely upon promises rather than async/await to avoid timeouts caused by
+// circular dependencies. Addressing the circular dependencies is quite
+// challenging due to Vite's preload helpers and bugs in `manualChunks`
+// configuration.
+//
+// See:
+// - https://github.com/vitejs/vite/issues/18551
+// - https://github.com/vitejs/vite/issues/13952
+// - https://github.com/vitejs/vite/issues/5189#issuecomment-2175410148
 awaitGBKitGlobal()
 	.then( initializeApiAndLoadI18n )
 	.then( importLocalization )

--- a/src/remote.jsx
+++ b/src/remote.jsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { setLocaleData } from '@wordpress/i18n';
 // Default styles that are needed for the editor.
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
@@ -27,27 +28,36 @@ window.wp.apiFetch = apiFetch;
 
 const I18N_PACKAGES = [ 'i18n', 'hooks' ];
 
-try {
-	await awaitGBKitGlobal();
-	initializeApiFetch();
+awaitGBKitGlobal()
+	.then( () => {
+		initializeApiFetch();
 
-	// Ensure the i18n packages are loaded, then set the locale before importing
-	// the rest of the packages.
-	await loadEditorAssets( { allowedPackages: I18N_PACKAGES } );
-	const { configureLocale } = await import( './utils/localization' );
-	await configureLocale();
-
-	// Ensure the correct translation strings are used by postponing the import
-	// of the remaining `@wordpress` packages until after the locale is set.
-	const { allowedBlockTypes } = await loadEditorAssets( {
-		disallowedPackages: I18N_PACKAGES,
+		// Ensure the i18n packages are loaded, then set the locale before importing
+		// the rest of the packages.
+		return loadEditorAssets( { allowedPackages: I18N_PACKAGES } );
+	} )
+	.then( () => {
+		return import( './utils/localization' );
+	} )
+	.then( ( { configureLocale } ) => {
+		return configureLocale( setLocaleData );
+	} )
+	.then( () => {
+		// Ensure the correct translation strings are used by postponing the import
+		// of the remaining `@wordpress` packages until after the locale is set.
+		return loadEditorAssets( {
+			disallowedPackages: I18N_PACKAGES,
+		} );
+	} )
+	.then( ( { allowedBlockTypes } ) => {
+		return import( './utils/editor' ).then( ( { initializeEditor } ) => {
+			initializeEditor( { allowedBlockTypes } );
+		} );
+	} )
+	.catch( ( err ) => {
+		error( 'Error initializing editor', err );
+		// Fallback to the local editor and display a notice. Because the remote
+		// editor loading failed, it is more practical to rely upon the local
+		// editor's scripts and styles for displaying the notice.
+		window.location.href = 'index.html?error=gbkit_global_unavailable';
 	} );
-	const { initializeEditor } = await import( './utils/editor' );
-	initializeEditor( { allowedBlockTypes } );
-} catch ( err ) {
-	error( 'Error initializing editor', err );
-	// Fallback to the local editor and display a notice. Because the remote
-	// editor loading failed, it is more practical to rely upon the local
-	// editor's scripts and styles for displaying the notice.
-	window.location.href = 'index.html?error=gbkit_global_unavailable';
-}

--- a/src/remote.jsx
+++ b/src/remote.jsx
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { setLocaleData } from '@wordpress/i18n';
 // Default styles that are needed for the editor.
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
@@ -50,7 +49,7 @@ function importLocalization() {
 
 function configureLocalization( localizationModule ) {
 	const { configureLocale } = localizationModule;
-	return configureLocale( setLocaleData );
+	return configureLocale();
 }
 
 function loadRemainingAssets() {

--- a/src/remote.jsx
+++ b/src/remote.jsx
@@ -29,35 +29,49 @@ window.wp.apiFetch = apiFetch;
 const I18N_PACKAGES = [ 'i18n', 'hooks' ];
 
 awaitGBKitGlobal()
-	.then( () => {
-		initializeApiFetch();
+	.then( initializeApiAndLoadI18n )
+	.then( importLocalization )
+	.then( configureLocalization )
+	.then( loadRemainingAssets )
+	.then( initializeEditorWithBlocks )
+	.catch( handleInitializationError );
 
-		// Ensure the i18n packages are loaded, then set the locale before importing
-		// the rest of the packages.
-		return loadEditorAssets( { allowedPackages: I18N_PACKAGES } );
-	} )
-	.then( () => {
-		return import( './utils/localization' );
-	} )
-	.then( ( { configureLocale } ) => {
-		return configureLocale( setLocaleData );
-	} )
-	.then( () => {
-		// Ensure the correct translation strings are used by postponing the import
-		// of the remaining `@wordpress` packages until after the locale is set.
-		return loadEditorAssets( {
-			disallowedPackages: I18N_PACKAGES,
-		} );
-	} )
-	.then( ( { allowedBlockTypes } ) => {
-		return import( './utils/editor' ).then( ( { initializeEditor } ) => {
-			initializeEditor( { allowedBlockTypes } );
-		} );
-	} )
-	.catch( ( err ) => {
-		error( 'Error initializing editor', err );
-		// Fallback to the local editor and display a notice. Because the remote
-		// editor loading failed, it is more practical to rely upon the local
-		// editor's scripts and styles for displaying the notice.
-		window.location.href = 'index.html?error=gbkit_global_unavailable';
+function initializeApiAndLoadI18n() {
+	initializeApiFetch();
+
+	// Ensure the i18n packages are loaded, then set the locale before importing
+	// the rest of the packages.
+	return loadEditorAssets( { allowedPackages: I18N_PACKAGES } );
+}
+
+function importLocalization() {
+	return import( './utils/localization' );
+}
+
+function configureLocalization( localizationModule ) {
+	const { configureLocale } = localizationModule;
+	return configureLocale( setLocaleData );
+}
+
+function loadRemainingAssets() {
+	// Ensure the correct translation strings are used by postponing the import
+	// of the remaining `@wordpress` packages until after the locale is set.
+	return loadEditorAssets( {
+		disallowedPackages: I18N_PACKAGES,
 	} );
+}
+
+function initializeEditorWithBlocks( assetsResult ) {
+	const { allowedBlockTypes } = assetsResult;
+	return import( './utils/editor' ).then( ( { initializeEditor } ) => {
+		initializeEditor( { allowedBlockTypes } );
+	} );
+}
+
+function handleInitializationError( err ) {
+	error( 'Error initializing editor', err );
+	// Fallback to the local editor and display a notice. Because the remote
+	// editor loading failed, it is more practical to rely upon the local
+	// editor's scripts and styles for displaying the notice.
+	window.location.href = 'index.html?error=gbkit_global_unavailable';
+}

--- a/src/remote.jsx
+++ b/src/remote.jsx
@@ -38,11 +38,11 @@ const I18N_PACKAGES = [ 'i18n', 'hooks' ];
 // - https://github.com/vitejs/vite/issues/5189#issuecomment-2175410148
 awaitGBKitGlobal()
 	.then( initializeApiAndLoadI18n )
-	.then( importLocalization )
-	.then( configureLocalization )
+	.then( importL10n )
+	.then( configureLocale )
 	.then( loadRemainingAssets )
-	.then( initializeEditorWithBlocks )
-	.catch( handleInitializationError );
+	.then( initializeEditor )
+	.catch( handleError );
 
 function initializeApiAndLoadI18n() {
 	initializeApiFetch();
@@ -52,13 +52,13 @@ function initializeApiAndLoadI18n() {
 	return loadEditorAssets( { allowedPackages: I18N_PACKAGES } );
 }
 
-function importLocalization() {
+function importL10n() {
 	return import( './utils/localization' );
 }
 
-function configureLocalization( localizationModule ) {
-	const { configureLocale } = localizationModule;
-	return configureLocale();
+function configureLocale( localeModule ) {
+	const { configureLocale: _configureLocale } = localeModule;
+	return _configureLocale();
 }
 
 function loadRemainingAssets() {
@@ -69,14 +69,16 @@ function loadRemainingAssets() {
 	} );
 }
 
-function initializeEditorWithBlocks( assetsResult ) {
+function initializeEditor( assetsResult ) {
 	const { allowedBlockTypes } = assetsResult;
-	return import( './utils/editor' ).then( ( { initializeEditor } ) => {
-		initializeEditor( { allowedBlockTypes } );
-	} );
+	return import( './utils/editor' ).then(
+		( { initializeEditor: _initializeEditor } ) => {
+			_initializeEditor( { allowedBlockTypes } );
+		}
+	);
 }
 
-function handleInitializationError( err ) {
+function handleError( err ) {
 	error( 'Error initializing editor', err );
 	// Fallback to the local editor and display a notice. Because the remote
 	// editor loading failed, it is more practical to rely upon the local

--- a/src/utils/localization.js
+++ b/src/utils/localization.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { setLocaleData } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { getGBKit } from './bridge';
@@ -12,20 +7,24 @@ import { error, debug } from './logger';
 /**
  * Initializes i18n support for the editor.
  *
+ * @param {Function} setLocaleData The function to set the locale data.
+ *
  * @return {Promise<void>} A promise that resolves when i18n is initialized.
  */
-export async function configureLocale() {
+export async function configureLocale( setLocaleData ) {
 	const { locale = 'en' } = getGBKit();
-	await loadTranslations( locale );
+	await loadTranslations( locale, setLocaleData );
 }
 
 /**
  * Loads translations for the specified locale from the downloaded files.
  *
- * @param {string} locale The locale to load translations for.
+ * @param {string}   locale        The locale to load translations for.
+ * @param {Function} setLocaleData The function to set the locale data.
+ *
  * @return {Promise<void>} A promise that resolves when translations are loaded.
  */
-async function loadTranslations( locale ) {
+async function loadTranslations( locale, setLocaleData ) {
 	if ( locale === DEFAULT_LOCALE ) {
 		return;
 	}
@@ -35,7 +34,7 @@ async function loadTranslations( locale ) {
 		const { default: translations } = await import(
 			`../translations/${ locale }.json`
 		);
-		setLocaleDataCompat( translations );
+		setLocaleDataCompat( translations, setLocaleData );
 	} catch ( err ) {
 		// Continue with default locale
 		error( 'Error loading translations', err );
@@ -49,9 +48,10 @@ async function loadTranslations( locale ) {
  * @todo Align the architecture of the two editors so that the setLocaleData
  * function is the same in both and remove this function.
  *
- * @param {Object} translations The translations to set.
+ * @param {Object}   translations  The translations to set.
+ * @param {Function} setLocaleData The function to set the locale data.
  */
-function setLocaleDataCompat( translations ) {
+function setLocaleDataCompat( translations, setLocaleData ) {
 	if ( window.wp?.i18n?.setLocaleData ) {
 		window.wp.i18n.setLocaleData( translations );
 	} else {

--- a/src/utils/localization.js
+++ b/src/utils/localization.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { setLocaleData } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { getGBKit } from './bridge';
@@ -7,24 +12,21 @@ import { error, debug } from './logger';
 /**
  * Initializes i18n support for the editor.
  *
- * @param {Function} setLocaleData The function to set the locale data.
- *
  * @return {Promise<void>} A promise that resolves when i18n is initialized.
  */
-export async function configureLocale( setLocaleData ) {
+export async function configureLocale() {
 	const { locale = 'en' } = getGBKit();
-	await loadTranslations( locale, setLocaleData );
+	await loadTranslations( locale );
 }
 
 /**
  * Loads translations for the specified locale from the downloaded files.
  *
- * @param {string}   locale        The locale to load translations for.
- * @param {Function} setLocaleData The function to set the locale data.
+ * @param {string} locale The locale to load translations for.
  *
  * @return {Promise<void>} A promise that resolves when translations are loaded.
  */
-async function loadTranslations( locale, setLocaleData ) {
+async function loadTranslations( locale ) {
 	if ( locale === DEFAULT_LOCALE ) {
 		return;
 	}
@@ -34,28 +36,10 @@ async function loadTranslations( locale, setLocaleData ) {
 		const { default: translations } = await import(
 			`../translations/${ locale }.json`
 		);
-		setLocaleDataCompat( translations, setLocaleData );
+		setLocaleData( translations );
 	} catch ( err ) {
 		// Continue with default locale
 		error( 'Error loading translations', err );
-	}
-}
-
-/**
- * Rudimentary utility bridging the setLocaleData function location between the
- * local and remote editors.
- *
- * @todo Align the architecture of the two editors so that the setLocaleData
- * function is the same in both and remove this function.
- *
- * @param {Object}   translations  The translations to set.
- * @param {Function} setLocaleData The function to set the locale data.
- */
-function setLocaleDataCompat( translations, setLocaleData ) {
-	if ( window.wp?.i18n?.setLocaleData ) {
-		window.wp.i18n.setLocaleData( translations );
-	} else {
-		setLocaleData( translations );
 	}
 }
 

--- a/src/utils/localization.js
+++ b/src/utils/localization.js
@@ -8,6 +8,7 @@ import { setLocaleData } from '@wordpress/i18n';
  */
 import { getGBKit } from './bridge';
 import { error, debug } from './logger';
+
 /**
  * Initializes i18n support for the editor.
  *
@@ -34,10 +35,27 @@ async function loadTranslations( locale ) {
 		const { default: translations } = await import(
 			`../translations/${ locale }.json`
 		);
-		setLocaleData( translations );
+		setLocaleDataCompat( translations );
 	} catch ( err ) {
 		// Continue with default locale
 		error( 'Error loading translations', err );
+	}
+}
+
+/**
+ * Rudimentary utility bridging the setLocaleData function location between the
+ * local and remote editors.
+ *
+ * @todo Align the architecture of the two editors so that the setLocaleData
+ * function is the same in both and remove this function.
+ *
+ * @param {Object} translations The translations to set.
+ */
+function setLocaleDataCompat( translations ) {
+	if ( window.wp?.i18n?.setLocaleData ) {
+		window.wp.i18n.setLocaleData( translations );
+	} else {
+		setLocaleData( translations );
 	}
 }
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -7,7 +7,11 @@ const LOG_LEVELS = {
 };
 
 // Default log level
-let currentLogLevel = process.env.LOG_LEVEL || LOG_LEVELS.INFO;
+let currentLogLevel = LOG_LEVELS.INFO;
+
+if ( typeof process !== 'undefined' && process?.env?.LOG_LEVEL ) {
+	currentLogLevel = process.env.LOG_LEVEL;
+}
 
 /**
  * Set the current log level

--- a/vite.config.remote.js
+++ b/vite.config.remote.js
@@ -19,38 +19,6 @@ export default defineConfig( {
 		rollupOptions: {
 			input: resolve( __dirname, 'src/remote.html' ),
 			external: externalize,
-			output: {
-				// Manual chunks are necessary to prevent circular dependencies, some of
-				// which originate from Vite's injected helpers.
-				//
-				// See:
-				// - https://github.com/vitejs/vite/issues/18551
-				// - https://github.com/vitejs/vite/issues/13952
-				// - https://github.com/vitejs/vite/issues/5189#issuecomment-2175410148
-				manualChunks( id ) {
-					const VITE_COMMON_MODULES = [
-						'vite/preload-helper',
-						'vite/modulepreload-polyfill',
-						'vite/dynamic-import-helper',
-						'commonjsHelpers',
-						'commonjs-dynamic-modules',
-						'__vite-browser-external',
-					];
-					if (
-						VITE_COMMON_MODULES.some( ( m ) => id.includes( m ) )
-					) {
-						return 'vite-helpers';
-					}
-
-					if ( id.includes( 'src/utils/bridge.js' ) ) {
-						return 'bridge';
-					}
-
-					if ( id.includes( 'src/utils/logger.js' ) ) {
-						return 'logger';
-					}
-				},
-			},
 		},
 		target: 'esnext',
 	},

--- a/vite.config.remote.js
+++ b/vite.config.remote.js
@@ -67,8 +67,8 @@ function wordPressExternals() {
 
 				if (
 					! externalDefinition ||
-					/@wordpress\/(api-fetch|i18n|url)/.test( id ) ||
-					/@wordpress\/(api-fetch|i18n|url)/.test( module )
+					/@wordpress\/(api-fetch|url|hooks)/.test( id ) ||
+					/@wordpress\/(api-fetch|url|hooks)/.test( module )
 				) {
 					continue; // Exclude the module from externalization
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix localization of strings within the remote editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close CMM-504. Close CMM-547. Localization worked in the local editor, but not in the remote editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The remote editor relies upon accessing `@wordpress` modules via the
`window.wp` global. Most of these references are handled by
externalization performed by Vite. However, the `@wordpress/i18n` module
is a dependency of `@wordpress/api-fetch`, which we do not want to
externalize. So, the `import` of `@wordpress/i18n` is not correctly
externalized for the remote editor.

As a workaround, we check for and utilize the global if it is available.
Long term, we should align the local and remote editor architecture so
that they load in the same manner. At which point, we could remove the
conditional and always reference the global.

Additionally, I added a guard to referencing the Node.js `process` to avoid
intermittent server errors.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Start the `make dev-server-remote` command.
2. Open the iOS demo app and set the `GUTENBERG_EDITOR_REMOTE_URL` environment
   variable to `http://localhost:5174/remote.html`.
3. Apply the below example diff to the iOS demo app, replacing the `<YOUR-SIMPLE-SITE-NAME>`
   and `<REDACTED>` placeholders with the actual site name and auth header.
4. Run the app.
5. Open the editor and verify that the UI strings are in Spanish.

<details><summary>Example Diff</summary>

```diff
diff --git a/ios/Demo-iOS/Gutenberg.xcodeproj/xcshareddata/xcschemes/Gutenberg.xcscheme b/ios/Demo-iOS/Gutenberg.xcodeproj/xcshareddata/xcschemes/Gutenberg.xcscheme
index 1a352df..b6fd3e5 100644
--- a/ios/Demo-iOS/Gutenberg.xcodeproj/xcshareddata/xcschemes/Gutenberg.xcscheme
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/xcshareddata/xcschemes/Gutenberg.xcscheme
@@ -54,12 +54,12 @@
          <EnvironmentVariable
             key = "GUTENBERG_EDITOR_URL"
             value = "http://localhost:5173/"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "GUTENBERG_EDITOR_REMOTE_URL"
             value = "http://localhost:5174/remote.html"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
diff --git a/ios/Demo-iOS/Sources/EditorView.swift b/ios/Demo-iOS/Sources/EditorView.swift
index f1f3394..b71ce84 100644
--- a/ios/Demo-iOS/Sources/EditorView.swift
+++ b/ios/Demo-iOS/Sources/EditorView.swift
@@ -72,7 +72,13 @@ private struct _EditorView: UIViewControllerRepresentable {
     var editorURL: URL?
 
     func makeUIViewController(context: Context) -> EditorViewController {
-        let viewController = EditorViewController()
+        var config = EditorConfiguration()
+        config.locale = "es"
+        config.plugins = true
+        config.siteApiNamespace = ["sites/<YOUR-SIMPLE-SITE-NAME>.wordpress.com"]
+        config.siteApiRoot = "https://public-api.wordpress.com/"
+        config.authHeader = "Bearer <YOUR-AUTH-TOKEN>"
+        let viewController = EditorViewController(configuration: config)
         viewController.editorURL = editorURL
         if #available(iOS 16.4, *) {
             viewController.webView.isInspectable = true

```

</details>

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no visual changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes. 
