### PR TITLE
feat: Send modal dialog state to host app

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -52,6 +52,7 @@ class GutenbergView : WebView {
     private var editorDidBecomeAvailableListener: EditorAvailableListener? = null
     private var logJsExceptionListener: LogJsExceptionListener? = null
     private var autocompleterTriggeredListener: AutocompleterTriggeredListener? = null
+    private var modalDialogStateListener: ModalDialogStateListener? = null
 
     var textEditorEnabled: Boolean = false
         set(value) {
@@ -84,6 +85,10 @@ class GutenbergView : WebView {
 
     fun setAutocompleterTriggeredListener(listener: AutocompleterTriggeredListener) {
         autocompleterTriggeredListener = listener
+    }
+
+    fun setModalDialogStateListener(listener: ModalDialogStateListener) {
+        modalDialogStateListener = listener
     }
 
     fun setOnFileChooserRequestedListener(listener: (Intent, Int) -> Unit) {
@@ -394,6 +399,11 @@ class GutenbergView : WebView {
         fun onAutocompleterTriggered(type: String)
     }
 
+    interface ModalDialogStateListener {
+        fun onModalDialogOpened(dialogType: String)
+        fun onModalDialogClosed(dialogType: String)
+    }
+
     fun getTitleAndContent(originalContent: CharSequence, callback: TitleAndContentCallback, completeComposition: Boolean = false) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
@@ -555,6 +565,20 @@ class GutenbergView : WebView {
         }
     }
 
+    @JavascriptInterface
+    fun onModalDialogOpened(dialogType: String) {
+        handler.post {
+            modalDialogStateListener?.onModalDialogOpened(dialogType)
+        }
+    }
+
+    @JavascriptInterface
+    fun onModalDialogClosed(dialogType: String) {
+        handler.post {
+            modalDialogStateListener?.onModalDialogClosed(dialogType)
+        }
+    }
+
     fun resetFilePathCallback() {
         filePathCallback = null
     }
@@ -571,6 +595,7 @@ class GutenbergView : WebView {
         filePathCallback = null
         onFileChooserRequested = null
         autocompleterTriggeredListener = null
+        modalDialogStateListener = null
         handler.removeCallbacksAndMessages(null)
         this.destroy()
     }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -446,6 +446,12 @@ class GutenbergView : WebView {
         }
     }
 
+    fun dismissTopModal() {
+        handler.post {
+            this.evaluateJavascript("editor.dismissTopModal();", null)
+        }
+    }
+
     fun appendTextAtCursor(text: String) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't append text until the editor has loaded")

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.webkit.WebView
 import android.content.pm.ApplicationInfo
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Box
@@ -71,6 +72,11 @@ fun EditorScreen(
 ) {
     var showMenu by remember { mutableStateOf(false) }
     var isModalDialogOpen by remember { mutableStateOf(false) }
+
+    BackHandler(enabled = isModalDialogOpen) {
+        // Do nothing - prevent back navigation when modal is open
+        // The web layer will handle closing the modal
+    }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -70,6 +70,8 @@ fun EditorScreen(
     onClose: () -> Unit
 ) {
     var showMenu by remember { mutableStateOf(false) }
+    var isModalDialogOpen by remember { mutableStateOf(false) }
+    var currentDialogType by remember { mutableStateOf<String?>(null) }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -77,7 +79,10 @@ fun EditorScreen(
             TopAppBar(
                 title = { },
                 navigationIcon = {
-                    IconButton(onClick = onClose) {
+                    IconButton(
+                        onClick = onClose,
+                        enabled = !isModalDialogOpen
+                    ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Close"
@@ -103,7 +108,10 @@ fun EditorScreen(
 
                     // Overflow menu button and dropdown in Box for proper anchoring
                     Box {
-                        IconButton(onClick = { showMenu = true }) {
+                        IconButton(
+                            onClick = { showMenu = true },
+                            enabled = !isModalDialogOpen
+                        ) {
                             Icon(
                                 imageVector = Icons.Default.MoreVert,
                                 contentDescription = "More options"
@@ -147,6 +155,17 @@ fun EditorScreen(
         AndroidView(
             factory = { context ->
                 GutenbergView(context).apply {
+                    setModalDialogStateListener(object : GutenbergView.ModalDialogStateListener {
+                        override fun onModalDialogOpened(dialogType: String) {
+                            isModalDialogOpen = true
+                            currentDialogType = dialogType
+                        }
+
+                        override fun onModalDialogClosed(dialogType: String) {
+                            isModalDialogOpen = false
+                            currentDialogType = null
+                        }
+                    })
                     start(configuration)
                 }
             },

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -75,7 +75,6 @@ fun EditorScreen(
     var gutenbergViewRef by remember { mutableStateOf<GutenbergView?>(null) }
 
     BackHandler(enabled = isModalDialogOpen) {
-        // Dismiss the topmost web modal/dialog/menu (simulates ESC key)
         gutenbergViewRef?.dismissTopModal()
     }
 

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -72,10 +72,11 @@ fun EditorScreen(
 ) {
     var showMenu by remember { mutableStateOf(false) }
     var isModalDialogOpen by remember { mutableStateOf(false) }
+    var gutenbergViewRef by remember { mutableStateOf<GutenbergView?>(null) }
 
     BackHandler(enabled = isModalDialogOpen) {
-        // Do nothing - prevent back navigation when modal is open
-        // The web layer will handle closing the modal
+        // Dismiss the topmost web modal/dialog/menu (simulates ESC key)
+        gutenbergViewRef?.dismissTopModal()
     }
 
     Scaffold(
@@ -160,6 +161,7 @@ fun EditorScreen(
         AndroidView(
             factory = { context ->
                 GutenbergView(context).apply {
+                    gutenbergViewRef = this
                     setModalDialogStateListener(object : GutenbergView.ModalDialogStateListener {
                         override fun onModalDialogOpened(dialogType: String) {
                             isModalDialogOpen = true

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -71,7 +71,6 @@ fun EditorScreen(
 ) {
     var showMenu by remember { mutableStateOf(false) }
     var isModalDialogOpen by remember { mutableStateOf(false) }
-    var currentDialogType by remember { mutableStateOf<String?>(null) }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -158,12 +157,10 @@ fun EditorScreen(
                     setModalDialogStateListener(object : GutenbergView.ModalDialogStateListener {
                         override fun onModalDialogOpened(dialogType: String) {
                             isModalDialogOpen = true
-                            currentDialogType = dialogType
                         }
 
                         override fun onModalDialogClosed(dialogType: String) {
                             isModalDialogOpen = false
-                            currentDialogType = null
                         }
                     })
                     start(configuration)

--- a/ios/Demo-iOS/Sources/EditorView.swift
+++ b/ios/Demo-iOS/Sources/EditorView.swift
@@ -3,6 +3,8 @@ import GutenbergKit
 
 struct EditorView: View {
     private let configuration: EditorConfiguration
+    @State private var isModalDialogOpen = false
+    @State private var currentDialogType: String?
     @Environment(\.dismiss) private var dismiss
 
     init(configuration: EditorConfiguration) {
@@ -10,7 +12,11 @@ struct EditorView: View {
     }
 
     var body: some View {
-        _EditorView(configuration: configuration)
+        _EditorView(
+            configuration: configuration,
+            isModalDialogOpen: $isModalDialogOpen,
+            currentDialogType: $currentDialogType
+        )
             .navigationBarBackButtonHidden(true)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
@@ -19,6 +25,7 @@ struct EditorView: View {
                     }, label: {
                         Image(systemName: "xmark")
                     })
+                    .disabled(isModalDialogOpen)
                 }
 
                 ToolbarItemGroup(placement: .topBarTrailing) {
@@ -32,6 +39,7 @@ struct EditorView: View {
 
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     moreMenu
+                        .disabled(isModalDialogOpen)
                 }
             }
     }
@@ -68,13 +76,29 @@ struct EditorView: View {
 
 private struct _EditorView: UIViewControllerRepresentable {
     private let configuration: EditorConfiguration
+    @Binding var isModalDialogOpen: Bool
+    @Binding var currentDialogType: String?
 
-    init(editorURL: URL? = nil, configuration: EditorConfiguration) {
+    init(
+        configuration: EditorConfiguration,
+        isModalDialogOpen: Binding<Bool>,
+        currentDialogType: Binding<String?>
+    ) {
         self.configuration = configuration
+        self._isModalDialogOpen = isModalDialogOpen
+        self._currentDialogType = currentDialogType
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            isModalDialogOpen: $isModalDialogOpen,
+            currentDialogType: $currentDialogType
+        )
     }
 
     func makeUIViewController(context: Context) -> EditorViewController {
         let viewController = EditorViewController(configuration: configuration)
+        viewController.delegate = context.coordinator
 
         if #available(iOS 16.4, *) {
             viewController.webView.isInspectable = true
@@ -85,6 +109,68 @@ private struct _EditorView: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: EditorViewController, context: Context) {
         // Do nothing
+    }
+
+    @MainActor
+    class Coordinator: NSObject, EditorViewControllerDelegate {
+        @Binding var isModalDialogOpen: Bool
+        @Binding var currentDialogType: String?
+
+        init(
+            isModalDialogOpen: Binding<Bool>,
+            currentDialogType: Binding<String?>
+        ) {
+            self._isModalDialogOpen = isModalDialogOpen
+            self._currentDialogType = currentDialogType
+        }
+
+        // MARK: - EditorViewControllerDelegate
+
+        func editorDidLoad(_ viewContoller: EditorViewController) {
+            // No-op for demo
+        }
+
+        func editor(_ viewContoller: EditorViewController, didDisplayInitialContent content: String) {
+            // No-op for demo
+        }
+
+        func editor(_ viewContoller: EditorViewController, didEncounterCriticalError error: Error) {
+            // No-op for demo
+        }
+
+        func editor(_ viewController: EditorViewController, didUpdateContentWithState state: EditorState) {
+            // No-op for demo
+        }
+
+        func editor(_ viewController: EditorViewController, didUpdateHistoryState state: EditorState) {
+            // No-op for demo
+        }
+
+        func editor(_ viewController: EditorViewController, didUpdateFeaturedImage mediaID: Int) {
+            // No-op for demo
+        }
+
+        func editor(_ viewController: EditorViewController, didLogException error: GutenbergJSException) {
+            // No-op for demo
+        }
+
+        func editor(_ viewController: EditorViewController, didRequestMediaFromSiteMediaLibrary config: OpenMediaLibraryAction) {
+            // No-op for demo
+        }
+
+        func editor(_ viewController: EditorViewController, didTriggerAutocompleter type: String) {
+            // No-op for demo
+        }
+
+        func editor(_ viewController: EditorViewController, didOpenModalDialog dialogType: String) {
+            isModalDialogOpen = true
+            currentDialogType = dialogType
+        }
+
+        func editor(_ viewController: EditorViewController, didCloseModalDialog dialogType: String) {
+            isModalDialogOpen = false
+            currentDialogType = nil
+        }
     }
 }
 

--- a/ios/Demo-iOS/Sources/EditorView.swift
+++ b/ios/Demo-iOS/Sources/EditorView.swift
@@ -4,7 +4,6 @@ import GutenbergKit
 struct EditorView: View {
     private let configuration: EditorConfiguration
     @State private var isModalDialogOpen = false
-    @State private var currentDialogType: String?
     @Environment(\.dismiss) private var dismiss
 
     init(configuration: EditorConfiguration) {
@@ -14,8 +13,7 @@ struct EditorView: View {
     var body: some View {
         _EditorView(
             configuration: configuration,
-            isModalDialogOpen: $isModalDialogOpen,
-            currentDialogType: $currentDialogType
+            isModalDialogOpen: $isModalDialogOpen
         )
             .navigationBarBackButtonHidden(true)
             .toolbar {
@@ -77,23 +75,17 @@ struct EditorView: View {
 private struct _EditorView: UIViewControllerRepresentable {
     private let configuration: EditorConfiguration
     @Binding var isModalDialogOpen: Bool
-    @Binding var currentDialogType: String?
 
     init(
         configuration: EditorConfiguration,
-        isModalDialogOpen: Binding<Bool>,
-        currentDialogType: Binding<String?>
+        isModalDialogOpen: Binding<Bool>
     ) {
         self.configuration = configuration
         self._isModalDialogOpen = isModalDialogOpen
-        self._currentDialogType = currentDialogType
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(
-            isModalDialogOpen: $isModalDialogOpen,
-            currentDialogType: $currentDialogType
-        )
+        Coordinator(isModalDialogOpen: $isModalDialogOpen)
     }
 
     func makeUIViewController(context: Context) -> EditorViewController {
@@ -114,14 +106,9 @@ private struct _EditorView: UIViewControllerRepresentable {
     @MainActor
     class Coordinator: NSObject, EditorViewControllerDelegate {
         @Binding var isModalDialogOpen: Bool
-        @Binding var currentDialogType: String?
 
-        init(
-            isModalDialogOpen: Binding<Bool>,
-            currentDialogType: Binding<String?>
-        ) {
+        init(isModalDialogOpen: Binding<Bool>) {
             self._isModalDialogOpen = isModalDialogOpen
-            self._currentDialogType = currentDialogType
         }
 
         // MARK: - EditorViewControllerDelegate
@@ -164,12 +151,10 @@ private struct _EditorView: UIViewControllerRepresentable {
 
         func editor(_ viewController: EditorViewController, didOpenModalDialog dialogType: String) {
             isModalDialogOpen = true
-            currentDialogType = dialogType
         }
 
         func editor(_ viewController: EditorViewController, didCloseModalDialog dialogType: String) {
             isModalDialogOpen = false
-            currentDialogType = nil
         }
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
@@ -39,6 +39,10 @@ struct EditorJSMessage {
         case openMediaLibrary
         /// The user triggered an autocompleter.
         case onAutocompleterTriggered
+        /// A modal dialog has opened.
+        case onModalDialogOpened
+        /// A modal dialog has closed.
+        case onModalDialogClosed
     }
 
     struct DidUpdateBlocksBody: Decodable {
@@ -56,5 +60,9 @@ struct EditorJSMessage {
 
     struct AutocompleterTriggeredBody: Decodable {
         let type: String
+    }
+
+    struct ModalDialogBody: Decodable {
+        let dialogType: String
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -318,6 +318,12 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
             case .onAutocompleterTriggered:
                 let body = try message.decode(EditorJSMessage.AutocompleterTriggeredBody.self)
                 delegate?.editor(self, didTriggerAutocompleter: body.type)
+            case .onModalDialogOpened:
+                let body = try message.decode(EditorJSMessage.ModalDialogBody.self)
+                delegate?.editor(self, didOpenModalDialog: body.dialogType)
+            case .onModalDialogClosed:
+                let body = try message.decode(EditorJSMessage.ModalDialogBody.self)
+                delegate?.editor(self, didCloseModalDialog: body.dialogType)
             }
         } catch {
             fatalError("failed to decode message: \(error)")

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -216,6 +216,11 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         evaluate("editor.redo();")
     }
 
+    /// Dismisses the topmost modal dialog or menu in the editor
+    public func dismissTopModal() {
+        evaluate("editor.dismissTopModal();")
+    }
+
     /// Enables code editor.
     public var isCodeEditorEnabled: Bool = false {
         didSet {

--- a/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
@@ -40,6 +40,16 @@ public protocol EditorViewControllerDelegate: AnyObject {
     ///
     /// - parameter type: The type of autocompleter that was triggered (e.g., "plus-symbol", "at-symbol").
     func editor(_ viewController: EditorViewController, didTriggerAutocompleter type: String)
+
+    /// Notifies the client that a modal dialog has opened in the web editor.
+    ///
+    /// - parameter dialogType: The type of modal dialog that opened (e.g., "block-inserter", "media-library").
+    func editor(_ viewController: EditorViewController, didOpenModalDialog dialogType: String)
+
+    /// Notifies the client that a modal dialog has closed in the web editor.
+    ///
+    /// - parameter dialogType: The type of modal dialog that closed (e.g., "block-inserter", "media-library").
+    func editor(_ viewController: EditorViewController, didCloseModalDialog dialogType: String)
 }
 #endif
 

--- a/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 #if canImport(UIKit)
+@MainActor
 public protocol EditorViewControllerDelegate: AnyObject {
     /// Called when the editor loads.
     func editorDidLoad(_ viewContoller: EditorViewController)

--- a/src/components/editor-toolbar/index.jsx
+++ b/src/components/editor-toolbar/index.jsx
@@ -26,6 +26,7 @@ import { store as editorStore } from '@wordpress/editor';
  */
 import './style.scss';
 import { useModalize } from './use-modalize';
+import { useModalDialogState } from '../editor/use-modal-dialog-state';
 
 /**
  * Renders the editor toolbar containing block-related actions.
@@ -52,6 +53,9 @@ const EditorToolbar = ( { className } ) => {
 
 	useModalize( isInserterOpened );
 	useModalize( isBlockInspectorShown );
+
+	useModalDialogState( isInserterOpened, 'block-inserter' );
+	useModalDialogState( isBlockInspectorShown, 'block-inspector' );
 
 	function openSettings() {
 		setBlockInspectorShown( true );

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -93,6 +93,21 @@ export function useHostBridge( post, editorRef ) {
 			switchEditorMode( mode );
 		};
 
+		window.editor.dismissTopModal = () => {
+			const target =
+				editorRef.current.ownerDocument.activeElement || document.body;
+			target.dispatchEvent(
+				new KeyboardEvent( 'keydown', {
+					key: 'Escape',
+					keyCode: 27,
+					which: 27,
+					code: 'Escape',
+					bubbles: true,
+					cancelable: true,
+				} )
+			);
+		};
+
 		window.editor.appendTextAtCursor = ( text ) => {
 			const selectedBlockClientId = getSelectedBlockClientId();
 
@@ -159,6 +174,7 @@ export function useHostBridge( post, editorRef ) {
 			delete window.editor.undo;
 			delete window.editor.redo;
 			delete window.editor.switchEditorMode;
+			delete window.editor.dismissTopModal;
 			delete window.editor.appendTextAtCursor;
 		};
 	}, [

--- a/src/components/editor/use-modal-dialog-state.js
+++ b/src/components/editor/use-modal-dialog-state.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { onModalDialogOpened, onModalDialogClosed } from '../../utils/bridge';
+
+/**
+ * Notifies the native host when a modal dialog opens or closes.
+ *
+ * This hook monitors the visibility state of a modal dialog and dispatches
+ * bridge events to inform the native host app (iOS/Android) when the dialog
+ * state changes. This allows the host app to respond appropriately, such as
+ * disabling navigation UI while a web modal is active.
+ *
+ * @param {boolean} isModalVisible A boolean indicating whether the modal is visible.
+ * @param {string}  dialogType     The type of modal dialog (e.g., 'block-inserter', 'media-library').
+ *
+ * @return {void}
+ */
+export function useModalDialogState( isModalVisible, dialogType ) {
+	useEffect( () => {
+		if ( isModalVisible ) {
+			onModalDialogOpened( dialogType );
+		} else {
+			onModalDialogClosed( dialogType );
+		}
+	}, [ isModalVisible, dialogType ] );
+}

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -129,6 +129,28 @@ export function onAutocompleterTriggered( type ) {
 }
 
 /**
+ * Notifies the native host that a modal dialog has opened.
+ *
+ * @param {string} dialogType The type of modal dialog that opened (e.g. 'block-inserter', 'media-library').
+ *
+ * @return {void}
+ */
+export function onModalDialogOpened( dialogType ) {
+	dispatchToBridge( 'onModalDialogOpened', { dialogType } );
+}
+
+/**
+ * Notifies the native host that a modal dialog has closed.
+ *
+ * @param {string} dialogType The type of modal dialog that closed (e.g. 'block-inserter', 'media-library').
+ *
+ * @return {void}
+ */
+export function onModalDialogClosed( dialogType ) {
+	dispatchToBridge( 'onModalDialogClosed', { dialogType } );
+}
+
+/**
  * @typedef GBKitConfig
  *
  * @property {boolean}  [themeStyles]            Controls if theme styles are applied to the editor.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related:

- https://github.com/wordpress-mobile/WordPress-iOS/pull/24917
- https://github.com/wordpress-mobile/WordPress-Android/pull/22260

## What?
<!-- In a few words, what is the PR actually doing? -->
Send web modal dialog state to the host app.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close CMM-822. Close CMM-444. Close #129. 

Enable host apps to respond to a web modal dialog opening or closing. E.g., it
may be prudent to disable surrounding native UI while a web modal dialog is
open.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add bridge events for opening and closing modal dialogs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
> [!important]
> When testing the iOS Demo app, you may need to run `make build` or use the development server before running the Demo app. 

### 1. Web modal dialogs disable native header navigation
1. Open the Demo app.
1. Open a modal dialog—e.g., block inserter, block inspector.
1. Verify the native header navigation is disabled.
1. Close the modal dialog.
1. Verify the native header navigation is enabled.

### 2. Android hardware back button dismisses web dialogs
1. Open the Demo app.
1. Open a modal dialog—e.g., block inserter, block inspector.
1. Press the hardware back button. 
1. Verify the web dialog is dismissed. 
1. Press the hardware back button. 
1. Verify the editor is dismissed. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Perform the testing via a screen reader.

## Screenshots or screencast <!-- if applicable -->
N/A
