### PR TITLE
fix: Force visual editor mode to ensure consistency with native host UI

### DIFF
--- a/src/utils/editor.jsx
+++ b/src/utils/editor.jsx
@@ -35,6 +35,11 @@ export function initializeEditor( { allowedBlockTypes } = {} ) {
 		themeStyles,
 	} );
 
+	// Force visual mode on initialization to ensure consistency with native UI,
+	// which defaults to visual mode. In the future, we could allow the native
+	// host app to configure the initial editor mode.
+	preferenceDispatch.set( 'core', 'editorMode', 'visual' );
+
 	registerCoreBlocks();
 	unregisterDisallowedBlocks( allowedBlockTypes );
 	const post = getPost();

--- a/src/utils/editor.test.jsx
+++ b/src/utils/editor.test.jsx
@@ -1,0 +1,154 @@
+/**
+ * External dependencies
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { dispatch } from '@wordpress/data';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+/**
+ * Internal dependencies
+ */
+import { initializeEditor } from './editor';
+import { getGBKit, getPost } from './bridge';
+import { getDefaultEditorSettings } from './editor-settings';
+import { unregisterDisallowedBlocks } from './blocks';
+
+vi.mock( '@wordpress/editor', () => ( {
+	store: { name: 'core/editor' },
+} ) );
+vi.mock( '@wordpress/data' );
+vi.mock( '@wordpress/preferences' );
+vi.mock( '@wordpress/block-library' );
+vi.mock( './blocks' );
+vi.mock( './bridge' );
+vi.mock( './editor-settings' );
+vi.mock( '../components/layout', () => ( {
+	default: () => null,
+} ) );
+
+describe( 'initializeEditor', () => {
+	let mockDispatch;
+	let mockPreferenceDispatch;
+	let mockEditorDispatch;
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+
+		mockPreferenceDispatch = {
+			setDefaults: vi.fn(),
+			set: vi.fn(),
+		};
+
+		mockEditorDispatch = {
+			updateEditorSettings: vi.fn(),
+		};
+
+		mockDispatch = vi.fn( ( store ) => {
+			if ( store.name === 'core/preferences' ) {
+				return mockPreferenceDispatch;
+			}
+			if ( store.name === 'core/editor' ) {
+				return mockEditorDispatch;
+			}
+			return {};
+		} );
+
+		dispatch.mockImplementation( mockDispatch );
+
+		getGBKit.mockReturnValue( {
+			themeStyles: true,
+			hideTitle: false,
+			editorSettings: null,
+		} );
+		getPost.mockReturnValue( {
+			id: 1,
+			type: 'post',
+			title: { raw: 'Test Post' },
+			content: { raw: '' },
+		} );
+
+		getDefaultEditorSettings.mockReturnValue( {} );
+
+		document.body.innerHTML = '<div id="root"></div>';
+	} );
+
+	it( 'should force editor mode to visual on initialization', () => {
+		initializeEditor();
+
+		expect( mockPreferenceDispatch.set ).toHaveBeenCalledWith(
+			'core',
+			'editorMode',
+			'visual'
+		);
+	} );
+
+	it( 'should set enable the fixed toolbar', () => {
+		initializeEditor();
+
+		expect( mockPreferenceDispatch.setDefaults ).toHaveBeenCalledWith(
+			'core',
+			expect.objectContaining( {
+				fixedToolbar: true,
+			} )
+		);
+	} );
+
+	it( 'should configure the theme styles preference', () => {
+		getGBKit.mockReturnValue( {
+			themeStyles: false,
+			hideTitle: false,
+			editorSettings: null,
+		} );
+
+		initializeEditor();
+
+		expect( mockPreferenceDispatch.setDefaults ).toHaveBeenCalledWith(
+			'core/edit-post',
+			expect.objectContaining( {
+				themeStyles: false,
+			} )
+		);
+	} );
+
+	it( 'should update editor settings', () => {
+		const mockSettings = { setting1: 'value1' };
+		getDefaultEditorSettings.mockReturnValue( mockSettings );
+
+		initializeEditor();
+
+		expect( mockEditorDispatch.updateEditorSettings ).toHaveBeenCalledWith(
+			mockSettings
+		);
+	} );
+
+	it( 'should use custom editor settings if provided', () => {
+		const customSettings = { custom: 'settings' };
+		getGBKit.mockReturnValue( {
+			themeStyles: true,
+			hideTitle: false,
+			editorSettings: customSettings,
+		} );
+
+		initializeEditor();
+
+		expect( mockEditorDispatch.updateEditorSettings ).toHaveBeenCalledWith(
+			customSettings
+		);
+	} );
+
+	it( 'should pass allowedBlockTypes to unregisterDisallowedBlocks', () => {
+		const allowedBlockTypes = [ 'core/paragraph', 'core/heading' ];
+
+		initializeEditor( { allowedBlockTypes } );
+
+		expect( unregisterDisallowedBlocks ).toHaveBeenCalledWith(
+			allowedBlockTypes
+		);
+	} );
+
+	it( 'should register core blocks', () => {
+		initializeEditor();
+
+		expect( registerCoreBlocks ).toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Avoid mismatches between native UI and the editor's mode. Ensure the native host
receives an `onEditorLoaded` event.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-795. 

GutenbergKit provides no way to configure the initial editor mode. When
GutenbergKit persists a different mode in its local storage, this leads
to a mismatch in native UI and the editor mode. Defaulting to visual avoids
any mismatches.

Additionally, forcing visual mode on initialization mitigates the fact
that the current logic does not trigger the `onEditorLoaded` event when
the text editor loads. This led to the native host never receiving the
event. The result was an indefinite loading indicator until the user
toggled the editor mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Update the preference store on initialization.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
> [!tip]
> Testing using the prototype build from https://github.com/wordpress-mobile/WordPress-iOS/pull/24905. 

1. Open the editor.
1. Toggle the mode to _Code Editor_.
1. Close the editor.
1. Open the editor.
1. Verify the editor visual mode loads.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes.
