### PR TITLE
Forward original failed HTTP response to web view

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorAssetsLibrary.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorAssetsLibrary.swift
@@ -81,7 +81,7 @@ public actor EditorAssetsLibrary {
     }
 
     /// Fetches one asset (JavaScript or stylesheet) and caches its content on the device.
-    func cacheAsset(from httpURL: URL) async throws -> URL {
+    func cacheAsset(from httpURL: URL) async throws -> (URLResponse, Data) {
         // The Web Inspector automatically requests ".js.map" files, we'll support it here for debugging purpose.
         let supportedResourceSuffixes = [".js", ".css", ".js.map"]
         guard httpURL.scheme?.starts(with: "http") == true,
@@ -103,11 +103,19 @@ public actor EditorAssetsLibrary {
             if let status = (response as? HTTPURLResponse)?.statusCode, (200..<300).contains(status) {
                 try fileManager.moveItem(at: downloaded, to: localURL)
             } else {
-                throw URLError(.badServerResponse)
+                NSLog("Received an unexpected HTTP response for URL: \(httpURL)")
+                return try (response, Data(contentsOf: downloaded))
             }
         }
 
-        return localURL
+        let content = try Data(contentsOf: localURL)
+        let mimeType: String = switch httpURL.pathExtension {
+        case "js": "application/javascript"
+        case "css": "text/css"
+        default: "application/octet-stream"
+        }
+        let response = URLResponse(url: httpURL, mimeType: mimeType, expectedContentLength: content.count, textEncodingName: nil)
+        return (response, content)
     }
 }
 

--- a/ios/Sources/GutenbergKit/Sources/EditorAssetsLibrary.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorAssetsLibrary.swift
@@ -81,7 +81,11 @@ public actor EditorAssetsLibrary {
     }
 
     /// Fetches one asset (JavaScript or stylesheet) and caches its content on the device.
-    func cacheAsset(from httpURL: URL) async throws -> (URLResponse, Data) {
+    ///
+    /// - Parameters:
+    ///   - httpURL: The javascript or css URL.
+    ///   - webViewURL: The corresponding URL requested by web view, which should the "GBK cache prefix" (`gbk-cache-https://`)
+    func cacheAsset(from httpURL: URL, webViewURL: URL? = nil) async throws -> (URLResponse, Data) {
         // The Web Inspector automatically requests ".js.map" files, we'll support it here for debugging purpose.
         let supportedResourceSuffixes = [".js", ".css", ".js.map"]
         guard httpURL.scheme?.starts(with: "http") == true,
@@ -104,7 +108,18 @@ public actor EditorAssetsLibrary {
                 try fileManager.moveItem(at: downloaded, to: localURL)
             } else {
                 NSLog("Received an unexpected HTTP response for URL: \(httpURL)")
-                return try (response, Data(contentsOf: downloaded))
+                var cacheResponse = response
+                // When loading the asset for web view, we need to make sure the return URLResponse.url matches the
+                // asset url in the web view.
+                if let webViewURL {
+                    cacheResponse = URLResponse(
+                        url: webViewURL,
+                        mimeType: response.mimeType,
+                        expectedContentLength: Int(response.expectedContentLength),
+                        textEncodingName: response.textEncodingName
+                    )
+                }
+                return try (cacheResponse, Data(contentsOf: downloaded))
             }
         }
 
@@ -114,7 +129,7 @@ public actor EditorAssetsLibrary {
         case "css": "text/css"
         default: "application/octet-stream"
         }
-        let response = URLResponse(url: httpURL, mimeType: mimeType, expectedContentLength: content.count, textEncodingName: nil)
+        let response = URLResponse(url: webViewURL ?? httpURL, mimeType: mimeType, expectedContentLength: content.count, textEncodingName: nil)
         return (response, content)
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -532,7 +532,7 @@ class CachedAssetSchemeHandler: NSObject, WKURLSchemeHandler {
 
             let fetchAssetTask = Task { [library, weak self] in
                 do {
-                    let (response, content) = try await library.cacheAsset(from: httpURL)
+                    let (response, content) = try await library.cacheAsset(from: httpURL, webViewURL: url)
 
                     await self?.tasks[taskKey]?.webViewTask.didReceive(response)
                     await self?.tasks[taskKey]?.webViewTask.didReceive(content)

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -532,16 +532,7 @@ class CachedAssetSchemeHandler: NSObject, WKURLSchemeHandler {
 
             let fetchAssetTask = Task { [library, weak self] in
                 do {
-                    let localURL = try await library.cacheAsset(from: httpURL)
-                    assert(localURL.isFileURL)
-
-                    let content = try Data(contentsOf: localURL)
-                    let mimeType: String = switch httpURL.pathExtension {
-                    case "js": "application/javascript"
-                    case "css": "text/css"
-                    default: "application/octet-stream"
-                    }
-                    let response = URLResponse(url: url, mimeType: mimeType, expectedContentLength: content.count, textEncodingName: nil)
+                    let (response, content) = try await library.cacheAsset(from: httpURL)
 
                     await self?.tasks[taskKey]?.webViewTask.didReceive(response)
                     await self?.tasks[taskKey]?.webViewTask.didReceive(content)


### PR DESCRIPTION
The web inspector can now show more helpful error messages when certain assets fail to load.

| Before | After |
| ------ | ----- |
| <img src="https://github.com/user-attachments/assets/48e5ebf2-6e6e-47fb-aac7-58664120b0a9" /> | <img src="https://github.com/user-attachments/assets/8696f5c1-746a-4a81-9869-c6c3c3a8f36c" /> |
