### PR TITLE
feat: Expose autocomplete triggers and text insertion utility

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -58,6 +58,7 @@ class GutenbergView : WebView {
     private var openMediaLibraryListener: OpenMediaLibraryListener? = null
     private var editorDidBecomeAvailableListener: EditorAvailableListener? = null
     private var logJsExceptionListener: LogJsExceptionListener? = null
+    private var autocompleterTriggeredListener: AutocompleterTriggeredListener? = null
 
     var textEditorEnabled: Boolean = false
         set(value) {
@@ -86,6 +87,10 @@ class GutenbergView : WebView {
 
     fun setLogJsExceptionListener(listener: LogJsExceptionListener) {
         logJsExceptionListener = listener
+    }
+
+    fun setAutocompleterTriggeredListener(listener: AutocompleterTriggeredListener) {
+        autocompleterTriggeredListener = listener
     }
 
     fun setOnFileChooserRequestedListener(listener: (Intent, Int) -> Unit) {
@@ -403,6 +408,10 @@ class GutenbergView : WebView {
         fun onLogJsException(exception: GutenbergJsException)
     }
 
+    interface AutocompleterTriggeredListener {
+        fun onAutocompleterTriggered(type: String)
+    }
+
     fun getTitleAndContent(originalContent: CharSequence, callback: TitleAndContentCallback, completeComposition: Boolean = false) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
@@ -442,6 +451,17 @@ class GutenbergView : WebView {
     fun redo() {
         handler.post {
             this.evaluateJavascript("editor.redo();", null)
+        }
+    }
+
+    fun appendTextAtCursor(text: String) {
+        if (!isEditorLoaded) {
+            Log.e("GutenbergView", "You can't append text until the editor has loaded")
+            return
+        }
+        val encodedText = encodeForEditor(text)
+        handler.post {
+            this.evaluateJavascript("editor.appendTextAtCursor(decodeURIComponent('$encodedText'));", null)
         }
     }
 
@@ -547,6 +567,13 @@ class GutenbergView : WebView {
         Log.i("GutenbergView", "BlockPickerShouldShow")
     }
 
+    @JavascriptInterface
+    fun onAutocompleterTriggered(type: String) {
+        handler.post {
+            autocompleterTriggeredListener?.onAutocompleterTriggered(type)
+        }
+    }
+
     fun resetFilePathCallback() {
         filePathCallback = null
     }
@@ -562,6 +589,7 @@ class GutenbergView : WebView {
         editorDidBecomeAvailable = null
         filePathCallback = null
         onFileChooserRequested = null
+        autocompleterTriggeredListener = null
         handler.removeCallbacksAndMessages(null)
         this.destroy()
     }

--- a/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
@@ -37,6 +37,8 @@ struct EditorJSMessage {
         case showBlockPicker
         /// User requested the Media Library.
         case openMediaLibrary
+        /// The user triggered an autocompleter.
+        case onAutocompleterTriggered
     }
 
     struct DidUpdateBlocksBody: Decodable {
@@ -50,5 +52,9 @@ struct EditorJSMessage {
 
     struct DidUpdateFeaturedImageBody: Decodable {
         let mediaID: Int
+    }
+
+    struct AutocompleterTriggeredBody: Decodable {
+        let type: String
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -301,7 +301,7 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     ///
     /// - parameter text: The text to append at the cursor position.
     public func appendTextAtCursor(_ text: String) {
-        let escapedText = text.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? text
+        let escapedText = text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? text
         evaluate("editor.appendTextAtCursor(decodeURIComponent('\(escapedText)'));")
     }
 

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -326,6 +326,9 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
             case .openMediaLibrary:
                 let config = try message.decode(OpenMediaLibraryAction.self)
                 openMediaLibrary(config)
+            case .onAutocompleterTriggered:
+                let body = try message.decode(EditorJSMessage.AutocompleterTriggeredBody.self)
+                delegate?.editor(self, didTriggerAutocompleter: body.type)
             }
         } catch {
             fatalError("failed to decode message: \(error)")

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -297,6 +297,14 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         evaluate("editor.setMediaUploadAttachment(\(media));")
     }
 
+    /// Appends text at the current cursor position in the editor.
+    ///
+    /// - parameter text: The text to append at the cursor position.
+    public func appendTextAtCursor(_ text: String) {
+        let escapedText = text.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? text
+        evaluate("editor.appendTextAtCursor(decodeURIComponent('\(escapedText)'));")
+    }
+
     // MARK: - GutenbergEditorControllerDelegate
 
     fileprivate func controller(_ controller: GutenbergEditorController, didReceiveMessage message: EditorJSMessage) {

--- a/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
@@ -34,6 +34,11 @@ public protocol EditorViewControllerDelegate: AnyObject {
     func editor(_ viewController: EditorViewController, didLogException error: GutenbergJSException)
 
     func editor(_ viewController: EditorViewController, didRequestMediaFromSiteMediaLibrary config: OpenMediaLibraryAction)
+
+    /// Notifies the client that an autocompleter was triggered.
+    ///
+    /// - parameter type: The type of autocompleter that was triggered (e.g., "plus-symbol", "at-mention").
+    func editor(_ viewController: EditorViewController, didTriggerAutocompleter type: String)
 }
 
 public struct EditorState {

--- a/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
@@ -37,7 +37,7 @@ public protocol EditorViewControllerDelegate: AnyObject {
 
     /// Notifies the client that an autocompleter was triggered.
     ///
-    /// - parameter type: The type of autocompleter that was triggered (e.g., "plus-symbol", "at-mention").
+    /// - parameter type: The type of autocompleter that was triggered (e.g., "plus-symbol", "at-symbol").
     func editor(_ viewController: EditorViewController, didTriggerAutocompleter type: String)
 }
 

--- a/src/components/editor/index.jsx
+++ b/src/components/editor/index.jsx
@@ -20,6 +20,7 @@ import TextEditor from '../text-editor';
 import { useSyncFeaturedImage } from './use-sync-featured-image';
 import { useDevModeNotice } from './use-dev-mode-notice';
 import { useAtAutocompleter } from './use-at-autocompleter';
+import { usePlusAutocompleter } from './use-plus-autocompleter';
 
 /**
  * @typedef {import('../utils/bridge').Post} Post
@@ -45,6 +46,7 @@ export default function Editor( { post, children, hideTitle } ) {
 	useMediaUpload();
 	useDevModeNotice();
 	useAtAutocompleter();
+	usePlusAutocompleter();
 
 	const { isReady, mode, isRichEditingEnabled, currentPost } = useSelect(
 		( select ) => {

--- a/src/components/editor/index.jsx
+++ b/src/components/editor/index.jsx
@@ -19,6 +19,7 @@ import { useMediaUpload } from './use-media-upload';
 import TextEditor from '../text-editor';
 import { useSyncFeaturedImage } from './use-sync-featured-image';
 import { useDevModeNotice } from './use-dev-mode-notice';
+import { useAtAutocompleter } from './use-at-autocompleter';
 
 /**
  * @typedef {import('../utils/bridge').Post} Post
@@ -43,6 +44,7 @@ export default function Editor( { post, children, hideTitle } ) {
 	useEditorSetup( post );
 	useMediaUpload();
 	useDevModeNotice();
+	useAtAutocompleter();
 
 	const { isReady, mode, isRichEditingEnabled, currentPost } = useSelect(
 		( select ) => {

--- a/src/components/editor/use-at-autocompleter.js
+++ b/src/components/editor/use-at-autocompleter.js
@@ -4,10 +4,10 @@
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { useEffect } from '@wordpress/element';
 
-/*
+/**
  * Internal dependencies
  */
-import { info } from '../../utils/logger';
+import { onAutocompleterTriggered } from '../../utils/bridge';
 
 /**
  * Adds a filter for the Autocomplete completers to show an alert when @ is typed.
@@ -48,7 +48,7 @@ function addAtSymbolCompleter( completers = [] ) {
 		name: 'at-symbol',
 		triggerPrefix: '@',
 		options: () => {
-			info( 'You typed an @ symbol!' );
+			onAutocompleterTriggered( 'at-symbol' );
 			// Return empty array since we're not providing actual completion options
 			return [];
 		},

--- a/src/components/editor/use-at-autocompleter.js
+++ b/src/components/editor/use-at-autocompleter.js
@@ -52,8 +52,7 @@ function addAtSymbolCompleter( completers = [] ) {
 			// Return empty array since we're not providing actual completion options
 			return [];
 		},
-		getOptionLabel: () => '',
-		getOptionCompletion: () => '@',
+		isDebounced: true,
 	};
 
 	return [ ...completers, atSymbolCompleter ];

--- a/src/components/editor/use-at-autocompleter.js
+++ b/src/components/editor/use-at-autocompleter.js
@@ -47,8 +47,11 @@ function addAtSymbolCompleter( completers = [] ) {
 	const atSymbolCompleter = {
 		name: 'at-symbol',
 		triggerPrefix: '@',
-		options: () => {
-			onAutocompleterTriggered( 'at-symbol' );
+		options: ( filterValue ) => {
+			// Only trigger when cursor is directly after @ (no characters typed yet)
+			if ( filterValue === '' ) {
+				onAutocompleterTriggered( 'at-symbol' );
+			}
 			// Return empty array since we're not providing actual completion options
 			return [];
 		},

--- a/src/components/editor/use-at-autocompleter.js
+++ b/src/components/editor/use-at-autocompleter.js
@@ -55,6 +55,11 @@ function addAtSymbolCompleter( completers = [] ) {
 			// Return empty array since we're not providing actual completion options
 			return [];
 		},
+		allowContext: ( before, after ) => {
+			const beforeEmptyOrWhitespace = /^$|\s$/.test( before );
+			const afterEmptyOrWhitespace = /^$|^\s/.test( after );
+			return beforeEmptyOrWhitespace && afterEmptyOrWhitespace;
+		},
 		isDebounced: true,
 	};
 

--- a/src/components/editor/use-at-autocompleter.js
+++ b/src/components/editor/use-at-autocompleter.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import { useEffect } from '@wordpress/element';
+
+/*
+ * Internal dependencies
+ */
+import { info } from '../../utils/logger';
+
+/**
+ * Adds a filter for the Autocomplete completers to show an alert when @ is typed.
+ *
+ * @return {void}
+ */
+export function useAtAutocompleter() {
+	useEffect( () => {
+		// Avoid conflicts with core's default autocompleter
+		removeFilter(
+			'editor.Autocomplete.completers',
+			'editor/autocompleters/set-default-completers'
+		);
+
+		addFilter(
+			'editor.Autocomplete.completers',
+			'GutenbergKit/at-symbol-alert',
+			addAtSymbolCompleter
+		);
+
+		return () => {
+			removeFilter(
+				'editor.Autocomplete.completers',
+				'GutenbergKit/at-symbol-alert'
+			);
+		};
+	}, [] );
+}
+
+/**
+ * Adds the @ symbol autocompleter to the completers array.
+ *
+ * @param {Array} completers Existing completers.
+ * @return {Array} Updated completers array.
+ */
+function addAtSymbolCompleter( completers = [] ) {
+	const atSymbolCompleter = {
+		name: 'at-symbol',
+		triggerPrefix: '@',
+		options: () => {
+			info( 'You typed an @ symbol!' );
+			// Return empty array since we're not providing actual completion options
+			return [];
+		},
+		getOptionLabel: () => '',
+		getOptionCompletion: () => '@',
+	};
+
+	return [ ...completers, atSymbolCompleter ];
+}

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -5,7 +5,14 @@ import { useEffect, useCallback, useRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
-import { parse, serialize } from '@wordpress/blocks';
+import { parse, serialize, getBlockType } from '@wordpress/blocks';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { insert, create, toHTMLString } from '@wordpress/rich-text';
+
+/**
+ * Internal dependencies
+ */
+import { warn } from '../../utils/logger';
 
 window.editor = window.editor || {};
 
@@ -14,6 +21,13 @@ export function useHostBridge( post, editorRef ) {
 	const { undo, redo, switchEditorMode } = useDispatch( editorStore );
 	const { getEditedPostAttribute, getEditedPostContent } =
 		useSelect( editorStore );
+	const { updateBlock, selectionChange } = useDispatch( blockEditorStore );
+	const {
+		getSelectedBlockClientId,
+		getBlock,
+		getSelectionStart,
+		getSelectionEnd,
+	} = useSelect( blockEditorStore );
 
 	const editContent = useCallback(
 		( edits ) => {
@@ -79,6 +93,64 @@ export function useHostBridge( post, editorRef ) {
 			switchEditorMode( mode );
 		};
 
+		window.editor.appendTextAtCursor = ( text ) => {
+			const selectedBlockClientId = getSelectedBlockClientId();
+
+			if ( ! selectedBlockClientId ) {
+				warn( 'Unable to append text: no block selected' );
+				return false;
+			}
+
+			const block = getBlock( selectedBlockClientId );
+
+			if ( ! block ) {
+				warn(
+					'Unable to append text: could not retrieve selected block'
+				);
+				return false;
+			}
+
+			const blockType = getBlockType( block.name );
+			const hasContentAttribute = blockType?.attributes?.content;
+
+			if ( ! hasContentAttribute ) {
+				warn(
+					`Unable to append text: block type ${ block.name } does not support text content`
+				);
+				return false;
+			}
+
+			const blockContent = block.attributes?.content || '';
+			const currentValue = create( { html: blockContent } );
+			const selectionStart = getSelectionStart();
+			const selectionEnd = getSelectionEnd();
+			const newValue = insert(
+				currentValue,
+				text,
+				selectionStart?.offset,
+				selectionEnd?.offset
+			);
+
+			updateBlock( selectedBlockClientId, {
+				attributes: {
+					...block.attributes,
+					content: toHTMLString( { value: newValue } ),
+				},
+			} );
+
+			const newCursorPosition =
+				selectionStart?.offset + text.length || newValue.text.length;
+
+			selectionChange( {
+				clientId: selectionStart?.clientId || selectedBlockClientId,
+				attributeKey: selectionStart?.attributeKey || 'content',
+				startOffset: newCursorPosition,
+				endOffset: newCursorPosition,
+			} );
+
+			return true;
+		};
+
 		return () => {
 			delete window.editor.setContent;
 			delete window.editor.setTitle;
@@ -87,6 +159,7 @@ export function useHostBridge( post, editorRef ) {
 			delete window.editor.undo;
 			delete window.editor.redo;
 			delete window.editor.switchEditorMode;
+			delete window.editor.appendTextAtCursor;
 		};
 	}, [
 		editorRef,
@@ -96,6 +169,12 @@ export function useHostBridge( post, editorRef ) {
 		redo,
 		switchEditorMode,
 		undo,
+		getSelectedBlockClientId,
+		getBlock,
+		getSelectionStart,
+		getSelectionEnd,
+		updateBlock,
+		selectionChange,
 	] );
 }
 

--- a/src/components/editor/use-plus-autocompleter.js
+++ b/src/components/editor/use-plus-autocompleter.js
@@ -46,8 +46,7 @@ function addPlusSymbolCompleter( completers = [] ) {
 			// Return empty array since we're not providing actual completion options
 			return [];
 		},
-		getOptionLabel: () => '',
-		getOptionCompletion: () => '+',
+		isDebounced: true,
 	};
 
 	return [ ...completers, plusSymbolCompleter ];

--- a/src/components/editor/use-plus-autocompleter.js
+++ b/src/components/editor/use-plus-autocompleter.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import { useEffect } from '@wordpress/element';
+
+/*
+ * Internal dependencies
+ */
+import { info } from '../../utils/logger';
+
+/**
+ * Adds a filter for the Autocomplete completers to show an alert when + is typed.
+ *
+ * @return {void}
+ */
+export function usePlusAutocompleter() {
+	useEffect( () => {
+		addFilter(
+			'editor.Autocomplete.completers',
+			'GutenbergKit/plus-symbol-alert',
+			addPlusSymbolCompleter
+		);
+
+		return () => {
+			removeFilter(
+				'editor.Autocomplete.completers',
+				'GutenbergKit/plus-symbol-alert'
+			);
+		};
+	}, [] );
+}
+
+/**
+ * Adds the + symbol autocompleter to the completers array.
+ *
+ * @param {Array} completers Existing completers.
+ * @return {Array} Updated completers array.
+ */
+function addPlusSymbolCompleter( completers = [] ) {
+	const plusSymbolCompleter = {
+		name: 'plus-symbol',
+		triggerPrefix: '+',
+		options: () => {
+			info( 'You typed a + symbol!' );
+			// Return empty array since we're not providing actual completion options
+			return [];
+		},
+		getOptionLabel: () => '',
+		getOptionCompletion: () => '+',
+	};
+
+	return [ ...completers, plusSymbolCompleter ];
+}

--- a/src/components/editor/use-plus-autocompleter.js
+++ b/src/components/editor/use-plus-autocompleter.js
@@ -4,10 +4,10 @@
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { useEffect } from '@wordpress/element';
 
-/*
+/**
  * Internal dependencies
  */
-import { info } from '../../utils/logger';
+import { onAutocompleterTriggered } from '../../utils/bridge';
 
 /**
  * Adds a filter for the Autocomplete completers to show an alert when + is typed.
@@ -42,7 +42,7 @@ function addPlusSymbolCompleter( completers = [] ) {
 		name: 'plus-symbol',
 		triggerPrefix: '+',
 		options: () => {
-			info( 'You typed a + symbol!' );
+			onAutocompleterTriggered( 'plus-symbol' );
 			// Return empty array since we're not providing actual completion options
 			return [];
 		},

--- a/src/components/editor/use-plus-autocompleter.js
+++ b/src/components/editor/use-plus-autocompleter.js
@@ -41,8 +41,11 @@ function addPlusSymbolCompleter( completers = [] ) {
 	const plusSymbolCompleter = {
 		name: 'plus-symbol',
 		triggerPrefix: '+',
-		options: () => {
-			onAutocompleterTriggered( 'plus-symbol' );
+		options: ( filterValue ) => {
+			// Only trigger when cursor is directly after + (no characters typed yet)
+			if ( filterValue === '' ) {
+				onAutocompleterTriggered( 'plus-symbol' );
+			}
 			// Return empty array since we're not providing actual completion options
 			return [];
 		},

--- a/src/components/editor/use-plus-autocompleter.js
+++ b/src/components/editor/use-plus-autocompleter.js
@@ -49,6 +49,11 @@ function addPlusSymbolCompleter( completers = [] ) {
 			// Return empty array since we're not providing actual completion options
 			return [];
 		},
+		allowContext: ( before, after ) => {
+			const beforeEmptyOrWhitespace = /^$|\s$/.test( before );
+			const afterEmptyOrWhitespace = /^$|^\s/.test( after );
+			return beforeEmptyOrWhitespace && afterEmptyOrWhitespace;
+		},
 		isDebounced: true,
 	};
 

--- a/src/remote.jsx
+++ b/src/remote.jsx
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 // Default styles that are needed for the editor.
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
@@ -17,15 +16,11 @@ import '@wordpress/editor/build-style/style.css';
  * Internal dependencies
  */
 import { awaitGBKitGlobal } from './utils/bridge';
-import { initializeApiFetch } from './utils/api-fetch';
 import { loadEditorAssets } from './utils/remote-editor';
 import { initializeVideoPressAjaxBridge } from './utils/videopress-bridge';
 import { error, warn } from './utils/logger';
 import { isDevMode } from './utils/dev-mode';
 import './index.scss';
-
-window.wp = window.wp || {};
-window.wp.apiFetch = apiFetch;
 
 const I18N_PACKAGES = [ 'i18n', 'hooks' ];
 
@@ -43,12 +38,11 @@ awaitGBKitGlobal()
 	.then( importL10n )
 	.then( configureLocale )
 	.then( loadRemainingAssets )
+	.then( initializeApiFetch )
 	.then( initializeEditor )
 	.catch( handleError );
 
 function initializeApiAndLoadI18n() {
-	initializeApiFetch();
-
 	// Ensure the i18n packages are loaded, then set the locale before importing
 	// the rest of the packages.
 	return loadEditorAssets( { allowedPackages: I18N_PACKAGES } );
@@ -69,6 +63,15 @@ function loadRemainingAssets() {
 	return loadEditorAssets( {
 		disallowedPackages: I18N_PACKAGES,
 	} );
+}
+
+function initializeApiFetch( assetsResult ) {
+	return import( './utils/api-fetch' ).then(
+		( { initializeApiFetch: _initializeApiFetch } ) => {
+			_initializeApiFetch();
+			return assetsResult;
+		}
+	);
 }
 
 function initializeEditor( assetsResult ) {

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import apiFetch from '@wordpress/api-fetch';
-
-/**
  * Internal dependencies
  */
 import parseException from './exception-parser';
@@ -298,16 +293,13 @@ export function awaitGBKitGlobal( timeoutMs = 3000 ) {
 export async function fetchEditorAssets() {
 	if ( window.webkit ) {
 		return await window.webkit.messageHandlers.loadFetchedEditorAssets.postMessage(
-			{
-				asset: 'manifest',
-			}
+			{ asset: 'manifest' }
 		);
 	}
-	// Android implementation - uses same API call that will be intercepted
 	const { siteApiRoot, editorAssetsEndpoint } = getGBKit();
 	const url =
 		editorAssetsEndpoint || `${ siteApiRoot }wpcom/v2/editor-assets`;
-	return await apiFetch( {
-		url,
-	} );
+	// The native Android bridge intercepts this request, managing any required
+	// authentication configuration
+	return await fetch( url );
 }

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -4,6 +4,7 @@
 import parseException from './exception-parser';
 import { debug } from './logger';
 import { isDevMode } from './dev-mode';
+import { basicFetch } from './fetch';
 
 /**
  * Generic function to dispatch messages to both Android and iOS bridges.
@@ -296,10 +297,12 @@ export async function fetchEditorAssets() {
 			{ asset: 'manifest' }
 		);
 	}
-	const { siteApiRoot, editorAssetsEndpoint } = getGBKit();
+
+	const { siteApiRoot, editorAssetsEndpoint, authHeader } = getGBKit();
 	const url =
 		editorAssetsEndpoint || `${ siteApiRoot }wpcom/v2/editor-assets`;
-	// The native Android bridge intercepts this request, managing any required
-	// authentication configuration
-	return await fetch( url );
+	// Use our fetch utility, as we have not yet loaded the `wp.apiFetch` utility
+	return await basicFetch( url, {
+		headers: { Authorization: authHeader },
+	} );
 }

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -122,6 +122,17 @@ export function openMediaLibrary( config ) {
 }
 
 /**
+ * Notifies the native host that an autocompleter was triggered.
+ *
+ * @param {string} type The type of autocompleter that was triggered (e.g. 'at-symbol', 'plus-symbol').
+ *
+ * @return {void}
+ */
+export function onAutocompleterTriggered( type ) {
+	dispatchToBridge( 'onAutocompleterTriggered', { type } );
+}
+
+/**
  * @typedef GBKitConfig
  *
  * @property {boolean}  [themeStyles]            Controls if theme styles are applied to the editor.

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -1,0 +1,114 @@
+/**
+ * Basic fetch implementation based on `@wordpress/api-fetch`.
+ *
+ * @param {string} url     The URL to fetch.
+ * @param {Object} options Fetch options.
+ * @return {Promise<any>} Fetch promise.
+ */
+export function basicFetch( url, options = {} ) {
+	const responsePromise = window.fetch( url, options );
+
+	return responsePromise.then(
+		( value ) =>
+			Promise.resolve( value )
+				.then( checkStatus )
+				.catch( ( response ) => parseAndThrowError( response ) )
+				.then( ( response ) =>
+					parseResponseAndNormalizeError( response )
+				),
+		( err ) => {
+			// Re-throw AbortError for the users to handle it themselves.
+			if ( err && err.name === 'AbortError' ) {
+				throw err;
+			}
+
+			// Otherwise, there is most likely no network connection.
+			// Unfortunately the message might depend on the browser.
+			throw {
+				code: 'fetch_error',
+				message: 'You are probably offline.',
+			};
+		}
+	);
+}
+
+/**
+ * Checks the status of a response, throwing an error if the status is not in the 200 range.
+ *
+ * @param {Response} response
+ * @return {Response} The response if the status is in the 200 range.
+ */
+function checkStatus( response ) {
+	if ( response.status >= 200 && response.status < 300 ) {
+		return response;
+	}
+
+	throw response;
+}
+
+/**
+ * Parses a response, throwing an error if parsing the response fails.
+ *
+ * @param {Response} response
+ * @return {Promise<any>} Parsed response.
+ */
+function parseAndThrowError( response ) {
+	return parseJsonAndNormalizeError( response ).then( ( error ) => {
+		const unknownError = {
+			code: 'unknown_error',
+			message: 'An unknown error occurred.',
+		};
+
+		throw error || unknownError;
+	} );
+}
+
+/**
+ * Calls the `json` function on the Response, throwing an error if the response
+ * doesn't have a json function or if parsing the json itself fails.
+ *
+ * @param {Response} response
+ * @return {Promise<any>} Parsed response.
+ */
+const parseJsonAndNormalizeError = ( response ) => {
+	const invalidJsonError = {
+		code: 'invalid_json',
+		message: 'The response is not a valid JSON response.',
+	};
+
+	if ( ! response || ! response.json ) {
+		throw invalidJsonError;
+	}
+
+	return response.json().catch( () => {
+		throw invalidJsonError;
+	} );
+};
+
+/**
+ * Parses the fetch response properly and normalize response errors.
+ *
+ * @param {Response} response
+ *
+ * @return {Promise<any>} Parsed response.
+ */
+function parseResponseAndNormalizeError( response ) {
+	return Promise.resolve( parseResponse( response ) ).catch( ( res ) =>
+		parseAndThrowError( res )
+	);
+}
+
+/**
+ * Parses the fetch response.
+ *
+ * @param {Response} response
+ *
+ * @return {Promise<any> | null | Response} Parsed response.
+ */
+function parseResponse( response ) {
+	if ( response.status === 204 ) {
+		return null;
+	}
+
+	return response.json ? response.json() : Promise.reject( response );
+}

--- a/src/utils/remote-editor.js
+++ b/src/utils/remote-editor.js
@@ -107,16 +107,8 @@ async function loadAssets(
 	html,
 	{ allowedPackages = [], disallowedPackages = [] } = {}
 ) {
-	/**
-	 * Locally-sourced Gutenberg packages excluded from remote loading to avoid
-	 * conflicts.
-	 */
-	const localGutenbergPackages = [ 'api-fetch', ...disallowedPackages ];
-
 	const excludedScriptIDs = new RegExp(
-		localGutenbergPackages
-			.map( ( script ) => `wp-${ script }-js` )
-			.join( '|' )
+		disallowedPackages.map( ( script ) => `wp-${ script }-js` ).join( '|' )
 	);
 
 	const allowedScriptIDs = allowedPackages.length

--- a/src/utils/videopress-bridge.js
+++ b/src/utils/videopress-bridge.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getGBKit } from './bridge';
-import { warn, info, error } from './logger';
+import { warn, debug, error } from './logger';
 
 /**
  * VideoPress AJAX to REST API bridge.
@@ -62,7 +62,7 @@ export function initializeVideoPressAjaxBridge() {
 		return deferred.promise();
 	};
 
-	info( 'VideoPress AJAX bridge initialized' );
+	debug( 'VideoPress AJAX bridge initialized' );
 }
 
 /**
@@ -89,7 +89,7 @@ function handleVideoPressUploadJWT() {
 				};
 				delete processedResponse.upload_url;
 
-				info(
+				debug(
 					'VideoPress JWT obtained successfully',
 					processedResponse
 				);

--- a/vite.config.remote.js
+++ b/vite.config.remote.js
@@ -34,14 +34,13 @@ export default defineConfig( {
 } );
 
 function externalize( id ) {
-	const externalDefinition = defaultRequestToExternal( id );
-	return (
-		!! externalDefinition &&
-		! id.match( /\.css(?:\?inline)?$/ ) &&
-		! [ 'apiFetch', 'i18n', 'url', 'hooks' ].includes(
-			externalDefinition[ externalDefinition.length - 1 ]
-		)
+	const hasExternal = defaultRequestToExternal( id ) !== undefined;
+	const isCss = id.match( /\.css(?:\?inline)?$/ );
+	const moduleWithSideEffects = [ '@wordpress/format-library' ].includes(
+		id
 	);
+
+	return hasExternal && ! isCss && ! moduleWithSideEffects;
 }
 
 /**
@@ -52,24 +51,22 @@ function externalize( id ) {
 function wordPressExternals() {
 	return {
 		name: 'wordpress-externals-plugin',
-		transform( code, id ) {
+		transform( code ) {
 			const magicString = new MagicString( code );
 			let hasReplacements = false;
 
 			// Match WordPress and React JSX runtime import statements
 			const regex =
-				/import\s*(?:{([^}]+)}\s*from)?\s*['"](@wordpress\/([^'"]+)|react\/jsx-runtime)['"];/g;
+				/import\s*(?:(\w+)|{([^}]+)})\s*from\s*['"](@wordpress\/(?!.*\.css)[^'"]+|react\/jsx-runtime)['"];/g;
 			let match;
 
 			while ( ( match = regex.exec( code ) ) !== null ) {
-				const [ fullMatch, imports, module ] = match;
+				const [ fullMatch, defaultImport, namedImports, module ] =
+					match;
+				const imports = defaultImport || namedImports;
 				const externalDefinition = defaultRequestToExternal( module );
 
-				if (
-					! externalDefinition ||
-					/@wordpress\/(api-fetch|url|hooks)/.test( id ) ||
-					/@wordpress\/(api-fetch|url|hooks)/.test( module )
-				) {
+				if ( ! externalDefinition ) {
 					continue; // Exclude the module from externalization
 				}
 
@@ -84,22 +81,31 @@ function wordPressExternals() {
 					continue;
 				}
 
-				const importList = imports.split( ',' ).map( ( i ) => {
-					const parts = i.trim().split( /\s+as\s+/ );
-					if ( parts.length === 2 ) {
-						// Convert import "as" syntax to destructuring assignment
-						return `${ parts[ 0 ] }: ${ parts[ 1 ] }`;
-					}
-					return i.trim();
-				} );
-
 				const definitionArray = Array.isArray( externalDefinition )
 					? externalDefinition
 					: [ externalDefinition ];
 
-				const replacement = `const { ${ importList.join(
-					', '
-				) } } = window.${ definitionArray.join( '.' ) };`;
+				let replacement;
+				if ( defaultImport ) {
+					// Handle default import
+					replacement = `const ${ defaultImport } = window.${ definitionArray.join(
+						'.'
+					) };`;
+				} else {
+					// Handle named imports
+					const importList = imports.split( ',' ).map( ( i ) => {
+						const parts = i.trim().split( /\s+as\s+/ );
+						if ( parts.length === 2 ) {
+							// Convert import "as" syntax to destructuring assignment
+							return `${ parts[ 0 ] }: ${ parts[ 1 ] }`;
+						}
+						return i.trim();
+					} );
+
+					replacement = `const { ${ importList.join(
+						', '
+					) } } = window.${ definitionArray.join( '.' ) };`;
+				}
 				magicString.overwrite(
 					match.index,
 					match.index + fullMatch.length,

--- a/vite.config.remote.js
+++ b/vite.config.remote.js
@@ -36,11 +36,8 @@ export default defineConfig( {
 function external( id ) {
 	const hasExternal = defaultRequestToExternal( id ) !== undefined;
 	const isCss = id.match( /\.css(?:\?inline)?$/ );
-	const moduleWithSideEffects = [ '@wordpress/format-library' ].includes(
-		id
-	);
 
-	return hasExternal && ! isCss && ! moduleWithSideEffects;
+	return hasExternal && ! isCss;
 }
 
 /**
@@ -62,7 +59,7 @@ function wordPressExternals() {
 
 			// Match WordPress and React JSX runtime import statements
 			const regex =
-				/import\s*(?:(\w+)|{([^}]+)})\s*from\s*['"](@wordpress\/(?!.*\.css)[^'"]+|react\/jsx-runtime)['"];/g;
+				/import\s*(?:(?:(\w+)|{([^}]+)})\s*from\s*)?['"](@wordpress\/(?!.*\.css)[^'"]+|react\/jsx-runtime)['"];/g;
 			let match;
 
 			while ( ( match = regex.exec( code ) ) !== null ) {

--- a/vite.config.remote.js
+++ b/vite.config.remote.js
@@ -45,6 +45,11 @@ function externalize( id ) {
 
 /**
  * Transform code by replacing WordPress imports with global definitions.
+ * E.g., `import { __ } from '@wordpress/i18n';` becomes `const { __ } = window.wp.i18n;`
+ * This replicates Gutenberg's behavior in a browser environment, which relies upon
+ * the `@wordpress/dependency-extraction-webpack-plugin` module.
+ *
+ * See: https://github.com/WordPress/gutenberg/tree/d2fce222ebbbef8dbc56eee1badcfe4ae0df04b0/packages/dependency-extraction-webpack-plugin
  *
  * @return {Object} The transformed code and map.
  */

--- a/vite.config.remote.js
+++ b/vite.config.remote.js
@@ -35,9 +35,9 @@ export default defineConfig( {
 
 function external( id ) {
 	const hasExternal = defaultRequestToExternal( id ) !== undefined;
-	const isCss = id.match( /\.css(?:\?inline)?$/ );
+	const isInlineCss = id.match( /\.css\?inline$/ );
 
-	return hasExternal && ! isCss;
+	return hasExternal && ! isInlineCss;
 }
 
 /**
@@ -59,13 +59,18 @@ function wordPressExternals() {
 
 			// Match WordPress and React JSX runtime import statements
 			const regex =
-				/import\s*(?:(?:(\w+)|{([^}]+)})\s*from\s*)?['"](@wordpress\/(?!.*\.css)[^'"]+|react\/jsx-runtime)['"];/g;
+				/import\s*(?:(?:(\w+)|{([^}]+)})\s*from\s*)?['"](@wordpress\/[^'"]+|react\/jsx-runtime)['"];/g;
 			let match;
 
 			while ( ( match = regex.exec( code ) ) !== null ) {
 				const [ fullMatch, defaultImport, namedImports, module ] =
 					match;
 				const imports = defaultImport || namedImports;
+
+				if ( module.match( /\.css\?inline$/ ) ) {
+					continue; // Exclude inlined CSS files from externalization
+				}
+
 				const externalDefinition = defaultRequestToExternal( module );
 
 				if ( ! externalDefinition ) {

--- a/vite.config.remote.js
+++ b/vite.config.remote.js
@@ -18,7 +18,7 @@ export default defineConfig( {
 		outDir: '../dist',
 		rollupOptions: {
 			input: resolve( __dirname, 'src/remote.html' ),
-			external: externalize,
+			external,
 		},
 		target: 'esnext',
 	},
@@ -33,7 +33,7 @@ export default defineConfig( {
 	},
 } );
 
-function externalize( id ) {
+function external( id ) {
 	const hasExternal = defaultRequestToExternal( id ) !== undefined;
 	const isCss = id.match( /\.css(?:\?inline)?$/ );
 	const moduleWithSideEffects = [ '@wordpress/format-library' ].includes(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Broadcast `@` and `+` keystrokes triggering autocompletion. Expose bridge method for appending text strings at cursor. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close CMM-453. 

Enable native host apps to respond to common autocomplete triggers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Register custom editor autocompletion callbacks via the `editor.Autocomplete.completers` filter.
- Send new `onAutocompleterTriggered` bridge event on autocompletion.
- Expose `appendTextAtCursor` bridge method allowing hosts to insert suggestions.
- Fix duplicative `@wordpress/hooks` namespace in the remote editor that results in discarded filters.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See sibling PRs:

- https://github.com/wordpress-mobile/WordPress-Android/pull/22109
- https://github.com/wordpress-mobile/WordPress-iOS/pull/24733

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, user-facing changes in sibling PRs. 

## Screenshots or screencast <!-- if applicable -->
N/A, visual changes in sibling PRs. 
