### PR TITLE
ci: Improve release script

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -105,6 +105,33 @@ get_current_version() {
     node -p "require('./package.json').version"
 }
 
+# Function to calculate new version without actually incrementing
+calculate_new_version() {
+    local current_version=$1
+    local version_type=$2
+
+    # Handle custom version numbers
+    case $version_type in
+        major|minor|patch|premajor|preminor|prepatch|prerelease)
+            # For prerelease types, use 'alpha' as the preid
+            if [[ "$version_type" =~ ^pre ]]; then
+                node -p "require('semver').inc('$current_version', '$version_type', 'alpha')"
+            else
+                node -p "require('semver').inc('$current_version', '$version_type')"
+            fi
+            ;;
+        from-git)
+            # For from-git, we would use the git tag version
+            # This is a placeholder - actual implementation would need to fetch from git
+            echo "$current_version"
+            ;;
+        *)
+            # Custom version number
+            echo "$version_type"
+            ;;
+    esac
+}
+
 # Function to validate version type
 validate_version_type() {
     local version_type=$1
@@ -166,11 +193,17 @@ increment_version() {
     local version_type=$1
     local current_version=$(get_current_version)
     local version_description=$(get_version_description "$version_type")
+    local new_version
 
     print_status "Current version: $current_version"
     print_status "Incrementing version ($version_description)..."
 
     if [ "$DRY_RUN" = "true" ]; then
+        # Calculate what the new version would be
+        new_version=$(calculate_new_version "$current_version" "$version_type")
+        print_success "Version would be incremented to: $new_version"
+        # Store in global variable for dry run
+        DRY_RUN_VERSION="$new_version"
         return
     fi
 
@@ -184,7 +217,7 @@ increment_version() {
             ;;
     esac
 
-    local new_version=$(get_current_version)
+    new_version=$(get_current_version)
     print_success "Version incremented to: $new_version"
 }
 
@@ -315,16 +348,21 @@ main() {
 
     # Get current version before incrementing
     local current_version=$(get_current_version)
+    local new_version
 
     # Execute release steps
     increment_version "$version_type"
     echo
 
+    # Get the new version
+    if [ "$DRY_RUN" = "true" ]; then
+        new_version="$DRY_RUN_VERSION"
+    else
+        new_version=$(get_current_version)
+    fi
+
     build_project
     echo
-
-    # Get new version after incrementing
-    local new_version=$(get_current_version)
 
     commit_changes "$new_version"
     echo

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -132,6 +132,20 @@ calculate_new_version() {
     esac
 }
 
+# Function to check if a version is a prerelease
+is_prerelease() {
+    local version=$1
+
+    # Use semver to check if the version has prerelease identifiers
+    local result=$(node -p "require('semver').prerelease('$version') !== null")
+
+    if [ "$result" = "true" ]; then
+        return 0  # It is a prerelease
+    else
+        return 1  # It is not a prerelease
+    fi
+}
+
 # Function to validate version type
 validate_version_type() {
     local version_type=$1
@@ -373,7 +387,12 @@ main() {
     push_changes "$new_version"
     echo
 
-    create_github_release "$new_version"
+    # Only create GitHub release for non-prerelease versions
+    if is_prerelease "$new_version"; then
+        print_status "Skipping GitHub release creation for prerelease version"
+    else
+        create_github_release "$new_version"
+    fi
     echo
 
     # Summary
@@ -384,7 +403,12 @@ main() {
         print_warning "This was a dry run. No actual changes were made."
         print_status "To perform the actual release, run: make release VERSION_TYPE=$version_type"
     else
-        print_status "The release is ready for integration into the WordPress app."
+        if is_prerelease "$new_version"; then
+            print_status "Prerelease tag v$new_version has been created and pushed."
+            print_status "No GitHub release was created for this prerelease version."
+        else
+            print_status "The release is ready for integration into the WordPress app."
+        fi
     fi
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Log correct version during dry runs
- Skip publishing GitHub Releases for pre-releases

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Improve the accuracy and usefulness of the dry runs
- Enable creating frequent pre-releases during ongoing development, without
  generating unnecessary noise from published GitHub Releases

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Utilize Node.js `semver` package for calculating target version for dry runs
- Disable GitHub Release publishing for pre-releases

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Temporarily disable branch checks while testing:

<details><summary>Disable checks diff</summary>
<p>

```diff
diff --git a/bin/release.sh b/bin/release.sh
index 4dabb97..9c1c651 100755
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -355,8 +355,8 @@ main() {
     # Pre-flight checks
     print_status "Running pre-flight checks..."
     check_dependencies
-    check_branch
-    check_working_directory
+    # check_branch
+    # check_working_directory
     print_success "Pre-flight checks passed"
     echo
 

```

</p>
</details> 

Perform dry runs with various release types to ensure the logged version is
correct.

```
make release DRY_RUN=true
```

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
