### PR TITLE
fix: Remove redundant trailing slash from API namespace configuration

### DIFF
--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -68,7 +68,7 @@ function apiPathModifierMiddleware( options, next ) {
 		// Insert the API namespace after the first two path segments.
 		options.path = options.path.replace(
 			/^(?<apiPath>\/?(?:[\w.-]+\/){2})/,
-			`$<apiPath>${ siteApiNamespace[ 0 ] }/`
+			`$<apiPath>${ siteApiNamespace[ 0 ] }`
 		);
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Avoid redundant trailing slashes in API namespace configuration. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-623.

Trailing slashes are now expected to be providing in the configuration. This expectation was put in place to simplify configuration logic here and in host apps.

This change prevents double trailing slashes, which began occurring in WP-Android in the following. This resulted in failed API requests, like image uploads.

https://github.com/wordpress-mobile/WordPress-Android/pull/22035

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove appended trailing slash. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
> [!tip]
> Testing via the prototype builds is likely easiest:
> - https://github.com/wordpress-mobile/WordPress-iOS/pull/24691
> - https://github.com/wordpress-mobile/WordPress-Android/pull/22065

<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a new post. 
2. Insert an image block. 
3. Choose an image to upload. 
4. Verify the upload succeeds. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, navigation changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes. 