### PR TITLE
feat: Update iOS Demo app navigation

### DIFF
--- a/ios/Demo-iOS/Sources/EditorView.swift
+++ b/ios/Demo-iOS/Sources/EditorView.swift
@@ -3,6 +3,7 @@ import GutenbergKit
 
 struct EditorView: View {
     private let configuration: EditorConfiguration
+    @Environment(\.dismiss) private var dismiss
 
     init(configuration: EditorConfiguration) {
         self.configuration = configuration
@@ -10,7 +11,16 @@ struct EditorView: View {
 
     var body: some View {
         _EditorView(configuration: configuration)
+            .navigationBarBackButtonHidden(true)
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: {
+                        dismiss()
+                    }, label: {
+                        Image(systemName: "xmark")
+                    })
+                }
+
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Button(action: {}, label: {
                         Image(systemName: "arrow.uturn.backward")

--- a/ios/Demo-iOS/Sources/EditorView.swift
+++ b/ios/Demo-iOS/Sources/EditorView.swift
@@ -11,25 +11,16 @@ struct EditorView: View {
     var body: some View {
         _EditorView(configuration: configuration)
             .toolbar {
-                ToolbarItemGroup(placement: .topBarLeading) {
-                    Button(action: {}, label: {
-                        Image(systemName: "xmark")
-                    })
-                }
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     Button(action: {}, label: {
                         Image(systemName: "arrow.uturn.backward")
-                    })
+                    }).disabled(true)
                     Button(action: {}, label: {
                         Image(systemName: "arrow.uturn.forward")
                     }).disabled(true)
                 }
 
                 ToolbarItemGroup(placement: .topBarTrailing) {
-                    Button(action: {}, label: {
-                        Image(systemName: "safari")
-                    })
-
                     moreMenu
                 }
             }
@@ -40,25 +31,19 @@ struct EditorView: View {
             Section {
                 Button(action: {}, label: {
                     Label("Code Editor", systemImage: "curlybraces")
-                })
-                Button(action: {}, label: {
-                    Label("Outline", systemImage: "list.bullet.indent")
-                })
+                }).disabled(true)
                 Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/, label: {
                     Label("Preview", systemImage: "safari")
-                })
-            }
-            Section {
+                }).disabled(true)
                 Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/, label: {
                     Label("Revisions (42)", systemImage: "clock.arrow.circlepath")
-                })
+                }).disabled(true)
                 Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/, label: {
                     Label("Post Settings", systemImage: "gearshape")
-                })
-
+                }).disabled(true)
                 Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/, label: {
                     Label("Help", systemImage: "questionmark.circle")
-                })
+                }).disabled(true)
             }
             Section {
                 Text("Blocks: 4, Words: 8, Characters: 15")
@@ -68,7 +53,6 @@ struct EditorView: View {
         } label: {
             Image(systemName: "ellipsis")
         }
-        .tint(Color.primary)
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update header navigation to more closely resemble the WordPress mobile app.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close CMM-820. 

Avoid duplicate close/back buttons. Prepare for new features involving bridge
communications controlling header navigation state.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove redundant back button. Remove unused open-in-Safari button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A, no functional changes.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no functional changes.

## Screenshots or screencast <!-- if applicable -->
Before | After
-- | --
<img width="380" height="819" alt="before" src="https://github.com/user-attachments/assets/77a2feb6-c2ca-4ca2-8ccd-acbafc0328fa" /> | <img width="380" height="819" alt="after" src="https://github.com/user-attachments/assets/2c816b1e-31a6-4fc2-8383-350ef7992ba9" />
