### PR TITLE
feat: Remove iOS cookie configuration

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorConfiguration.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorConfiguration.swift
@@ -22,7 +22,6 @@ public struct EditorConfiguration {
     /// The locale to use for translations
     public var locale = "en"
     public var editorAssetsEndpoint: URL?
-    public var cookies: [HTTPCookie] = []
 
     public init(title: String = "", content: String = "") {
         self.title = title

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -37,12 +37,6 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         config.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
         config.setValue(true, forKey: "allowUniversalAccessFromFileURLs")
 
-        // The editor shouldn't try to persist cookies – we want complete control over how they're handled
-        config.websiteDataStore = WKWebsiteDataStore.nonPersistent()
-        for cookie in configuration.cookies {
-            config.websiteDataStore.httpCookieStore.setCookie(cookie)
-        }
-
         // Set-up communications with the editor.
         config.userContentController.add(controller, name: "editorDelegate")
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Remove iOS cookie configuration added in https://github.com/wordpress-mobile/GutenbergKit/pull/144. The removal is done in service of https://github.com/wordpress-mobile/WordPress-iOS/pull/24680. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The ability to configure WKWebView cookies in this manner became unnecessary, as we utilize a different, established approach within the WP-iOS app.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Revert the iOS changes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See https://github.com/wordpress-mobile/WordPress-iOS/pull/24680.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
