### PR TITLE
Native Inserter: Fix SVG rendering

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,30 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "cocoalumberjack",
+      "identity" : "svgview",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
+      "location" : "https://github.com/exyte/SVGView.git",
       "state" : {
-        "revision" : "a9ed4b6f9bdedce7d77046f43adfb8ce1fd54114",
-        "version" : "3.9.0"
-      }
-    },
-    {
-      "identity" : "svgkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SVGKit/SVGKit",
-      "state" : {
-        "revision" : "58152b9f7c85eab239160b36ffdfd364aa43d666",
-        "version" : "3.0.0"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log",
-      "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "6465962facdd25cb96eaebc35603afa2f15d2c0d",
+        "version" : "1.0.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,12 +11,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.7.5"),
-        .package(url: "https://github.com/SVGKit/SVGKit", from: "3.0.0"),
+        .package(url: "https://github.com/exyte/SVGView.git", from: "1.0.6"),
     ],
     targets: [
         .target(
             name: "GutenbergKit",
-            dependencies: ["SwiftSoup", "SVGKit"],
+            dependencies: ["SwiftSoup", "SVGView"],
             path: "ios/Sources/GutenbergKit",
             exclude: [],
             resources: [.copy("Gutenberg")]

--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,30 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "cocoalumberjack",
+      "identity" : "svgview",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
+      "location" : "https://github.com/exyte/SVGView.git",
       "state" : {
-        "revision" : "a9ed4b6f9bdedce7d77046f43adfb8ce1fd54114",
-        "version" : "3.9.0"
-      }
-    },
-    {
-      "identity" : "svgkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SVGKit/SVGKit",
-      "state" : {
-        "revision" : "58152b9f7c85eab239160b36ffdfd364aa43d666",
-        "version" : "3.0.0"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log",
-      "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "6465962facdd25cb96eaebc35603afa2f15d2c0d",
+        "version" : "1.0.6"
       }
     },
     {

--- a/ios/Sources/GutenbergKit/Sources/Helpers/BlockIconCache.swift
+++ b/ios/Sources/GutenbergKit/Sources/Helpers/BlockIconCache.swift
@@ -1,11 +1,11 @@
 import Foundation
-import SVGKit
+import SVGView
 
 @MainActor
 final class BlockIconCache: ObservableObject {
-    var icons: [String: Result<SVGKImage, Error>] = [:]
+    var icons: [String: Result<SVGNode, Error>] = [:]
 
-    func getIcon(for block: BlockType) -> SVGKImage? {
+    func getIcon(for block: BlockType) -> SVGNode? {
         if let result = icons[block.id] {
             return try? result.get()
         }
@@ -14,19 +14,15 @@ final class BlockIconCache: ObservableObject {
         return try? result.get()
     }
 
-    private func _getIcon(for block: BlockType) throws -> SVGKImage {
-        guard let svg = block.icon,
-              !svg.isEmpty,
-              let source = SVGKSourceString.source(fromContentsOf: svg),
-              let image = SVGKImage(source: source) else {
+    private func _getIcon(for block: BlockType) throws -> SVGNode {
+        guard let svg = block.icon, !svg.isEmpty else {
             throw BlockIconCacheError.unknown
         }
-        if let result = image.parseErrorsAndWarnings,
-           let error = result.errorsFatal.firstObject {
+        guard let image = SVGParser.parse(string: svg) else {
 #if DEBUG
-            debugPrint("failed to parse SVG for block: \(block.name) with errors: \(String(describing: result.errorsFatal))\n\n\(svg)")
+            debugPrint("failed to parse SVG for block: \(block.name), svg: \(svg)")
 #endif
-            throw (error as? Error) ?? BlockIconCacheError.unknown
+            throw BlockIconCacheError.unknown
         }
         return image
     }

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockIconView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockIconView.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import SVGKit
+import SVGView
 
 struct BlockIconView: View {
     let block: BlockType
@@ -14,56 +14,17 @@ struct BlockIconView: View {
                 .frame(width: size, height: size)
                 .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
 
-            if let image = cache.getIcon(for: block),
-               let view = SVGKFastImageView(svgkImage: image) {
-                SVGIconView(view: view)
-                    .frame(width: size * 0.5, height: size * 0.5)
+            if let image = cache.getIcon(for: block) {
+                Color(.label).mask {
+                    SVGView(svg: image)
+                }
+                .frame(width: size * 0.5, height: size * 0.5)
             } else {
                 Image(systemName: "square")
                     .font(.system(size: size * 0.5))
                     .foregroundStyle(Color(.label))
                     .symbolRenderingMode(.hierarchical)
             }
-        }
-    }
-}
-
-private struct SVGIconView: UIViewRepresentable {
-    let view: SVGKFastImageView
-
-    @Environment(\.colorScheme) private var colorScheme
-
-    func makeUIView(context: Context) -> SVGKFastImageView {
-        view.contentMode = .scaleAspectFit
-        return view
-    }
-
-    func updateUIView(_ uiView: SVGKFastImageView, context: Context) {
-        view.image?.fillColor(color: UIColor.label)
-        view.setNeedsDisplay()
-    }
-}
-
-private extension SVGKImage {
-    /// SVGKit maintains two parallel representations of every SVG file: a
-    /// DOMTree following W3C SVG specifications and a CALayerTree for native
-    /// iOS rendering. The easiest and fastest way to change the colors of the
-    /// shapes it creates is by recursively traversing the layers.
-    private func fillColorForSubLayer(layer: CALayer, color: UIColor, opacity: Float) {
-        if let shapeLayer = layer as? CAShapeLayer {
-            shapeLayer.fillColor = color.cgColor
-            shapeLayer.opacity = opacity
-        }
-        if let sublayers = layer.sublayers {
-            for subLayer in sublayers {
-                fillColorForSubLayer(layer: subLayer, color: color, opacity: opacity)
-            }
-        }
-    }
-
-    func fillColor(color: UIColor, opacity: Float = 1.0) {
-        if let layer = caLayerTree {
-            fillColorForSubLayer(layer: layer, color: color, opacity: opacity)
         }
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterBlockView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterBlockView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import SVGKit
 
 struct BlockInserterBlockView: View {
     let block: BlockType


### PR DESCRIPTION
## What?
- Fix [CMM-873: SVG for icons for some blocks is invalid](https://linear.app/a8c/issue/CMM-873/svg-for-icons-for-some-blocks-is-invalid).
- Fix an issue with wpios/jpios failing to build due to some conflict with SVGKit

## How?

Switch to [SVGView](https://github.com/exyte/SVGView), which is a more modern framework, and as lenient as a browser when it comes to parsing SVG. It supports shorten coordinates like `5.5h3a.5.5` that are common in Gutenberg.

One of the design choices was to enforce a particular fill color (in order to support dark mode). It works great for nearly all icons, but I found only one exception so far – "Animoto Embed". This icon uses multiple colors, and doesn't look ideal (see screenshots below). We can simply hardcode a different icon for it if we want. **Note**: you need to merge https://github.com/wordpress-mobile/GutenbergKit/pull/204 to test the embed variants.

## Testing Instructions
- **Verify** that no blocks display placeholder icons
- **Verify** that icons work in dark mode

## Screenshots or screencast <!-- if applicable -->

<img width="360" alt="Screenshot 2025-10-27 at 6 21 21 PM" src="https://github.com/user-attachments/assets/89e7f60d-15b0-4aab-869b-ad8c21cbcf4c" />
<img width="360" alt="Screenshot 2025-10-27 at 6 21 27 PM" src="https://github.com/user-attachments/assets/c47adcfa-cfa4-4d1d-9a8a-470b8f9bb3a7" />

## Known Issues (Identified in the scope of this PR)

- [CMM-905: Remove "Pattern Placeholder"](https://linear.app/a8c/issue/CMM-905/remove-pattern-placeholder)
- [CMM-904: Add support for deprecated blocks](https://linear.app/a8c/issue/CMM-904/add-support-for-deprecated-blocks)

(these are fixed by https://github.com/wordpress-mobile/GutenbergKit/pull/199)

## Screenshots (`core/embed` variants)

Before:

<img width="360" alt="Screenshot 2025-10-27 at 4 21 24 PM" src="https://github.com/user-attachments/assets/e17596ba-d8f0-41b4-bdf3-11bbd2d2f5c6" />

After:
<img width="360"  alt="Screenshot 2025-10-27 at 6 26 02 PM" src="https://github.com/user-attachments/assets/b3712c3d-97ac-4836-bea5-a6a605a052b0" /> <img width="360" alt="Screenshot 2025-10-27 at 6 26 04 PM" src="https://github.com/user-attachments/assets/25b03f0e-cdc3-411f-8cd8-37c2c8cfc7a4" />

