### PR TITLE
feat: Demo app navigates history state

### DIFF
--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -72,6 +72,8 @@ fun EditorScreen(
 ) {
     var showMenu by remember { mutableStateOf(false) }
     var isModalDialogOpen by remember { mutableStateOf(false) }
+    var hasUndoState by remember { mutableStateOf(false) }
+    var hasRedoState by remember { mutableStateOf(false) }
     var gutenbergViewRef by remember { mutableStateOf<GutenbergView?>(null) }
 
     BackHandler(enabled = isModalDialogOpen) {
@@ -95,13 +97,19 @@ fun EditorScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { }, enabled = false) {
+                    IconButton(
+                        onClick = { gutenbergViewRef?.undo() },
+                        enabled = hasUndoState && !isModalDialogOpen
+                    ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.Undo,
                             contentDescription = "Undo"
                         )
                     }
-                    IconButton(onClick = { }, enabled = false) {
+                    IconButton(
+                        onClick = { gutenbergViewRef?.redo() },
+                        enabled = hasRedoState && !isModalDialogOpen
+                    ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.Redo,
                             contentDescription = "Redo"
@@ -168,6 +176,12 @@ fun EditorScreen(
 
                         override fun onModalDialogClosed(dialogType: String) {
                             isModalDialogOpen = false
+                        }
+                    })
+                    setHistoryChangeListener(object : GutenbergView.HistoryChangeListener {
+                        override fun onHistoryChanged(hasUndo: Boolean, hasRedo: Boolean) {
+                            hasUndoState = hasUndo
+                            hasRedoState = hasRedo
                         }
                     })
                     start(configuration)

--- a/ios/Demo-iOS/Sources/EditorView.swift
+++ b/ios/Demo-iOS/Sources/EditorView.swift
@@ -4,6 +4,9 @@ import GutenbergKit
 struct EditorView: View {
     private let configuration: EditorConfiguration
     @State private var isModalDialogOpen = false
+    @State private var hasUndo = false
+    @State private var hasRedo = false
+    @State private var editorViewController: EditorViewController?
     @Environment(\.dismiss) private var dismiss
 
     init(configuration: EditorConfiguration) {
@@ -13,7 +16,10 @@ struct EditorView: View {
     var body: some View {
         _EditorView(
             configuration: configuration,
-            isModalDialogOpen: $isModalDialogOpen
+            isModalDialogOpen: $isModalDialogOpen,
+            hasUndo: $hasUndo,
+            hasRedo: $hasRedo,
+            editorViewController: $editorViewController
         )
             .navigationBarBackButtonHidden(true)
             .toolbar {
@@ -27,12 +33,19 @@ struct EditorView: View {
                 }
 
                 ToolbarItemGroup(placement: .topBarTrailing) {
-                    Button(action: {}, label: {
+                    Button(action: {
+                        editorViewController?.undo()
+                    }, label: {
                         Image(systemName: "arrow.uturn.backward")
-                    }).disabled(true)
-                    Button(action: {}, label: {
+                    })
+                    .disabled(!hasUndo || isModalDialogOpen)
+
+                    Button(action: {
+                        editorViewController?.redo()
+                    }, label: {
                         Image(systemName: "arrow.uturn.forward")
-                    }).disabled(true)
+                    })
+                    .disabled(!hasRedo || isModalDialogOpen)
                 }
 
                 ToolbarItemGroup(placement: .topBarTrailing) {
@@ -75,17 +88,30 @@ struct EditorView: View {
 private struct _EditorView: UIViewControllerRepresentable {
     private let configuration: EditorConfiguration
     @Binding var isModalDialogOpen: Bool
+    @Binding var hasUndo: Bool
+    @Binding var hasRedo: Bool
+    @Binding var editorViewController: EditorViewController?
 
     init(
         configuration: EditorConfiguration,
-        isModalDialogOpen: Binding<Bool>
+        isModalDialogOpen: Binding<Bool>,
+        hasUndo: Binding<Bool>,
+        hasRedo: Binding<Bool>,
+        editorViewController: Binding<EditorViewController?>
     ) {
         self.configuration = configuration
         self._isModalDialogOpen = isModalDialogOpen
+        self._hasUndo = hasUndo
+        self._hasRedo = hasRedo
+        self._editorViewController = editorViewController
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(isModalDialogOpen: $isModalDialogOpen)
+        Coordinator(
+            isModalDialogOpen: $isModalDialogOpen,
+            hasUndo: $hasUndo,
+            hasRedo: $hasRedo
+        )
     }
 
     func makeUIViewController(context: Context) -> EditorViewController {
@@ -96,6 +122,12 @@ private struct _EditorView: UIViewControllerRepresentable {
             viewController.webView.isInspectable = true
         }
         viewController.startEditorSetup()
+
+        // Store reference to view controller
+        DispatchQueue.main.async {
+            self.editorViewController = viewController
+        }
+
         return viewController
     }
 
@@ -106,9 +138,17 @@ private struct _EditorView: UIViewControllerRepresentable {
     @MainActor
     class Coordinator: NSObject, EditorViewControllerDelegate {
         @Binding var isModalDialogOpen: Bool
+        @Binding var hasUndo: Bool
+        @Binding var hasRedo: Bool
 
-        init(isModalDialogOpen: Binding<Bool>) {
+        init(
+            isModalDialogOpen: Binding<Bool>,
+            hasUndo: Binding<Bool>,
+            hasRedo: Binding<Bool>
+        ) {
             self._isModalDialogOpen = isModalDialogOpen
+            self._hasUndo = hasUndo
+            self._hasRedo = hasRedo
         }
 
         // MARK: - EditorViewControllerDelegate
@@ -130,7 +170,8 @@ private struct _EditorView: UIViewControllerRepresentable {
         }
 
         func editor(_ viewController: EditorViewController, didUpdateHistoryState state: EditorState) {
-            // No-op for demo
+            hasUndo = state.hasUndo
+            hasRedo = state.hasRedo
         }
 
         func editor(_ viewController: EditorViewController, didUpdateFeaturedImage mediaID: Int) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Synchronize Demo app undo and redo buttons with editor history state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Allow the Demo app to showcase additional bridge functionality.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Synchronize undo/redo buttons with editor history state. Add bridge function
callbacks do undo/redo buttons.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add post content.
1. Navigate forward/backwards through history state.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Verify undo/redo buttons are accessible via screen readers.

## Screenshots or screencast <!-- if applicable -->
N/A
