### PR TITLE
fix: API requests utilize single auth mechanism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7456,9 +7456,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001696",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
-			"integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
+			"version": "1.0.30001735",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
+			"integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
 			"dev": true,
 			"funding": [
 				{

--- a/src/components/editor-load-notice.test.jsx
+++ b/src/components/editor-load-notice.test.jsx
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-
 /**
  * External dependencies
  */

--- a/src/components/editor/test/use-media-upload.test.jsx
+++ b/src/components/editor/test/use-media-upload.test.jsx
@@ -1,5 +1,3 @@
-// @vitest-environment jsdom
-
 /**
  * WordPress dependencies
  */

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -24,7 +24,7 @@ export function initializeApiFetch() {
 	apiFetch.use( apiFetch.createRootURLMiddleware( siteApiRoot ) );
 	apiFetch.use( corsMiddleware );
 	apiFetch.use( apiPathModifierMiddleware );
-	apiFetch.use( createHeadersMiddleware() );
+	apiFetch.use( tokenAuthMiddleware );
 	apiFetch.use( filterEndpointsMiddleware );
 	apiFetch.use( mediaUploadMiddleware );
 	apiFetch.use( transformOEmbedApiResponse );
@@ -75,18 +75,16 @@ function apiPathModifierMiddleware( options, next ) {
 	return next( options );
 }
 
-function createHeadersMiddleware() {
-	return ( options, next ) => {
-		const { authHeader } = getGBKit();
-		options.headers = options.headers || {};
+function tokenAuthMiddleware( options, next ) {
+	const { authHeader } = getGBKit();
+	options.headers = options.headers || {};
 
-		if ( authHeader ) {
-			options.headers.Authorization = authHeader;
-			options.credentials = 'omit'; // Avoid cookies disrupting token authentication
-		}
+	if ( authHeader ) {
+		options.headers.Authorization = authHeader;
+		options.credentials = 'omit'; // Avoid cookies disrupting token authentication
+	}
 
-		return next( options );
-	};
+	return next( options );
 }
 
 /**

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -75,6 +75,18 @@ function apiPathModifierMiddleware( options, next ) {
 	return next( options );
 }
 
+/**
+ * Middleware that handles token-based authentication.
+ *
+ * When an auth header is present, this middleware:
+ * 1. Adds the Authorization header to the request
+ * 2. Sets credentials to 'omit' to prevent cookies from interfering with token authentication
+ *
+ * This prevents authentication conflicts where browser cookies could disrupt
+ * token-based authentication by being sent alongside the Authorization header.
+ *
+ * @type {APIFetchMiddleware}
+ */
 function tokenAuthMiddleware( options, next ) {
 	const { authHeader } = getGBKit();
 	options.headers = options.headers || {};

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -19,12 +19,12 @@ import { getGBKit } from './bridge';
  * @return {void}
  */
 export function initializeApiFetch() {
-	const { siteApiRoot = '', authHeader } = getGBKit();
+	const { siteApiRoot = '' } = getGBKit();
 
 	apiFetch.use( apiFetch.createRootURLMiddleware( siteApiRoot ) );
 	apiFetch.use( corsMiddleware );
 	apiFetch.use( apiPathModifierMiddleware );
-	apiFetch.use( createHeadersMiddleware( authHeader ) );
+	apiFetch.use( createHeadersMiddleware() );
 	apiFetch.use( filterEndpointsMiddleware );
 	apiFetch.use( mediaUploadMiddleware );
 	apiFetch.use( transformOEmbedApiResponse );
@@ -75,8 +75,9 @@ function apiPathModifierMiddleware( options, next ) {
 	return next( options );
 }
 
-function createHeadersMiddleware( authHeader ) {
+function createHeadersMiddleware() {
 	return ( options, next ) => {
+		const { authHeader } = getGBKit();
 		options.headers = options.headers || {};
 
 		if ( authHeader ) {

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -81,6 +81,7 @@ function createHeadersMiddleware( authHeader ) {
 
 		if ( authHeader ) {
 			options.headers.Authorization = authHeader;
+			options.credentials = 'omit'; // Avoid cookies disrupting token authentication
 		}
 
 		return next( options );

--- a/src/utils/api-fetch.test.js
+++ b/src/utils/api-fetch.test.js
@@ -1,0 +1,149 @@
+/**
+ * External dependencies
+ */
+import {
+	describe,
+	it,
+	expect,
+	beforeAll,
+	beforeEach,
+	afterEach,
+	vi,
+} from 'vitest';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { initializeApiFetch } from './api-fetch';
+import * as bridge from './bridge';
+
+vi.mock( './bridge' );
+
+describe( 'api-fetch credentials handling', () => {
+	let originalFetch;
+
+	beforeAll( () => {
+		// Set up initial bridge mock for middleware initialization
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: 'https://example.com/wp-json/',
+		} );
+
+		// Initialize middleware once - it will persist across all tests
+		initializeApiFetch();
+	} );
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		originalFetch = global.fetch;
+		global.fetch = vi.fn( () =>
+			Promise.resolve( {
+				ok: true,
+				json: () => Promise.resolve( {} ),
+			} )
+		);
+	} );
+
+	afterEach( () => {
+		global.fetch = originalFetch;
+	} );
+
+	it( 'should set credentials to omit when authHeader is provided', async () => {
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: 'https://example.com/wp-json/',
+			authHeader: 'Bearer test-token',
+			siteApiNamespace: [ 'wp/v2' ],
+			namespaceExcludedPaths: [],
+		} );
+
+		try {
+			await apiFetch( { path: '/wp/v2/posts' } );
+		} catch ( error ) {
+			// Ignore errors from the actual fetch
+		}
+
+		expect( global.fetch ).toHaveBeenCalled();
+		const [ , options ] = global.fetch.mock.calls[ 0 ];
+
+		expect( options.credentials ).toBe( 'omit' );
+		expect( options.headers.Authorization ).toBe( 'Bearer test-token' );
+	} );
+
+	it( 'should not set credentials when authHeader is not provided', async () => {
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: 'https://example.com/wp-json/',
+			authHeader: null,
+			siteApiNamespace: [ 'wp/v2' ],
+			namespaceExcludedPaths: [],
+		} );
+
+		try {
+			await apiFetch( { path: '/wp/v2/posts' } );
+		} catch ( error ) {
+			// Ignore errors from the actual fetch
+		}
+
+		expect( global.fetch ).toHaveBeenCalled();
+		const [ , options ] = global.fetch.mock.calls[ 0 ];
+
+		expect( options.credentials ).not.toBe( 'omit' );
+		expect( options.headers?.Authorization ).toBeUndefined();
+	} );
+
+	it( 'should override existing credentials setting when authHeader is provided', async () => {
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: 'https://example.com/wp-json/',
+			authHeader: 'Bearer override-token',
+			siteApiNamespace: [ 'wp/v2' ],
+			namespaceExcludedPaths: [],
+		} );
+
+		try {
+			await apiFetch( {
+				path: '/wp/v2/posts',
+				credentials: 'include',
+			} );
+		} catch ( error ) {
+			// Ignore errors from the actual fetch
+		}
+
+		expect( global.fetch ).toHaveBeenCalled();
+		const [ , options ] = global.fetch.mock.calls[ 0 ];
+
+		expect( options.credentials ).toBe( 'omit' );
+		expect( options.headers.Authorization ).toBe( 'Bearer override-token' );
+	} );
+
+	it( 'should preserve other headers when adding Authorization', async () => {
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: 'https://example.com/wp-json/',
+			authHeader: 'Bearer preserve-test',
+			siteApiNamespace: [ 'wp/v2' ],
+			namespaceExcludedPaths: [],
+		} );
+
+		try {
+			await apiFetch( {
+				path: '/wp/v2/posts',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Custom-Header': 'custom-value',
+				},
+			} );
+		} catch ( error ) {
+			// Ignore errors from the actual fetch
+		}
+
+		expect( global.fetch ).toHaveBeenCalled();
+		const [ , options ] = global.fetch.mock.calls[ 0 ];
+
+		expect( options.credentials ).toBe( 'omit' );
+		expect( options.headers[ 'Content-Type' ] ).toBe( 'application/json' );
+		expect( options.headers[ 'X-Custom-Header' ] ).toBe( 'custom-value' );
+		expect( options.headers.Authorization ).toBe( 'Bearer preserve-test' );
+	} );
+} );

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -9,5 +9,6 @@ export default defineConfig( {
 	test: {
 		setupFiles: [ './vitest.setup.js' ],
 		css: false,
+		environment: 'jsdom',
 	},
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Omit credentials (cookies) for `apiFetch` calls.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-684. 

GutenbergKit is setup to utilize token authentication. The presence of
authentication cookies means there were duplicative authentication mechanisms,
which can cause failed requests for some endpoints that favor cookies.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Set `credentials: 'omit'` for all `apiFetch` calls.
- Add automated tests, including refactoring to avoid stale closure variables in
  tests.
- Modify Vitest configuration to default to the `jsdom` environment—the most
  common for this project. 
- Update `caniuse` database to avoid out-of-date logs in `npm` commands.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
See https://github.com/wordpress-mobile/WordPress-iOS/pull/24747. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
