### PR TITLE
feat: Modernize Android demo app 

### DIFF
--- a/android/app/src/main/java/com/example/gutenbergkit/AuthenticationManager.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/AuthenticationManager.kt
@@ -19,6 +19,10 @@ class AuthenticationManager(private val context: Context) {
 
     private var currentApiRootUrl: String? = null
 
+    companion object {
+        private const val APP_NAME_AUTH = "GutenbergKitAndroidDemoApp"
+    }
+
     fun startAuthentication(siteUrl: String, callback: AuthenticationCallback) {
         CoroutineScope(Dispatchers.IO).launch {
             when (val apiDiscoveryResult = WpLoginClient().apiDiscovery(siteUrl)) {
@@ -54,7 +58,7 @@ class AuthenticationManager(private val context: Context) {
         val uriBuilder = applicationPasswordAuthenticationUrl.toUri().buildUpon()
 
         uriBuilder
-            .appendQueryParameter("app_name", "GutenbergKitAndroidDemoApp")
+            .appendQueryParameter("app_name", APP_NAME_AUTH)
             .appendQueryParameter("app_id", "00000000-0000-4000-9000-000000000000")
             // Url scheme is defined in AndroidManifest file
             .appendQueryParameter("success_url", "gutenbergkit://authorized")

--- a/android/app/src/main/java/com/example/gutenbergkit/AuthenticationManager.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/AuthenticationManager.kt
@@ -3,7 +3,6 @@ package com.example.gutenbergkit
 import android.content.Context
 import android.content.Intent
 import android.util.Base64
-import androidx.appcompat.app.AlertDialog
 import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -21,67 +20,28 @@ class AuthenticationManager(private val context: Context) {
     private var currentApiRootUrl: String? = null
 
     fun startAuthentication(siteUrl: String, callback: AuthenticationCallback) {
-        showProgressDialog { progressDialog ->
-            CoroutineScope(Dispatchers.IO).launch {
-                when (val apiDiscoveryResult = WpLoginClient().apiDiscovery(siteUrl)) {
-                    is ApiDiscoveryResult.Success -> {
-                        val success = apiDiscoveryResult.success
-                        val apiRootUrl = success.apiRootUrl.url()
-                        val applicationPasswordAuthenticationUrl =
-                            success.applicationPasswordsAuthenticationUrl.url()
-                        withContext(Dispatchers.Main) {
-                            progressDialog.dismiss()
-                            launchAuthenticationFlow(
-                                apiRootUrl,
-                                applicationPasswordAuthenticationUrl
-                            )
-                        }
+        CoroutineScope(Dispatchers.IO).launch {
+            when (val apiDiscoveryResult = WpLoginClient().apiDiscovery(siteUrl)) {
+                is ApiDiscoveryResult.Success -> {
+                    val success = apiDiscoveryResult.success
+                    val apiRootUrl = success.apiRootUrl.url()
+                    val applicationPasswordAuthenticationUrl =
+                        success.applicationPasswordsAuthenticationUrl.url()
+                    withContext(Dispatchers.Main) {
+                        launchAuthenticationFlow(
+                            apiRootUrl,
+                            applicationPasswordAuthenticationUrl
+                        )
                     }
+                }
 
-                    else -> {
-                        withContext(Dispatchers.Main) {
-                            progressDialog.dismiss()
-                            callback.onAuthenticationFailure("Failed to find api root: $apiDiscoveryResult")
-                        }
+                else -> {
+                    withContext(Dispatchers.Main) {
+                        callback.onAuthenticationFailure("Failed to find api root: $apiDiscoveryResult")
                     }
                 }
             }
         }
-    }
-
-    private fun showProgressDialog(onCreated: (AlertDialog) -> Unit) {
-        val progressView = android.widget.LinearLayout(context).apply {
-            orientation = android.widget.LinearLayout.VERTICAL
-            gravity = android.view.Gravity.CENTER
-            setPadding(64, 48, 64, 48)
-
-            // Add circular progress indicator
-            addView(android.widget.ProgressBar(context).apply {
-                isIndeterminate = true
-                layoutParams = android.widget.LinearLayout.LayoutParams(
-                    android.widget.LinearLayout.LayoutParams.WRAP_CONTENT,
-                    android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
-                ).apply {
-                    setMargins(0, 0, 0, 32)
-                }
-            })
-
-            // Add message text
-            addView(android.widget.TextView(context).apply {
-                text = context.getString(R.string.connecting_to_api)
-                gravity = android.view.Gravity.CENTER
-                textSize = 16f
-            })
-        }
-
-        val progressDialog = AlertDialog.Builder(context)
-            .setTitle(context.getString(R.string.discovering_site))
-            .setView(progressView)
-            .setCancelable(false)
-            .create()
-            .also { it.show() }
-
-        onCreated(progressDialog)
     }
 
     private fun launchAuthenticationFlow(

--- a/android/app/src/main/java/com/example/gutenbergkit/AuthenticationManager.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/AuthenticationManager.kt
@@ -50,14 +50,29 @@ class AuthenticationManager(private val context: Context) {
     }
 
     private fun showProgressDialog(onCreated: (AlertDialog) -> Unit) {
-        val progressView = android.view.LayoutInflater.from(context)
-            .inflate(android.R.layout.simple_list_item_1, null).apply {
-                findViewById<android.widget.TextView>(android.R.id.text1).apply {
-                    text = context.getString(R.string.finding_api_root)
-                    gravity = android.view.Gravity.CENTER
-                    setPadding(32, 32, 32, 32)
+        val progressView = android.widget.LinearLayout(context).apply {
+            orientation = android.widget.LinearLayout.VERTICAL
+            gravity = android.view.Gravity.CENTER
+            setPadding(64, 48, 64, 48)
+
+            // Add circular progress indicator
+            addView(android.widget.ProgressBar(context).apply {
+                isIndeterminate = true
+                layoutParams = android.widget.LinearLayout.LayoutParams(
+                    android.widget.LinearLayout.LayoutParams.WRAP_CONTENT,
+                    android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
+                ).apply {
+                    setMargins(0, 0, 0, 32)
                 }
-            }
+            })
+
+            // Add message text
+            addView(android.widget.TextView(context).apply {
+                text = context.getString(R.string.connecting_to_api)
+                gravity = android.view.Gravity.CENTER
+                textSize = 16f
+            })
+        }
 
         val progressDialog = AlertDialog.Builder(context)
             .setTitle(context.getString(R.string.discovering_site))

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
 import com.example.gutenbergkit.ui.theme.AppTheme
 import org.wordpress.gutenberg.EditorConfiguration
@@ -99,7 +100,7 @@ fun EditorScreen(
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Close"
+                            contentDescription = stringResource(R.string.close)
                         )
                     }
                 },
@@ -110,7 +111,7 @@ fun EditorScreen(
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.Undo,
-                            contentDescription = "Undo"
+                            contentDescription = stringResource(R.string.undo)
                         )
                     }
                     IconButton(
@@ -119,11 +120,11 @@ fun EditorScreen(
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.Redo,
-                            contentDescription = "Redo"
+                            contentDescription = stringResource(R.string.redo)
                         )
                     }
                     TextButton(onClick = { }, enabled = false) {
-                        Text("PUBLISH")
+                        Text(stringResource(R.string.publish))
                     }
 
                     // Overflow menu button and dropdown in Box for proper anchoring
@@ -134,7 +135,7 @@ fun EditorScreen(
                         ) {
                             Icon(
                                 imageVector = Icons.Default.MoreVert,
-                                contentDescription = "More options"
+                                contentDescription = stringResource(R.string.more_options)
                             )
                         }
                         DropdownMenu(
@@ -142,17 +143,17 @@ fun EditorScreen(
                             onDismissRequest = { showMenu = false }
                         ) {
                             DropdownMenuItem(
-                                text = { Text("Save") },
+                                text = { Text(stringResource(R.string.save)) },
                                 onClick = { },
                                 enabled = false
                             )
                             DropdownMenuItem(
-                                text = { Text("Preview") },
+                                text = { Text(stringResource(R.string.preview)) },
                                 onClick = { },
                                 enabled = false
                             )
                             DropdownMenuItem(
-                                text = { Text(if (isCodeEditorEnabled) "Visual editor" else "Code editor") },
+                                text = { Text(stringResource(if (isCodeEditorEnabled) R.string.visual_editor else R.string.code_editor)) },
                                 onClick = {
                                     isCodeEditorEnabled = !isCodeEditorEnabled
                                     gutenbergViewRef?.textEditorEnabled = isCodeEditorEnabled
@@ -160,12 +161,12 @@ fun EditorScreen(
                                 }
                             )
                             DropdownMenuItem(
-                                text = { Text("Post settings") },
+                                text = { Text(stringResource(R.string.post_settings)) },
                                 onClick = { },
                                 enabled = false
                             )
                             DropdownMenuItem(
-                                text = { Text("Help") },
+                                text = { Text(stringResource(R.string.help)) },
                                 onClick = { },
                                 enabled = false
                             )

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import com.example.gutenbergkit.ui.theme.AppTheme
 import org.wordpress.gutenberg.EditorConfiguration
 import org.wordpress.gutenberg.GutenbergView
 
@@ -56,10 +57,12 @@ class EditorActivity : ComponentActivity() {
             } ?: EditorConfiguration.builder().build()
 
         setContent {
-            EditorScreen(
-                configuration = configuration,
-                onClose = { finish() }
-            )
+            AppTheme {
+                EditorScreen(
+                    configuration = configuration,
+                    onClose = { finish() }
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -85,7 +86,9 @@ fun EditorScreen(
     }
 
     Scaffold(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .imePadding(),
         topBar = {
             TopAppBar(
                 title = { },

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -174,7 +174,7 @@ fun MainScreen(
             ) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    contentDescription = stringResource(R.string.add_remote_config_description)
+                    contentDescription = stringResource(R.string.add_remote_editor_description)
                 )
             }
         }
@@ -204,7 +204,7 @@ fun MainScreen(
     if (showAddDialog) {
         AlertDialog(
             onDismissRequest = { showAddDialog = false },
-            title = { Text(stringResource(R.string.add_remote_configuration)) },
+            title = { Text(stringResource(R.string.add_remote_editor)) },
             text = {
                 OutlinedTextField(
                     value = siteUrlInput,

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -2,18 +2,49 @@ package com.example.gutenbergkit
 
 import android.content.Intent
 import android.os.Bundle
-import android.widget.EditText
-import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.floatingactionbutton.FloatingActionButton
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Computer
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.gutenbergkit.ui.theme.AppTheme
 import org.wordpress.gutenberg.EditorConfiguration
 
-class MainActivity : AppCompatActivity(), AuthenticationManager.AuthenticationCallback {
-    private lateinit var recyclerView: RecyclerView
-    private lateinit var adapter: ConfigurationAdapter
-    private val configurations = mutableListOf<ConfigurationItem>()
+class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCallback {
+    private val configurations = mutableStateListOf<ConfigurationItem>()
     private lateinit var configurationStorage: ConfigurationStorage
     private lateinit var authenticationManager: AuthenticationManager
 
@@ -23,14 +54,10 @@ class MainActivity : AppCompatActivity(), AuthenticationManager.AuthenticationCa
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_configuration)
+        enableEdgeToEdge()
 
-        title = getString(R.string.demo_title)
         configurationStorage = ConfigurationStorage(this)
         authenticationManager = AuthenticationManager(this)
-
-        recyclerView = findViewById(R.id.configurationsRecyclerView)
-        recyclerView.layoutManager = LinearLayoutManager(this)
 
         // Add default bundled editor configuration
         configurations.add(ConfigurationItem.BundledEditor)
@@ -38,31 +65,31 @@ class MainActivity : AppCompatActivity(), AuthenticationManager.AuthenticationCa
         // Load saved configurations
         configurations.addAll(configurationStorage.loadConfigurations())
 
-        adapter = ConfigurationAdapter(
-            configurations,
-            onItemClick = { config ->
-                when (config) {
-                    is ConfigurationItem.BundledEditor -> launchEditor(createBundledConfiguration())
-                    is ConfigurationItem.RemoteEditor -> {
-                        launchEditor(createRemoteConfiguration(config))
+        setContent {
+            AppTheme {
+                MainScreen(
+                    configurations = configurations,
+                    onConfigurationClick = { config ->
+                        when (config) {
+                            is ConfigurationItem.BundledEditor -> launchEditor(createBundledConfiguration())
+                            is ConfigurationItem.RemoteEditor -> launchEditor(createRemoteConfiguration(config))
+                        }
+                    },
+                    onConfigurationLongClick = { config ->
+                        when (config) {
+                            is ConfigurationItem.BundledEditor -> false
+                            is ConfigurationItem.RemoteEditor -> true
+                        }
+                    },
+                    onAddConfiguration = { siteUrl ->
+                        authenticationManager.startAuthentication(siteUrl, this)
+                    },
+                    onDeleteConfiguration = { config ->
+                        configurations.remove(config)
+                        configurationStorage.saveConfigurations(configurations)
                     }
-                }
-            },
-            onItemLongClick = { config ->
-                when (config) {
-                    is ConfigurationItem.BundledEditor -> false // Can't delete bundled editor
-                    is ConfigurationItem.RemoteEditor -> {
-                        showDeleteDialog(config)
-                        true
-                    }
-                }
+                )
             }
-        )
-        recyclerView.adapter = adapter
-
-        // Add FAB for adding new remote configurations
-        findViewById<FloatingActionButton>(R.id.addConfigurationFab).setOnClickListener {
-            showAddConfigurationDialog()
         }
     }
 
@@ -101,24 +128,6 @@ class MainActivity : AppCompatActivity(), AuthenticationManager.AuthenticationCa
         startActivity(intent)
     }
 
-    private fun showAddConfigurationDialog() {
-        val dialogView = layoutInflater.inflate(R.layout.dialog_configuration, null)
-        val siteUrlInput = dialogView.findViewById<EditText>(R.id.siteUrlInput)
-
-        AlertDialog.Builder(this)
-            .setTitle(getString(R.string.add_remote_configuration))
-            .setView(dialogView)
-            .setPositiveButton(getString(R.string.add)) { dialog, _ ->
-                val siteUrl = siteUrlInput.text.toString().trim()
-                if (siteUrl.isNotEmpty()) {
-                    dialog.dismiss()
-                    authenticationManager.startAuthentication(siteUrl, this)
-                }
-            }
-            .setNegativeButton(getString(R.string.cancel), null)
-            .show()
-    }
-
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         authenticationManager.processAuthenticationResult(intent, this)
@@ -133,30 +142,164 @@ class MainActivity : AppCompatActivity(), AuthenticationManager.AuthenticationCa
             authHeader = authToken
         )
         configurations.add(newConfig)
-        adapter.notifyItemInserted(configurations.size - 1)
         configurationStorage.saveConfigurations(configurations)
     }
 
     override fun onAuthenticationFailure(errorMessage: String) {
-        AlertDialog.Builder(this)
-            .setTitle(getString(R.string.authentication_failed))
-            .setMessage(errorMessage)
-            .setPositiveButton(getString(R.string.ok), null)
-            .setCancelable(true)
-            .show()
+        // Error will be shown in Compose UI
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MainScreen(
+    configurations: List<ConfigurationItem>,
+    onConfigurationClick: (ConfigurationItem) -> Unit,
+    onConfigurationLongClick: (ConfigurationItem) -> Boolean,
+    onAddConfiguration: (String) -> Unit,
+    onDeleteConfiguration: (ConfigurationItem) -> Unit
+) {
+    var showAddDialog by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf<ConfigurationItem.RemoteEditor?>(null) }
+    var siteUrlInput by remember { mutableStateOf("") }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.demo_title)) }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { showAddDialog = true }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = stringResource(R.string.add_remote_config_description)
+                )
+            }
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(configurations) { config ->
+                ConfigurationCard(
+                    configuration = config,
+                    onClick = { onConfigurationClick(config) },
+                    onLongClick = {
+                        if (config is ConfigurationItem.RemoteEditor) {
+                            showDeleteDialog = config
+                        }
+                    }
+                )
+            }
+        }
     }
 
-    private fun showDeleteDialog(config: ConfigurationItem.RemoteEditor) {
-        AlertDialog.Builder(this)
-            .setTitle(getString(R.string.delete_site_title))
-            .setMessage(getString(R.string.delete_site_message))
-            .setPositiveButton(getString(R.string.delete)) { _, _ ->
-                val index = configurations.indexOf(config)
-                configurations.removeAt(index)
-                adapter.notifyItemRemoved(index)
-                configurationStorage.saveConfigurations(configurations)
+    // Add Configuration Dialog
+    if (showAddDialog) {
+        AlertDialog(
+            onDismissRequest = { showAddDialog = false },
+            title = { Text(stringResource(R.string.add_remote_configuration)) },
+            text = {
+                OutlinedTextField(
+                    value = siteUrlInput,
+                    onValueChange = { siteUrlInput = it },
+                    label = { Text(stringResource(R.string.site_url)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        if (siteUrlInput.isNotBlank()) {
+                            onAddConfiguration(siteUrlInput.trim())
+                            showAddDialog = false
+                            siteUrlInput = ""
+                        }
+                    }
+                ) {
+                    Text(stringResource(R.string.add))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAddDialog = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
             }
-            .setNegativeButton(getString(R.string.cancel), null)
-            .show()
+        )
+    }
+
+    // Delete Configuration Dialog
+    showDeleteDialog?.let { config ->
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = null },
+            title = { Text(stringResource(R.string.delete_site_title)) },
+            text = { Text(stringResource(R.string.delete_site_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onDeleteConfiguration(config)
+                        showDeleteDialog = null
+                    }
+                ) {
+                    Text(stringResource(R.string.delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = null }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+}
+
+@Composable
+fun ConfigurationCard(
+    configuration: ConfigurationItem,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+    ) {
+        ListItem(
+            headlineContent = {
+                Text(
+                    when (configuration) {
+                        is ConfigurationItem.BundledEditor -> stringResource(R.string.bundled_editor)
+                        is ConfigurationItem.RemoteEditor -> configuration.name
+                    }
+                )
+            },
+            supportingContent = {
+                Text(
+                    when (configuration) {
+                        is ConfigurationItem.BundledEditor -> stringResource(R.string.bundled_editor_subtitle)
+                        is ConfigurationItem.RemoteEditor -> configuration.siteUrl
+                    }
+                )
+            },
+            leadingContent = {
+                Icon(
+                    imageVector = when (configuration) {
+                        is ConfigurationItem.BundledEditor -> Icons.Default.Computer
+                        is ConfigurationItem.RemoteEditor -> Icons.Default.Language
+                    },
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        )
     }
 }

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -91,7 +91,8 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
                         configurations.remove(config)
                         configurationStorage.saveConfigurations(configurations)
                     },
-                    isDiscoveringSite = isDiscoveringSite.value
+                    isDiscoveringSite = isDiscoveringSite.value,
+                    onDismissDiscovering = { isDiscoveringSite.value = false }
                 )
             }
         }
@@ -164,7 +165,8 @@ fun MainScreen(
     onConfigurationLongClick: (ConfigurationItem) -> Boolean,
     onAddConfiguration: (String) -> Unit,
     onDeleteConfiguration: (ConfigurationItem) -> Unit,
-    isDiscoveringSite: Boolean = false
+    isDiscoveringSite: Boolean = false,
+    onDismissDiscovering: () -> Unit = {}
 ) {
     var showAddDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf<ConfigurationItem.RemoteEditor?>(null) }
@@ -277,7 +279,7 @@ fun MainScreen(
     // Discovering Site Dialog
     if (isDiscoveringSite) {
         AlertDialog(
-            onDismissRequest = { },
+            onDismissRequest = onDismissDiscovering,
             title = { Text(stringResource(R.string.discovering_site)) },
             text = {
                 Column(
@@ -291,7 +293,12 @@ fun MainScreen(
                     Text(stringResource(R.string.connecting_to_api))
                 }
             },
-            confirmButton = { }
+            confirmButton = { },
+            dismissButton = {
+                TextButton(onClick = onDismissDiscovering) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
         )
     }
 }

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -7,8 +7,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,6 +21,7 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -44,6 +46,7 @@ import org.wordpress.gutenberg.EditorConfiguration
 
 class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCallback {
     private val configurations = mutableStateListOf<ConfigurationItem>()
+    private val isDiscoveringSite = mutableStateOf(false)
     private lateinit var configurationStorage: ConfigurationStorage
     private lateinit var authenticationManager: AuthenticationManager
 
@@ -81,12 +84,14 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
                         }
                     },
                     onAddConfiguration = { siteUrl ->
+                        isDiscoveringSite.value = true
                         authenticationManager.startAuthentication(siteUrl, this)
                     },
                     onDeleteConfiguration = { config ->
                         configurations.remove(config)
                         configurationStorage.saveConfigurations(configurations)
-                    }
+                    },
+                    isDiscoveringSite = isDiscoveringSite.value
                 )
             }
         }
@@ -133,6 +138,7 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
     }
 
     override fun onAuthenticationSuccess(siteUrl: String, siteApiRoot: String, authToken: String) {
+        isDiscoveringSite.value = false
         val siteName = siteUrl.removePrefix("https://").removePrefix("http://").substringBefore("/")
         val newConfig = ConfigurationItem.RemoteEditor(
             name = siteName,
@@ -145,6 +151,7 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
     }
 
     override fun onAuthenticationFailure(errorMessage: String) {
+        isDiscoveringSite.value = false
         // Error will be shown in Compose UI
     }
 }
@@ -156,7 +163,8 @@ fun MainScreen(
     onConfigurationClick: (ConfigurationItem) -> Unit,
     onConfigurationLongClick: (ConfigurationItem) -> Boolean,
     onAddConfiguration: (String) -> Unit,
-    onDeleteConfiguration: (ConfigurationItem) -> Unit
+    onDeleteConfiguration: (ConfigurationItem) -> Unit,
+    isDiscoveringSite: Boolean = false
 ) {
     var showAddDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf<ConfigurationItem.RemoteEditor?>(null) }
@@ -263,6 +271,27 @@ fun MainScreen(
                     Text(stringResource(R.string.cancel))
                 }
             }
+        )
+    }
+
+    // Discovering Site Dialog
+    if (isDiscoveringSite) {
+        AlertDialog(
+            onDismissRequest = { },
+            title = { Text(stringResource(R.string.discovering_site)) },
+            text = {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                    horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    CircularProgressIndicator()
+                    Text(stringResource(R.string.connecting_to_api))
+                }
+            },
+            confirmButton = { }
         )
     }
 }

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -17,8 +17,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -293,7 +293,7 @@ fun ConfigurationCard(
             leadingContent = {
                 Icon(
                     imageVector = when (configuration) {
-                        is ConfigurationItem.BundledEditor -> Icons.Default.Computer
+                        is ConfigurationItem.BundledEditor -> Icons.Outlined.Inventory2
                         is ConfigurationItem.RemoteEditor -> Icons.Default.Language
                     },
                     contentDescription = null,

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -285,7 +285,7 @@ fun MainScreen(
                         .fillMaxWidth()
                         .padding(vertical = 16.dp),
                     horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                    verticalArrangement = Arrangement.spacedBy(24.dp)
                 ) {
                     CircularProgressIndicator()
                     Text(stringResource(R.string.connecting_to_api))

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -239,6 +240,12 @@ fun MainScreen(
     showDeleteDialog?.let { config ->
         AlertDialog(
             onDismissRequest = { showDeleteDialog = null },
+            icon = {
+                Icon(
+                    imageVector = Icons.Outlined.Delete,
+                    contentDescription = null
+                )
+            },
             title = { Text(stringResource(R.string.delete_site_title)) },
             text = { Text(stringResource(R.string.delete_site_message)) },
             confirmButton = {

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -7,7 +7,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,30 +16,26 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Language
-import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Inventory2
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.example.gutenbergkit.ui.dialogs.AddConfigurationDialog
+import com.example.gutenbergkit.ui.dialogs.DeleteConfigurationDialog
+import com.example.gutenbergkit.ui.dialogs.DiscoveringSiteDialog
 import com.example.gutenbergkit.ui.theme.AppTheme
 import org.wordpress.gutenberg.EditorConfiguration
 
@@ -168,9 +163,9 @@ fun MainScreen(
     isDiscoveringSite: Boolean = false,
     onDismissDiscovering: () -> Unit = {}
 ) {
-    var showAddDialog by remember { mutableStateOf(false) }
-    var showDeleteDialog by remember { mutableStateOf<ConfigurationItem.RemoteEditor?>(null) }
-    var siteUrlInput by remember { mutableStateOf("") }
+    var showAddDialog = remember { mutableStateOf(false) }
+    var showDeleteDialog = remember { mutableStateOf<ConfigurationItem.RemoteEditor?>(null) }
+    var siteUrlInput = remember { mutableStateOf("") }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -181,7 +176,7 @@ fun MainScreen(
         },
         floatingActionButton = {
             FloatingActionButton(
-                onClick = { showAddDialog = true }
+                onClick = { showAddDialog.value = true }
             ) {
                 Icon(
                     imageVector = Icons.Default.Add,
@@ -203,7 +198,7 @@ fun MainScreen(
                     onClick = { onConfigurationClick(config) },
                     onLongClick = {
                         if (config is ConfigurationItem.RemoteEditor) {
-                            showDeleteDialog = config
+                            showDeleteDialog.value = config
                         }
                     }
                 )
@@ -211,94 +206,34 @@ fun MainScreen(
         }
     }
 
-    // Add Configuration Dialog
-    if (showAddDialog) {
-        AlertDialog(
-            onDismissRequest = { showAddDialog = false },
-            title = { Text(stringResource(R.string.add_remote_editor)) },
-            text = {
-                OutlinedTextField(
-                    value = siteUrlInput,
-                    onValueChange = { siteUrlInput = it },
-                    label = { Text(stringResource(R.string.site_url)) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        if (siteUrlInput.isNotBlank()) {
-                            onAddConfiguration(siteUrlInput.trim())
-                            showAddDialog = false
-                            siteUrlInput = ""
-                        }
-                    }
-                ) {
-                    Text(stringResource(R.string.add))
+    if (showAddDialog.value) {
+        AddConfigurationDialog(
+            siteUrlInput = siteUrlInput.value,
+            onSiteUrlChange = { siteUrlInput.value = it },
+            onConfirm = {
+                if (siteUrlInput.value.isNotBlank()) {
+                    onAddConfiguration(siteUrlInput.value.trim())
+                    showAddDialog.value = false
+                    siteUrlInput.value = ""
                 }
             },
-            dismissButton = {
-                TextButton(onClick = { showAddDialog = false }) {
-                    Text(stringResource(R.string.cancel))
-                }
-            }
+            onDismiss = { showAddDialog.value = false }
         )
     }
 
-    // Delete Configuration Dialog
-    showDeleteDialog?.let { config ->
-        AlertDialog(
-            onDismissRequest = { showDeleteDialog = null },
-            icon = {
-                Icon(
-                    imageVector = Icons.Outlined.Delete,
-                    contentDescription = null
-                )
+    showDeleteDialog.value?.let { config ->
+        DeleteConfigurationDialog(
+            onConfirm = {
+                onDeleteConfiguration(config)
+                showDeleteDialog.value = null
             },
-            title = { Text(stringResource(R.string.delete_site_title)) },
-            text = { Text(stringResource(R.string.delete_site_message)) },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        onDeleteConfiguration(config)
-                        showDeleteDialog = null
-                    }
-                ) {
-                    Text(stringResource(R.string.delete))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDeleteDialog = null }) {
-                    Text(stringResource(R.string.cancel))
-                }
-            }
+            onDismiss = { showDeleteDialog.value = null }
         )
     }
 
-    // Discovering Site Dialog
     if (isDiscoveringSite) {
-        AlertDialog(
-            onDismissRequest = onDismissDiscovering,
-            title = { Text(stringResource(R.string.discovering_site)) },
-            text = {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 16.dp),
-                    horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(24.dp)
-                ) {
-                    CircularProgressIndicator()
-                    Text(stringResource(R.string.connecting_to_api))
-                }
-            },
-            confirmButton = { },
-            dismissButton = {
-                TextButton(onClick = onDismissDiscovering) {
-                    Text(stringResource(R.string.cancel))
-                }
-            }
+        DiscoveringSiteDialog(
+            onDismiss = onDismissDiscovering
         )
     }
 }

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -260,6 +260,7 @@ fun MainScreen(
     }
 }
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 fun ConfigurationCard(
     configuration: ConfigurationItem,
@@ -269,7 +270,10 @@ fun ConfigurationCard(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick
+            )
     ) {
         ListItem(
             headlineContent = {

--- a/android/app/src/main/java/com/example/gutenbergkit/ui/dialogs/ConfigurationDialogs.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/ui/dialogs/ConfigurationDialogs.kt
@@ -1,0 +1,107 @@
+package com.example.gutenbergkit.ui.dialogs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.gutenbergkit.R
+
+@Composable
+fun AddConfigurationDialog(
+    siteUrlInput: String,
+    onSiteUrlChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.add_remote_editor)) },
+        text = {
+            OutlinedTextField(
+                value = siteUrlInput,
+                onValueChange = onSiteUrlChange,
+                label = { Text(stringResource(R.string.site_url)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.add))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}
+
+@Composable
+fun DeleteConfigurationDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.Outlined.Delete,
+                contentDescription = null
+            )
+        },
+        title = { Text(stringResource(R.string.delete_site_title)) },
+        text = { Text(stringResource(R.string.delete_site_message)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.delete))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}
+
+@Composable
+fun DiscoveringSiteDialog(
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.discovering_site)) },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp),
+                horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(24.dp)
+            ) {
+                CircularProgressIndicator()
+                Text(stringResource(R.string.connecting_to_api))
+            }
+        },
+        confirmButton = { },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}

--- a/android/app/src/main/java/com/example/gutenbergkit/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/ui/theme/Theme.kt
@@ -1,0 +1,35 @@
+package com.example.gutenbergkit.ui.theme
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+private val LightColorScheme = lightColorScheme()
+private val DarkColorScheme = darkColorScheme()
+
+@Composable
+fun AppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        content = content
+    )
+}

--- a/android/app/src/main/res/layout/activity_configuration.xml
+++ b/android/app/src/main/res/layout/activity_configuration.xml
@@ -17,7 +17,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_margin="16dp"
-        android:contentDescription="@string/add_remote_config_description"
+        android:contentDescription="@string/add_remote_editor_description"
         android:src="@android:drawable/ic_input_add"
         app:backgroundTint="@color/design_default_color_primary"
         app:tint="@android:color/white" />

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="authentication_failed">Authentication failed</string>
     <string name="ok">OK</string>
     <string name="discovering_site">Discovering site</string>
-    <string name="finding_api_root">Finding API root and authentication URL…</string>
+    <string name="connecting_to_api">Connecting to WordPress API…</string>
 
     <!-- Editor Activity -->
     <string name="editor">Editor</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 
     <!-- Configuration Activity -->
     <string name="demo_title">GutenbergKit Demo</string>
-    <string name="bundled_editor">Bundled Editor</string>
+    <string name="bundled_editor">Bundled editor</string>
     <string name="bundled_editor_subtitle">Offline editor with bundled assets</string>
     <string name="add_remote_editor_description">Add remote editor</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -25,4 +25,15 @@
 
     <!-- Editor Activity -->
     <string name="editor">Editor</string>
+    <string name="close">Close</string>
+    <string name="undo">Undo</string>
+    <string name="redo">Redo</string>
+    <string name="publish">PUBLISH</string>
+    <string name="more_options">More options</string>
+    <string name="save">Save</string>
+    <string name="preview">Preview</string>
+    <string name="visual_editor">Visual editor</string>
+    <string name="code_editor">Code editor</string>
+    <string name="post_settings">Post settings</string>
+    <string name="help">Help</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,23 +5,23 @@
     <string name="demo_title">GutenbergKit Demo</string>
     <string name="bundled_editor">Bundled Editor</string>
     <string name="bundled_editor_subtitle">Offline editor with bundled assets</string>
-    <string name="add_remote_config_description">Add remote configuration</string>
+    <string name="add_remote_editor_description">Add remote editor</string>
 
     <!-- Dialog strings -->
-    <string name="add_remote_configuration">Add Remote Configuration</string>
+    <string name="add_remote_editor">Add remote editor</string>
     <string name="site_url_hint">Site URL</string>
     <string name="site_url">Site URL</string>
     <string name="add">Add</string>
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
-    <string name="delete_site_title">Delete Site</string>
-    <string name="delete_site_message">Are you sure you want to delete this site configuration?</string>
+    <string name="delete_site_title">Delete site configuration?</string>
+    <string name="delete_site_message">This will remove the site from the editor configuration list.</string>
     
     <!-- Authentication -->
-    <string name="authentication_failed">Authentication Failed</string>
+    <string name="authentication_failed">Authentication failed</string>
     <string name="ok">OK</string>
-    <string name="discovering_site">Discovering Site</string>
-    <string name="finding_api_root">Finding API root and authentication URL...</string>
+    <string name="discovering_site">Discovering site</string>
+    <string name="finding_api_root">Finding API root and authentication URL…</string>
 
     <!-- Editor Activity -->
     <string name="editor">Editor</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="authentication_failed">Authentication failed</string>
     <string name="ok">OK</string>
     <string name="discovering_site">Discovering site</string>
-    <string name="connecting_to_api">Connecting to WordPress API…</string>
+    <string name="connecting_to_api">Connecting to the WordPress API…</string>
 
     <!-- Editor Activity -->
     <string name="editor">Editor</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <!-- Dialog strings -->
     <string name="add_remote_configuration">Add Remote Configuration</string>
     <string name="site_url_hint">Site URL</string>
+    <string name="site_url">Site URL</string>
     <string name="add">Add</string>
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>

--- a/ios/Demo-iOS/Sources/ContentView.swift
+++ b/ios/Demo-iOS/Sources/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
                 NavigationLink {
                     EditorView(configuration: .default)
                 } label: {
-                    Text("Bundled Editor")
+                    Text("Bundled editor")
                 }
             }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update Android Demo app to use Material 3 styles. Fix the virtual keyboard obscuring the block toolbar. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Align with WordPress-Android app coding patterns. Simplify future UI updates. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Refactor to Jetpack Compose. Apply edge-to-edge support. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Smoke test the Demo editor. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

<details><summary>Screenshots</summary>
<p>

Before | After
-- | --
![before-editors](https://github.com/user-attachments/assets/c5af6561-971c-4745-b5ea-f2937b69179d) | ![after-editors](https://github.com/user-attachments/assets/58f10963-4aad-431f-9a77-11d998f3fefa)
![before-editor-add](https://github.com/user-attachments/assets/158cd220-ae91-4c8b-979c-95e26c470de2) | ![after-editor-add](https://github.com/user-attachments/assets/02f2423e-9804-42a9-9e45-8589d10c7d14)
![before-editor](https://github.com/user-attachments/assets/a15f4951-b591-4a60-b771-105dc56f3c5d) | ![after-editor](https://github.com/user-attachments/assets/3c4bfe3f-8b5a-4150-a57c-59a113eedca1)
![before-editor-menu](https://github.com/user-attachments/assets/8748f2cd-5e8f-4acf-a222-0a6507da3c11) | ![after-editor-menu](https://github.com/user-attachments/assets/2255377f-0aee-444d-a0bd-d679a26c96c2)

</p>
</details> 