### PR TITLE
feature: Auto-focus when creating a new post

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -10,6 +10,7 @@ import android.os.Looper
 import android.util.AttributeSet
 import android.util.Log
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import android.webkit.ConsoleMessage
 import android.webkit.CookieManager
 import android.webkit.JavascriptInterface
@@ -477,6 +478,18 @@ class GutenbergView : WebView {
                     .alpha(1f)
                     .setDuration(300)
                     .start()
+
+                if (configuration.content.isEmpty()) {
+                    // Focus the editor content
+                    this.evaluateJavascript("editor.focus();", null)
+
+                    // Request focus on the WebView and show the soft keyboard
+                    handler.postDelayed({
+                        this.requestFocus()
+                        val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+                        imm?.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+                    }, 100)
+                }
             }
         }
     }

--- a/ios/Sources/GutenbergKit/Sources/EditorConfiguration.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorConfiguration.swift
@@ -16,6 +16,9 @@ public struct EditorConfiguration: Sendable {
     public let shouldUsePlugins: Bool
     /// Toggles visibility of the title field
     public let shouldHideTitle: Bool
+    /// If enabled, the editor automatically becomes focused when initialized
+    /// with an empty content.
+    public let shouldAutoFocus: Bool
     /// Root URL for the site
     public let siteURL: String
     /// Root URL for the site API
@@ -42,6 +45,7 @@ public struct EditorConfiguration: Sendable {
         shouldUseThemeStyles: Bool,
         shouldUsePlugins: Bool,
         shouldHideTitle: Bool,
+        shouldAutoFocus: Bool,
         siteURL: String,
         siteApiRoot: String,
         siteApiNamespace: [String],
@@ -58,6 +62,7 @@ public struct EditorConfiguration: Sendable {
         self.shouldUseThemeStyles = shouldUseThemeStyles
         self.shouldUsePlugins = shouldUsePlugins
         self.shouldHideTitle = shouldHideTitle
+        self.shouldAutoFocus = shouldAutoFocus
         self.siteURL = siteURL
         self.siteApiRoot = siteApiRoot
         self.siteApiNamespace = siteApiNamespace
@@ -77,6 +82,7 @@ public struct EditorConfiguration: Sendable {
             shouldUseThemeStyles: shouldUseThemeStyles,
             shouldUsePlugins: shouldUsePlugins,
             shouldHideTitle: shouldHideTitle,
+            shouldAutoFocus: shouldAutoFocus,
             siteURL: siteURL,
             siteApiRoot: siteApiRoot,
             siteApiNamespace: siteApiNamespace,
@@ -107,6 +113,7 @@ public struct EditorConfigurationBuilder {
     private var shouldUseThemeStyles: Bool
     private var shouldUsePlugins: Bool
     private var shouldHideTitle: Bool
+    private var shouldAutoFocus: Bool
     private var siteURL: String
     private var siteApiRoot: String
     private var siteApiNamespace: [String]
@@ -124,6 +131,7 @@ public struct EditorConfigurationBuilder {
         shouldUseThemeStyles: Bool = false,
         shouldUsePlugins: Bool = false,
         shouldHideTitle: Bool = false,
+        shouldAutoFocus: Bool = true,
         siteURL: String = "",
         siteApiRoot: String = "",
         siteApiNamespace: [String] = [],
@@ -140,6 +148,7 @@ public struct EditorConfigurationBuilder {
         self.shouldUseThemeStyles = shouldUseThemeStyles
         self.shouldUsePlugins = shouldUsePlugins
         self.shouldHideTitle = shouldHideTitle
+        self.shouldAutoFocus = shouldAutoFocus
         self.siteURL = siteURL
         self.siteApiRoot = siteApiRoot
         self.siteApiNamespace = siteApiNamespace
@@ -189,6 +198,12 @@ public struct EditorConfigurationBuilder {
     public func setShouldHideTitle(_ shouldHideTitle: Bool) -> EditorConfigurationBuilder {
         var copy = self
         copy.shouldHideTitle = shouldHideTitle
+        return copy
+    }
+
+    public func setShouldAutoFocus(_ shouldAutoFocus: Bool) -> EditorConfigurationBuilder {
+        var copy = self
+        copy.shouldAutoFocus = shouldAutoFocus
         return copy
     }
 
@@ -271,6 +286,7 @@ public struct EditorConfigurationBuilder {
             shouldUseThemeStyles: shouldUseThemeStyles,
             shouldUsePlugins: shouldUsePlugins,
             shouldHideTitle: shouldHideTitle,
+            shouldAutoFocus: shouldAutoFocus,
             siteURL: siteURL,
             siteApiRoot: siteApiRoot,
             siteApiNamespace: siteApiNamespace,

--- a/ios/Sources/GutenbergKit/Sources/EditorConfiguration.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorConfiguration.swift
@@ -16,9 +16,6 @@ public struct EditorConfiguration: Sendable {
     public let shouldUsePlugins: Bool
     /// Toggles visibility of the title field
     public let shouldHideTitle: Bool
-    /// If enabled, the editor automatically becomes focused when initialized
-    /// with an empty content.
-    public let shouldAutoFocus: Bool
     /// Root URL for the site
     public let siteURL: String
     /// Root URL for the site API
@@ -45,7 +42,6 @@ public struct EditorConfiguration: Sendable {
         shouldUseThemeStyles: Bool,
         shouldUsePlugins: Bool,
         shouldHideTitle: Bool,
-        shouldAutoFocus: Bool,
         siteURL: String,
         siteApiRoot: String,
         siteApiNamespace: [String],
@@ -62,7 +58,6 @@ public struct EditorConfiguration: Sendable {
         self.shouldUseThemeStyles = shouldUseThemeStyles
         self.shouldUsePlugins = shouldUsePlugins
         self.shouldHideTitle = shouldHideTitle
-        self.shouldAutoFocus = shouldAutoFocus
         self.siteURL = siteURL
         self.siteApiRoot = siteApiRoot
         self.siteApiNamespace = siteApiNamespace
@@ -82,7 +77,6 @@ public struct EditorConfiguration: Sendable {
             shouldUseThemeStyles: shouldUseThemeStyles,
             shouldUsePlugins: shouldUsePlugins,
             shouldHideTitle: shouldHideTitle,
-            shouldAutoFocus: shouldAutoFocus,
             siteURL: siteURL,
             siteApiRoot: siteApiRoot,
             siteApiNamespace: siteApiNamespace,
@@ -113,7 +107,6 @@ public struct EditorConfigurationBuilder {
     private var shouldUseThemeStyles: Bool
     private var shouldUsePlugins: Bool
     private var shouldHideTitle: Bool
-    private var shouldAutoFocus: Bool
     private var siteURL: String
     private var siteApiRoot: String
     private var siteApiNamespace: [String]
@@ -131,7 +124,6 @@ public struct EditorConfigurationBuilder {
         shouldUseThemeStyles: Bool = false,
         shouldUsePlugins: Bool = false,
         shouldHideTitle: Bool = false,
-        shouldAutoFocus: Bool = true,
         siteURL: String = "",
         siteApiRoot: String = "",
         siteApiNamespace: [String] = [],
@@ -148,7 +140,6 @@ public struct EditorConfigurationBuilder {
         self.shouldUseThemeStyles = shouldUseThemeStyles
         self.shouldUsePlugins = shouldUsePlugins
         self.shouldHideTitle = shouldHideTitle
-        self.shouldAutoFocus = shouldAutoFocus
         self.siteURL = siteURL
         self.siteApiRoot = siteApiRoot
         self.siteApiNamespace = siteApiNamespace
@@ -198,12 +189,6 @@ public struct EditorConfigurationBuilder {
     public func setShouldHideTitle(_ shouldHideTitle: Bool) -> EditorConfigurationBuilder {
         var copy = self
         copy.shouldHideTitle = shouldHideTitle
-        return copy
-    }
-
-    public func setShouldAutoFocus(_ shouldAutoFocus: Bool) -> EditorConfigurationBuilder {
-        var copy = self
-        copy.shouldAutoFocus = shouldAutoFocus
         return copy
     }
 
@@ -286,7 +271,6 @@ public struct EditorConfigurationBuilder {
             shouldUseThemeStyles: shouldUseThemeStyles,
             shouldUsePlugins: shouldUsePlugins,
             shouldHideTitle: shouldHideTitle,
-            shouldAutoFocus: shouldAutoFocus,
             siteURL: siteURL,
             siteApiRoot: siteApiRoot,
             siteApiNamespace: siteApiNamespace,

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -321,23 +321,9 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         print("gutenbergkit-measure_editor-first-render:", duration)
         delegate?.editorDidLoad(self)
 
-        if configuration.shouldAutoFocus, configuration.content.isEmpty {
-            autoFocusEditor()
+        if configuration.content.isEmpty {
+            evaluate("editor.focus();")
         }
-    }
-
-    // MARK: - Helpers
-
-    private func autoFocusEditor() {
-        evaluate("""
-        (function() {
-            const editable = document.querySelector('[contenteditable="true"]');
-            if (editable) {
-                editable.focus();
-                editable.click();
-            }
-        })();
-        """)
     }
 
     // MARK: - Warmup

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -86,33 +86,6 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
             setUpEditor()
             loadEditor()
         }
-
-        // TODO: register it when editor is loaded
-//        service.$rawBlockTypesResponseData.compactMap({ $0 }).sink { [weak self] data in
-//            guard let self else { return }
-//            assert(Thread.isMainThread)
-//
-//        }.store(in: &cancellables)
-    }
-
-    // TODO: move
-    private func registerBlockTypes(data: Data) async {
-        guard let string = String(data: data, encoding: .utf8),
-            let escapedString = string.addingPercentEncoding(withAllowedCharacters: .alphanumerics) else {
-            assertionFailure("invalid block types")
-            return
-        }
-        do {
-            // TODO: simplify this
-            try await webView.evaluateJavaScript("""
-                const blockTypes = JSON.parse(decodeURIComponent('\(escapedString)'));
-                editor.registerBlocks(blockTypes);
-                "done";
-                """)
-        } catch {
-            NSLog("failed to register blocks \(error)")
-            // TOOD: relay to the client
-        }
     }
 
     private func setUpEditor() {
@@ -347,6 +320,24 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         let duration = CFAbsoluteTimeGetCurrent() - timestampInit
         print("gutenbergkit-measure_editor-first-render:", duration)
         delegate?.editorDidLoad(self)
+
+        if configuration.shouldAutoFocus, configuration.content.isEmpty {
+            autoFocusEditor()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func autoFocusEditor() {
+        evaluate("""
+        (function() {
+            const editable = document.querySelector('[contenteditable="true"]');
+            if (editable) {
+                editable.focus();
+                editable.click();
+            }
+        })();
+        """)
     }
 
     // MARK: - Warmup

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -108,6 +108,16 @@ export function useHostBridge( post, editorRef ) {
 			);
 		};
 
+		window.editor.focus = () => {
+			const editable = document.querySelector(
+				'[contenteditable="true"]'
+			);
+			if ( editable ) {
+				editable.focus();
+				editable.click();
+			}
+		};
+
 		window.editor.appendTextAtCursor = ( text ) => {
 			const selectedBlockClientId = getSelectedBlockClientId();
 


### PR DESCRIPTION
## What?
The editor will now automatically focus when you open create a new post. This is the behavior you expect on iOS, and it matches Gutenberg Mobile.

This change is part of https://github.com/wordpress-mobile/GutenbergKit/pull/162.

## How?
Programmatically click on the first editable element.

## Testing Instructions
- Open an editor with empty content and verify that the editor automatically becomes focused
- Open an editor with non-empty content and verify that it doesn't

## Screenshots or screencast 


https://github.com/user-attachments/assets/ed29735f-10e3-4528-a33d-f375be5afba8




