### PR TITLE
feat: Demo editor toggles code editor mode

### DIFF
--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -74,6 +74,7 @@ fun EditorScreen(
     var isModalDialogOpen by remember { mutableStateOf(false) }
     var hasUndoState by remember { mutableStateOf(false) }
     var hasRedoState by remember { mutableStateOf(false) }
+    var isCodeEditorEnabled by remember { mutableStateOf(false) }
     var gutenbergViewRef by remember { mutableStateOf<GutenbergView?>(null) }
 
     BackHandler(enabled = isModalDialogOpen) {
@@ -145,9 +146,12 @@ fun EditorScreen(
                                 enabled = false
                             )
                             DropdownMenuItem(
-                                text = { Text("Code editor") },
-                                onClick = { },
-                                enabled = false
+                                text = { Text(if (isCodeEditorEnabled) "Visual editor" else "Code editor") },
+                                onClick = {
+                                    isCodeEditorEnabled = !isCodeEditorEnabled
+                                    gutenbergViewRef?.textEditorEnabled = isCodeEditorEnabled
+                                    showMenu = false
+                                }
                             )
                             DropdownMenuItem(
                                 text = { Text("Post settings") },

--- a/ios/Demo-iOS/Sources/EditorView.swift
+++ b/ios/Demo-iOS/Sources/EditorView.swift
@@ -6,6 +6,7 @@ struct EditorView: View {
     @State private var isModalDialogOpen = false
     @State private var hasUndo = false
     @State private var hasRedo = false
+    @State private var isCodeEditorEnabled = false
     @State private var editorViewController: EditorViewController?
     @Environment(\.dismiss) private var dismiss
 
@@ -19,6 +20,7 @@ struct EditorView: View {
             isModalDialogOpen: $isModalDialogOpen,
             hasUndo: $hasUndo,
             hasRedo: $hasRedo,
+            isCodeEditorEnabled: $isCodeEditorEnabled,
             editorViewController: $editorViewController
         )
             .navigationBarBackButtonHidden(true)
@@ -58,9 +60,14 @@ struct EditorView: View {
     private var moreMenu: some View {
         Menu {
             Section {
-                Button(action: {}, label: {
-                    Label("Code Editor", systemImage: "curlybraces")
-                }).disabled(true)
+                Button(action: {
+                    isCodeEditorEnabled.toggle()
+                }, label: {
+                    Label(
+                        isCodeEditorEnabled ? "Visual Editor" : "Code Editor",
+                        systemImage: isCodeEditorEnabled ? "doc.richtext" : "curlybraces"
+                    )
+                })
                 Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/, label: {
                     Label("Preview", systemImage: "safari")
                 }).disabled(true)
@@ -90,6 +97,7 @@ private struct _EditorView: UIViewControllerRepresentable {
     @Binding var isModalDialogOpen: Bool
     @Binding var hasUndo: Bool
     @Binding var hasRedo: Bool
+    @Binding var isCodeEditorEnabled: Bool
     @Binding var editorViewController: EditorViewController?
 
     init(
@@ -97,12 +105,14 @@ private struct _EditorView: UIViewControllerRepresentable {
         isModalDialogOpen: Binding<Bool>,
         hasUndo: Binding<Bool>,
         hasRedo: Binding<Bool>,
+        isCodeEditorEnabled: Binding<Bool>,
         editorViewController: Binding<EditorViewController?>
     ) {
         self.configuration = configuration
         self._isModalDialogOpen = isModalDialogOpen
         self._hasUndo = hasUndo
         self._hasRedo = hasRedo
+        self._isCodeEditorEnabled = isCodeEditorEnabled
         self._editorViewController = editorViewController
     }
 
@@ -129,7 +139,7 @@ private struct _EditorView: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: EditorViewController, context: Context) {
-        // Do nothing
+        uiViewController.isCodeEditorEnabled = isCodeEditorEnabled
     }
 
     @MainActor


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Enable toggling the code editor mode in the Demo app.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Allow the Demo app to showcase additional bridge functionality.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add bridge method callbacks to the editor mode buttons.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Toggle the editor mode.
1. Verify the correct mode displays.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
N/A
