### PR TITLE
fix: Prevent iOS crash in WebView navigations

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -402,6 +402,7 @@ private final class GutenbergEditorController: NSObject, WKNavigationDelegate, W
             // Open the request in OS browser
             UIApplication.shared.open(url)
             decisionHandler(.cancel)
+            return
         }
 
         decisionHandler(.allow)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Prevent a crash occurring when navigating to a URL in the editor WebView. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-589. The crash is disruptive. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add an overlooked return statement t avoid erroneously calling `decisionHandler` multiple times, which leads to a crash.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add a link to a text block. 
2. Drag the cursor onto the link. 
3. Tap the link button in the toolbar. 
4. Tap the link preview in the pop over. 
5. Verify the editor/app does not crash. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes. 

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/2532800e-fa38-4201-80ef-cce77fe5b45e

