### PR TITLE
Fix `WebView` Memory Leak in `GutenbergView`

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -545,6 +545,7 @@ class GutenbergView : WebView {
         filePathCallback = null
         onFileChooserRequested = null
         handler.removeCallbacksAndMessages(null)
+        this.destroy()
     }
 }
 

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -83,7 +83,6 @@ class MainActivity : AppCompatActivity(), AuthenticationManager.AuthenticationCa
             .setPlugins(true) // Enable plugins for remote editor
             .setSiteURL(config.siteUrl)
             .setSiteApiRoot(config.siteApiRoot)
-            .setSiteApiNamespace(arrayOf("wp/v2"))
             .setNamespaceExcludedPaths(arrayOf())
             .setAuthHeader(config.authHeader)
             .build()


### PR DESCRIPTION
Follow-up to #155 that addresses `WebView` memory leaks in `GutenbergView`.

## Changes

- **Fix WebView cleanup**: Added `this.destroy()` call to `GutenbergView.onDetachedFromWindow()` to properly dispose of `WebView`s when detached from window hierarchy.
- **Remove unnecessary namespace**: Removed `setSiteApiNamespace(arrayOf("wp/v2"))` call as it's only needed for WPCOM sites using the WPCOM API

## Testing

1. Open Android demo app
2. Tap "Bundled Editor" to open the editor
3. Open Chrome DevTools and navigate to `chrome://inspect`
4. Verify `WebView` appears in inspector while editor is open
5. Close editor to return to site picker
6. **Verify `WebView` disappears from Chrome inspector**
7. Open editor again
8. **Verify new `WebView` appears in inspector**

Before this fix, `WebView`s would accumulate in the inspector after closing the editor.
