### PR TITLE
feat: Bridge AJAX request to the REST API

### DIFF
--- a/src/remote.jsx
+++ b/src/remote.jsx
@@ -19,6 +19,7 @@ import '@wordpress/editor/build-style/style.css';
 import { awaitGBKitGlobal } from './utils/bridge';
 import { initializeApiFetch } from './utils/api-fetch';
 import { loadEditorAssets } from './utils/remote-editor';
+import { initializeVideoPressAjaxBridge } from './utils/videopress-bridge';
 import { error } from './utils/logger';
 import './index.scss';
 
@@ -70,6 +71,8 @@ function loadRemainingAssets() {
 }
 
 function initializeEditor( assetsResult ) {
+	initializeVideoPressAjaxBridge();
+
 	const { allowedBlockTypes } = assetsResult;
 	return import( './utils/editor' ).then(
 		( { initializeEditor: _initializeEditor } ) => {

--- a/src/utils/videopress-bridge.js
+++ b/src/utils/videopress-bridge.js
@@ -1,0 +1,124 @@
+/**
+ * Internal dependencies
+ */
+import { getGBKit } from './bridge';
+import { warn, info, error } from './logger';
+
+/**
+ * VideoPress AJAX to REST API bridge.
+ *
+ * GutenbergKit lacks authentication cookies required for AJAX requests.
+ * This module overrides wp.media.ajax to bridge specific VideoPress AJAX
+ * requests to their corresponding REST API endpoints.
+ */
+
+/**
+ * Initializes the VideoPress AJAX bridge.
+ *
+ * This function overrides wp.media.ajax to intercept VideoPress-specific
+ * AJAX requests and redirect them to the appropriate REST API endpoints.
+ *
+ * @return {void}
+ */
+export function initializeVideoPressAjaxBridge() {
+	// Ensure necessary globals are available
+	if ( ! window.wp || ! window.wp.apiFetch ) {
+		warn( 'VideoPress bridge: wp.apiFetch not available' );
+		return;
+	}
+
+	// Initialize wp.ajax if not already present
+	window.wp.ajax = window.wp.ajax || {};
+	window.wp.ajax.settings = window.wp.ajax.settings || {};
+
+	// Set up AJAX settings with site URL
+	const { siteURL } = getGBKit();
+	if ( siteURL ) {
+		window.wp.ajax.settings.url = `${ siteURL }/wp-admin/admin-ajax.php`;
+	}
+
+	// Store original wp.media.ajax function if it exists
+	const originalMediaAjax = window.wp.media?.ajax;
+
+	// Override wp.media.ajax
+	window.wp.media = window.wp.media || {};
+	window.wp.media.ajax = ( ...args ) => {
+		const [ action ] = args;
+
+		// Handle VideoPress upload JWT request
+		if ( action === 'videopress-get-upload-jwt' ) {
+			return handleVideoPressUploadJWT();
+		}
+
+		// Fall back to original function or default behavior
+		if ( originalMediaAjax ) {
+			return originalMediaAjax( ...args );
+		}
+
+		// If no original function exists, return a rejected promise
+		const deferred =
+			window.jQuery?.Deferred?.() || createFallbackDeferred();
+		deferred.reject( new Error( `Unhandled AJAX action: ${ action }` ) );
+		return deferred.promise();
+	};
+
+	info( 'VideoPress AJAX bridge initialized' );
+}
+
+/**
+ * Handles the VideoPress upload JWT request by calling the REST API.
+ *
+ * @return {Promise} jQuery Deferred promise that resolves with the JWT response.
+ */
+function handleVideoPressUploadJWT() {
+	const deferred = window.jQuery?.Deferred?.() || createFallbackDeferred();
+
+	window.wp
+		.apiFetch( {
+			path: '/wpcom/v2/videopress/upload-jwt',
+			method: 'POST',
+		} )
+		.then( ( response ) => {
+			if ( response.error ) {
+				deferred.reject( response.error );
+			} else {
+				// Transform the response to match expected AJAX format
+				const processedResponse = {
+					...response,
+					upload_action_url: response.upload_url,
+				};
+				delete processedResponse.upload_url;
+
+				info(
+					'VideoPress JWT obtained successfully',
+					processedResponse
+				);
+				deferred.resolve( processedResponse );
+			}
+		} )
+		.catch( ( err ) => {
+			error( 'VideoPress JWT request failed', err );
+			deferred.reject( err );
+		} );
+
+	return deferred.promise();
+}
+
+/**
+ * Creates a fallback deferred object if jQuery is not available.
+ *
+ * @return {Object} Deferred-like object with resolve, reject, and promise methods.
+ */
+function createFallbackDeferred() {
+	let resolveCallback, rejectCallback;
+	const promise = new Promise( ( resolve, reject ) => {
+		resolveCallback = resolve;
+		rejectCallback = reject;
+	} );
+
+	return {
+		resolve: resolveCallback,
+		reject: rejectCallback,
+		promise: () => promise,
+	};
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Bridge a VideoPress AJAX request to the matching REST API endpoint. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
GutenbergKit lacks authentication cookies required for AJAX requests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Fix CMM-594. Override the `window.wp.media.ajax` global with conditional logic managing a request necessary for video uploads. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See relevant sibling PRs:
- https://github.com/wordpress-mobile/WordPress-Android/pull/22080
- https://github.com/wordpress-mobile/WordPress-iOS/pull/24706

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes. 

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5b96de96-bb87-4033-8990-310a10578da2

