### PR TITLE
Native Inserter: Improve ordering of blocks and more

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
@@ -67,7 +67,6 @@ struct EditorJSMessage {
     }
 
     struct ShowBlockInserterBody: Decodable {
-        let blocks: [BlockType]
-        let destinationBlockName: String?
+        let sections: [BlockInserterSection]
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -256,8 +256,7 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
 
         let host = UIHostingController(rootView: NavigationStack {
             BlockInserterView(
-                blocks: data.blocks,
-                destinationBlockName: data.destinationBlockName,
+                sections: data.sections,
                 mediaPicker: mediaPicker,
                 presentationContext: context,
                 onBlockSelected: { [weak self] block in

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterBlockView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterBlockView.swift
@@ -29,6 +29,7 @@ struct BlockInserterBlockView: View {
             .padding(.horizontal, 4)
         }
         .buttonStyle(.plain)
+        .disabled(block.isDisabled)
         .frame(maxWidth: .infinity, alignment: .center)
         .contextMenu {
             Button {

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterSectionView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterSectionView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct BlockInserterSection: Identifiable {
+struct BlockInserterSection: Identifiable, Decodable {
     var id: String { category }
     let category: String
     let name: String?

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterSectionView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterSectionView.swift
@@ -69,10 +69,11 @@ struct BlockInserterSectionView: View {
                 Text(isExpanded ? "Show Less" : "Show More")
                     .font(.subheadline)
                     .fontWeight(.medium)
+                    .foregroundStyle(Color.secondary)
                 Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                     .font(.caption)
+                    .foregroundStyle(Color.primary)
             }
-            .foregroundStyle(Color.primary)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 8)
         }

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterSectionView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterSectionView.swift
@@ -13,6 +13,20 @@ struct BlockInserterSectionView: View {
 
     @ScaledMetric(relativeTo: .largeTitle) private var miniumSize = 80
     @ScaledMetric(relativeTo: .largeTitle) private var padding = 20
+    @State private var isExpanded = false
+
+    private let initialDisplayCount = 16
+
+    private var displayedBlocks: [BlockType] {
+        if !isExpanded && section.blocks.count > initialDisplayCount {
+            return Array(section.blocks.prefix(initialDisplayCount))
+        }
+        return section.blocks
+    }
+
+    private var hasMoreBlocks: Bool {
+        section.blocks.count > initialDisplayCount
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -24,6 +38,9 @@ struct BlockInserterSectionView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
             grid
+            if hasMoreBlocks {
+                toggleButton
+            }
         }
         .padding(.top, section.name != nil ? 20 : 24)
         .padding(.bottom, 10)
@@ -32,12 +49,34 @@ struct BlockInserterSectionView: View {
 
     private var grid: some View {
         LazyVGrid(columns: [GridItem(.adaptive(minimum: miniumSize, maximum: miniumSize * 1.5), spacing: 0)]) {
-            ForEach(section.blocks) { block in
+            ForEach(displayedBlocks) { block in
                 BlockInserterBlockView(block: block) {
                     onBlockSelected(block)
                 }
             }
         }
+        .padding(.horizontal, 12)
+    }
+
+    private var toggleButton: some View {
+        Button {
+            withAnimation {
+                isExpanded.toggle()
+            }
+        } label: {
+            HStack {
+                // TODO: CMM-874 add localization
+                Text(isExpanded ? "Show Less" : "Show More")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.caption)
+            }
+            .foregroundStyle(Color.primary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.plain)
         .padding(.horizontal, 12)
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
@@ -3,8 +3,7 @@ import PhotosUI
 import UIKit
 
 struct BlockInserterView: View {
-    let blocks: [BlockType]
-    let destinationBlockName: String?
+    let sections: [BlockInserterSection]
     let mediaPicker: MediaPickerController?
     let presentationContext: MediaPickerPresentationContext
     let onBlockSelected: (BlockType) -> Void
@@ -18,21 +17,19 @@ struct BlockInserterView: View {
     @Environment(\.dismiss) private var dismiss
 
     init(
-        blocks: [BlockType],
-        destinationBlockName: String?,
+        sections: [BlockInserterSection],
         mediaPicker: MediaPickerController?,
         presentationContext: MediaPickerPresentationContext,
         onBlockSelected: @escaping (BlockType) -> Void,
         onMediaSelected: @escaping ([MediaInfo]) -> Void
     ) {
-        self.blocks = blocks
-        self.destinationBlockName = destinationBlockName
+        self.sections = sections
         self.mediaPicker = mediaPicker
         self.presentationContext = presentationContext
         self.onBlockSelected = onBlockSelected
         self.onMediaSelected = onMediaSelected
 
-        let viewModel = BlockInserterViewModel(blocks: blocks, destinationBlockName: destinationBlockName)
+        let viewModel = BlockInserterViewModel(sections: sections)
         self._viewModel = StateObject(wrappedValue: viewModel)
     }
 
@@ -97,8 +94,9 @@ struct BlockInserterView: View {
 #Preview {
     NavigationStack {
         BlockInserterView(
-            blocks: BlockType.mocks,
-            destinationBlockName: nil,
+            sections: [
+                BlockInserterSection(category: "text", name: "Text", blocks: BlockType.mocks)
+            ],
             mediaPicker: MockMediaPickerController(),
             presentationContext: MediaPickerPresentationContext(),
             onBlockSelected: {

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
@@ -47,110 +47,43 @@ class BlockInserterViewModel: ObservableObject {
 
     private static func createSections(from blocks: [BlockType], destinationBlockName: String?) -> [BlockInserterSection] {
         var sections: [BlockInserterSection] = []
+        var currentSection: BlockInserterSection?
 
-        // Separate contextual blocks (specifically allowed in current parent block)
-        // A block is contextual if the destination block name is in its parents array
-        let contextualBlocks = blocks.filter { block in
-            guard let destinationBlockName = destinationBlockName else { return false }
-            return !block.parents.isEmpty && block.parents.contains(destinationBlockName)
-        }
- 
-        // Add contextual section at the top if there are contextual blocks
-        if !contextualBlocks.isEmpty {
-            sections.append(BlockInserterSection(category: "gbk-contextual", name: nil, blocks: contextualBlocks))
-        }
+        // Blocks are already ordered and have section metadata from JS
+        // Simply iterate and create sections when the category changes
+        for block in blocks {
+            let category = block.sectionCategory ?? block.category?.lowercased() ?? "common"
+            let sectionName = block.sectionName
 
-        // Group regular blocks by category
-        let blocksByCategory = Dictionary(grouping: blocks) {
-            $0.category?.lowercased() ?? "common"
-        }
-
-        let categories = Constants.orderedCategories
-
-        // Add known categories in a predefined order
-        for (category, name) in categories {
-            if let blocks = blocksByCategory[category] {
-                let sortedBlocks = orderBlocks(blocks, category: category)
-                // Use nil for text category, otherwise use the display name
-                let displayName = (category == "text" && contextualBlocks.isEmpty) ? nil : name
-                sections.append(BlockInserterSection(category: category, name: displayName, blocks: sortedBlocks))
+            // Check if we need to start a new section
+            if let current = currentSection, current.category == category {
+                // Add block to current section
+                var updatedBlocks = current.blocks
+                updatedBlocks.append(block)
+                currentSection = BlockInserterSection(
+                    category: current.category,
+                    name: current.name,
+                    blocks: updatedBlocks
+                )
+            } else {
+                // Save previous section if it exists
+                if let current = currentSection {
+                    sections.append(current)
+                }
+                // Start new section
+                currentSection = BlockInserterSection(
+                    category: category,
+                    name: sectionName,
+                    blocks: [block]
+                )
             }
         }
 
-        // Add any remaining categories
-        for (category, blocks) in blocksByCategory {
-            let isStandardCategory = categories.contains { $0.key == category }
-            if !isStandardCategory {
-                sections.append(BlockInserterSection(category: category, name: category.capitalized, blocks: blocks))
-            }
+        // Add the last section
+        if let current = currentSection {
+            sections.append(current)
         }
 
         return sections
     }
-}
-
-// MARK: Ordering
-
-private func orderBlocks(_ blocks: [BlockType], category: String) -> [BlockType] {
-    switch category {
-    case "text":
-        return _orderBlocks(blocks, order: [
-            "core/paragraph",
-            "core/heading",
-            "core/list",
-            "core/list-item",
-            "core/quote",
-            "core/code",
-            "core/preformatted",
-            "core/verse",
-            "core/table"
-        ])
-    case "media":
-        return _orderBlocks(blocks, order: [
-            "core/image",
-            "core/video",
-            "core/gallery",
-            "core/embed",
-            "core/audio",
-            "core/file"
-        ])
-    case "design":
-        return _orderBlocks(blocks, order: [
-            "core/separator",
-            "core/spacer",
-            "core/columns",
-            "core/column"
-        ])
-    default:
-        return blocks
-    }
-}
-
-private func _orderBlocks(_ blocks: [BlockType], order: [String]) -> [BlockType] {
-    var orderedBlocks: [BlockType] = []
-
-    // Add blocks in a predefined order
-    for name in order {
-        if let block = blocks.first(where: { $0.name == name }) {
-            orderedBlocks.append(block)
-        }
-    }
-
-    // Add remaining blocks in their original order
-    let remainingBlocks = blocks.filter { block in
-        !order.contains(block.name)
-    }
-
-    return orderedBlocks + remainingBlocks
-}
-
-private enum Constants {
-    static let orderedCategories: [(key: String, displayName: String)] = [
-        ("text", "Text"),
-        ("media", "Media"),
-        ("design", "Design"),
-        ("widgets", "Widgets"),
-        ("theme", "Theme"),
-        ("embed", "Embeds")
-    ]
 }

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
@@ -7,19 +7,16 @@ class BlockInserterViewModel: ObservableObject {
     @Published var searchText = ""
     @Published private(set) var sections: [BlockInserterSection] = []
 
-    private let blocks: [BlockType]
     private let allSections: [BlockInserterSection]
     private var cancellables = Set<AnyCancellable>()
 
-    init(blocks: [BlockType], destinationBlockName: String?) {
-        self.blocks = blocks
-
-        self.allSections = BlockInserterViewModel.createSections(from: blocks, destinationBlockName: destinationBlockName)
-        self.sections = allSections
+    init(sections: [BlockInserterSection]) {
+        self.allSections = sections
+        self.sections = sections
 
         setupSearchObserver()
     }
-    
+
     private func setupSearchObserver() {
         $searchText
             .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
@@ -43,47 +40,5 @@ class BlockInserterViewModel: ObservableObject {
                 )
             }
         }
-    }
-
-    private static func createSections(from blocks: [BlockType], destinationBlockName: String?) -> [BlockInserterSection] {
-        var sections: [BlockInserterSection] = []
-        var currentSection: BlockInserterSection?
-
-        // Blocks are already ordered and have section metadata from JS
-        // Simply iterate and create sections when the category changes
-        for block in blocks {
-            let category = block.sectionCategory ?? block.category?.lowercased() ?? "common"
-            let sectionName = block.sectionName
-
-            // Check if we need to start a new section
-            if let current = currentSection, current.category == category {
-                // Add block to current section
-                var updatedBlocks = current.blocks
-                updatedBlocks.append(block)
-                currentSection = BlockInserterSection(
-                    category: current.category,
-                    name: current.name,
-                    blocks: updatedBlocks
-                )
-            } else {
-                // Save previous section if it exists
-                if let current = currentSection {
-                    sections.append(current)
-                }
-                // Start new section
-                currentSection = BlockInserterSection(
-                    category: category,
-                    name: sectionName,
-                    blocks: [block]
-                )
-            }
-        }
-
-        // Add the last section
-        if let current = currentSection {
-            sections.append(current)
-        }
-
-        return sections
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
@@ -12,8 +12,6 @@ class BlockInserterViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
 
     init(blocks: [BlockType], destinationBlockName: String?) {
-        let blocks = blocks.filter { $0.name != "core/missing" }
-
         self.blocks = blocks
 
         self.allSections = BlockInserterViewModel.createSections(from: blocks, destinationBlockName: destinationBlockName)

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockType.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockType.swift
@@ -15,6 +15,10 @@ struct BlockType: Decodable, Identifiable {
     var frecency: Double = 0.0
     var isDisabled = false
     var parents: [String] = []
+
+    // Section metadata provided by JavaScript
+    var sectionCategory: String?
+    var sectionName: String?
 }
 
 extension BlockType: Searchable {

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockType.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockType.swift
@@ -15,10 +15,6 @@ struct BlockType: Decodable, Identifiable {
     var frecency: Double = 0.0
     var isDisabled = false
     var parents: [String] = []
-
-    // Section metadata provided by JavaScript
-    var sectionCategory: String?
-    var sectionName: String?
 }
 
 extension BlockType: Searchable {

--- a/src/components/native-block-inserter-button/index.jsx
+++ b/src/components/native-block-inserter-button/index.jsx
@@ -81,7 +81,10 @@ export default function NativeBlockInserterButton() {
 	);
 
 	// Serialize blocks for native consumption
-	const blocks = serializeBlocksForNative( inserterItems );
+	const blocks = serializeBlocksForNative(
+		inserterItems,
+		destinationBlockName
+	);
 
 	// Expose the current inserter state globally for native access
 	// This automatically stays in sync with editor state via hooks

--- a/src/components/native-block-inserter-button/index.jsx
+++ b/src/components/native-block-inserter-button/index.jsx
@@ -74,16 +74,18 @@ export default function NativeBlockInserterButton() {
 		selectBlockOnInsert: true,
 	} );
 
-	const [ inserterItems, , , onSelectItem ] = useBlockTypesState(
+	const [ inserterItems, categories, , onSelectItem ] = useBlockTypesState(
 		destinationRootClientId,
 		onInsertBlocks,
 		false // isQuick
 	);
 
 	// Preprocess blocks into sections for native consumption
+	// Categories are passed to get localized category names
 	const sections = preprocessBlockTypesForNativeInserter(
 		inserterItems,
-		destinationBlockName
+		destinationBlockName,
+		categories
 	);
 
 	// Expose the current inserter state globally for native access
@@ -114,7 +116,7 @@ export default function NativeBlockInserterButton() {
 		return () => {
 			delete window.blockInserter;
 		};
-	}, [ sections, inserterItems, onSelectItem ] );
+	}, [ sections, inserterItems, categories, onSelectItem ] );
 
 	return (
 		<Button

--- a/src/components/native-block-inserter-button/index.jsx
+++ b/src/components/native-block-inserter-button/index.jsx
@@ -32,7 +32,7 @@ import useInsertionPoint from '@wordpress/block-editor/build-module/components/i
 import useBlockTypesState from '@wordpress/block-editor/build-module/components/inserter/hooks/use-block-types-state';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { debug } from '../../utils/logger';
-import { serializeBlocksForNative } from '../../utils/blocks';
+import { preprocessBlockTypesForNativeInserter } from '../../utils/blocks';
 import { showBlockInserter } from '../../utils/bridge';
 
 /**
@@ -80,8 +80,8 @@ export default function NativeBlockInserterButton() {
 		false // isQuick
 	);
 
-	// Serialize blocks for native consumption
-	const blocks = serializeBlocksForNative(
+	// Preprocess blocks into sections for native consumption
+	const sections = preprocessBlockTypesForNativeInserter(
 		inserterItems,
 		destinationBlockName
 	);
@@ -90,8 +90,7 @@ export default function NativeBlockInserterButton() {
 	// This automatically stays in sync with editor state via hooks
 	useEffect( () => {
 		window.blockInserter = {
-			blocks,
-			destinationBlockName,
+			sections,
 			insertBlock: ( blockId ) => {
 				const item = inserterItems.find( ( i ) => i.id === blockId );
 				if ( ! item ) {
@@ -115,7 +114,7 @@ export default function NativeBlockInserterButton() {
 		return () => {
 			delete window.blockInserter;
 		};
-	}, [ blocks, destinationBlockName, inserterItems, onSelectItem ] );
+	}, [ sections, inserterItems, onSelectItem ] );
 
 	return (
 		<Button

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -66,21 +66,115 @@ export function getBlockIcon( item ) {
 }
 
 /**
+ * Predefined category ordering.
+ */
+const ORDERED_CATEGORIES = [
+	{ key: 'text', displayName: 'Text' },
+	{ key: 'media', displayName: 'Media' },
+	{ key: 'design', displayName: 'Design' },
+	{ key: 'widgets', displayName: 'Widgets' },
+	{ key: 'theme', displayName: 'Theme' },
+	{ key: 'embed', displayName: 'Embeds' },
+];
+
+/**
+ * Predefined block ordering within categories.
+ */
+const BLOCK_ORDER_BY_CATEGORY = {
+	text: [
+		'core/paragraph',
+		'core/heading',
+		'core/list',
+		'core/list-item',
+		'core/quote',
+		'core/code',
+		'core/preformatted',
+		'core/verse',
+		'core/table',
+	],
+	media: [
+		'core/image',
+		'core/video',
+		'core/gallery',
+		'core/embed',
+		'core/audio',
+		'core/file',
+	],
+	design: [
+		'core/separator',
+		'core/spacer',
+		'core/columns',
+		'core/column',
+	],
+};
+
+/**
+ * Most used blocks to show when there are no contextual blocks.
+ */
+const MOST_USED_BLOCKS = [
+	'core/paragraph',
+	'core/heading',
+	'core/list',
+	'core/quote',
+];
+
+/**
+ * Orders blocks within a category according to predefined ordering.
+ *
+ * @param {Array}  blocks   Blocks to order.
+ * @param {string} category Category key.
+ *
+ * @return {Array} Ordered blocks.
+ */
+function orderBlocksInCategory( blocks, category ) {
+	const order = BLOCK_ORDER_BY_CATEGORY[ category ];
+	if ( ! order ) {
+		return blocks;
+	}
+
+	const orderedBlocks = [];
+
+	// Add blocks in predefined order
+	for ( const name of order ) {
+		const block = blocks.find( ( b ) => b.name === name );
+		if ( block ) {
+			orderedBlocks.push( block );
+		}
+	}
+
+	// Add remaining blocks in their original order
+	const remainingBlocks = blocks.filter(
+		( block ) => ! order.includes( block.name )
+	);
+
+	return [ ...orderedBlocks, ...remainingBlocks ];
+}
+
+/**
  * Serializes inserter items to a format suitable for native consumption.
  * Extracts only the properties needed by the native side and ensures
  * proper formatting (e.g., converting React icon elements to SVG strings).
+ *
+ * This function also handles ordering of blocks by category and within categories,
+ * as well as creating a contextual section for blocks that are specifically allowed
+ * in the current parent block.
  *
  * WARNING: This function eliminates 90+% of JSON payload by compacting
  * otherwise duplicated block variants. Do not add unnecessary properties
  * or modify the compact format without careful consideration of the
  * performance impact on the native bridge.
  *
- * @param {Array} inserterItems Array of block inserter items from WordPress.
+ * @param {Array}  inserterItems        Array of block inserter items from WordPress.
+ * @param {string} destinationBlockName Name of the parent block where new blocks will be inserted.
  *
- * @return {Array} Array of serialized block objects for native consumption.
+ * @return {Array} Array of serialized block objects for native consumption, ordered and with section metadata.
  */
-export function serializeBlocksForNative( inserterItems ) {
-	return inserterItems.map( ( item ) => {
+export function serializeBlocksForNative(
+	inserterItems,
+	destinationBlockName = null
+) {
+	// First, serialize all blocks
+	const serializedBlocks = inserterItems.map( ( item ) => {
 		return {
 			id: item.id,
 			name: item.name,
@@ -94,4 +188,84 @@ export function serializeBlocksForNative( inserterItems ) {
 			parents: item.parent || [],
 		};
 	} );
+
+	// Separate contextual blocks (specifically allowed in current parent block)
+	const contextualBlocks = serializedBlocks.filter( ( block ) => {
+		if ( ! destinationBlockName ) {
+			return false;
+		}
+		return (
+			block.parents.length > 0 &&
+			block.parents.includes( destinationBlockName )
+		);
+	} );
+
+	// Determine blocks to show in contextual section
+	const contextualSectionBlocks =
+		contextualBlocks.length > 0
+			? contextualBlocks
+			: serializedBlocks.filter( ( block ) =>
+					MOST_USED_BLOCKS.includes( block.name )
+			  );
+
+	// Group regular blocks by category
+	const blocksByCategory = {};
+	for ( const block of serializedBlocks ) {
+		const category = block.category?.toLowerCase() || 'common';
+		if ( ! blocksByCategory[ category ] ) {
+			blocksByCategory[ category ] = [];
+		}
+		blocksByCategory[ category ].push( block );
+	}
+
+	const result = [];
+
+	// Add contextual section
+	const hasContextualBlocks = contextualBlocks.length > 0;
+	for ( const block of contextualSectionBlocks ) {
+		result.push( {
+			...block,
+			sectionCategory: 'gbk-contextual',
+			sectionName: null,
+		} );
+	}
+
+	// Add blocks by category in predefined order
+	for ( const { key: category, displayName } of ORDERED_CATEGORIES ) {
+		const blocks = blocksByCategory[ category ];
+		if ( blocks ) {
+			const orderedBlocks = orderBlocksInCategory( blocks, category );
+			// Use null for text category name if no contextual blocks, otherwise use display name
+			const sectionName =
+				category === 'text' && ! hasContextualBlocks
+					? null
+					: displayName;
+
+			for ( const block of orderedBlocks ) {
+				result.push( {
+					...block,
+					sectionCategory: category,
+					sectionName,
+				} );
+			}
+		}
+	}
+
+	// Add any remaining categories
+	const knownCategories = ORDERED_CATEGORIES.map( ( c ) => c.key );
+	for ( const [ category, blocks ] of Object.entries( blocksByCategory ) ) {
+		if ( ! knownCategories.includes( category ) ) {
+			for ( const block of blocks ) {
+				result.push( {
+					...block,
+					sectionCategory: category,
+					sectionName:
+						category.charAt( 0 ).toUpperCase() +
+						category.slice( 1 ),
+				} );
+			}
+		}
+	}
+
+	return result;
 }

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -222,7 +222,6 @@ export function preprocessBlockTypesForNativeInserter(
 	const sections = [];
 
 	// Add contextual section
-	const hasContextualBlocks = contextualBlocks.length > 0;
 	if ( contextualSectionBlocks.length > 0 ) {
 		sections.push( {
 			category: 'gbk-contextual',
@@ -236,15 +235,10 @@ export function preprocessBlockTypesForNativeInserter(
 		const blocks = blocksByCategory[ category ];
 		if ( blocks ) {
 			const orderedBlocks = orderBlocksInCategory( blocks, category );
-			// Use null for text category name if no contextual blocks, otherwise use display name
-			const sectionName =
-				category === 'text' && ! hasContextualBlocks
-					? null
-					: displayName;
 
 			sections.push( {
 				category,
-				name: sectionName,
+				name: displayName,
 				blocks: orderedBlocks,
 			} );
 		}

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -111,12 +111,25 @@ const BLOCK_ORDER_BY_CATEGORY = {
 
 /**
  * Most used blocks to show when there are no contextual blocks.
+ * Optimized for mobile usage patterns where users frequently create content
+ * with text, media from device cameras, and visual formatting.
  */
 const MOST_USED_BLOCKS = [
+	// Fundamentals
 	'core/paragraph',
 	'core/heading',
 	'core/list',
 	'core/quote',
+	// Layout and more
+	'core/table',
+	'core/separator',
+	'core/code',
+	'core/preformatted',
+	// Media blocks - very popular on mobile (camera/photo usage)
+	'core/image',
+	'core/gallery',
+	'core/video',
+	'core/embed',
 ];
 
 /**
@@ -219,12 +232,19 @@ export function preprocessBlockTypesForNativeInserter(
 	} );
 
 	// Determine blocks to show in contextual section
-	const contextualSectionBlocks =
-		contextualBlocks.length > 0
-			? contextualBlocks
-			: serializedBlocks.filter( ( block ) =>
-					MOST_USED_BLOCKS.includes( block.name )
-			  );
+	let contextualSectionBlocks;
+	if ( contextualBlocks.length > 0 ) {
+		contextualSectionBlocks = contextualBlocks;
+	} else {
+		// Show most-used blocks in the order specified by MOST_USED_BLOCKS
+		contextualSectionBlocks = [];
+		for ( const blockName of MOST_USED_BLOCKS ) {
+			const block = serializedBlocks.find( ( b ) => b.name === blockName );
+			if ( block ) {
+				contextualSectionBlocks.push( block );
+			}
+		}
+	}
 
 	// Group regular blocks by category
 	const blocksByCategory = {};

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -231,18 +231,12 @@ export function preprocessBlockTypesForNativeInserter(
 		);
 	} );
 
-	// Determine blocks to show in contextual section
-	let contextualSectionBlocks;
-	if ( contextualBlocks.length > 0 ) {
-		contextualSectionBlocks = contextualBlocks;
-	} else {
-		// Show most-used blocks in the order specified by MOST_USED_BLOCKS
-		contextualSectionBlocks = [];
-		for ( const blockName of MOST_USED_BLOCKS ) {
-			const block = serializedBlocks.find( ( b ) => b.name === blockName );
-			if ( block ) {
-				contextualSectionBlocks.push( block );
-			}
+	// Build most-used blocks in the order specified by MOST_USED_BLOCKS
+	const mostUsedBlocks = [];
+	for ( const blockName of MOST_USED_BLOCKS ) {
+		const block = serializedBlocks.find( ( b ) => b.name === blockName );
+		if ( block ) {
+			mostUsedBlocks.push( block );
 		}
 	}
 
@@ -258,12 +252,21 @@ export function preprocessBlockTypesForNativeInserter(
 
 	const sections = [];
 
-	// Add contextual section
-	if ( contextualSectionBlocks.length > 0 ) {
+	// Add contextual section (only if there are parent-based contextual blocks)
+	if ( contextualBlocks.length > 0 ) {
 		sections.push( {
 			category: 'gbk-contextual',
 			name: null,
-			blocks: contextualSectionBlocks,
+			blocks: contextualBlocks,
+		} );
+	}
+
+	// Add most-used section (always shown)
+	if ( mostUsedBlocks.length > 0 ) {
+		sections.push( {
+			category: 'gbk-most-used',
+			name: null,
+			blocks: mostUsedBlocks,
 		} );
 	}
 

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -107,6 +107,20 @@ const BLOCK_ORDER_BY_CATEGORY = {
 		'core/columns',
 		'core/column',
 	],
+	embed: [
+		'core/embed', // Generic embed - always first
+		'core/embed/youtube',
+		'core/embed/vimeo',
+		'core/embed/tiktok',
+		'core/embed/wordpress',
+		'core/embed/tumblr',
+		'core/embed/videopress',
+		'core/embed/pocket-casts',
+		'core/embed/reddit',
+		'core/embed/pinterest',
+		'core/embed/spotify',
+		'core/embed/soundcloud',
+	],
 };
 
 /**
@@ -148,9 +162,9 @@ function orderBlocksInCategory( blocks, category ) {
 
 	const orderedBlocks = [];
 
-	// Add blocks in predefined order
-	for ( const name of order ) {
-		const block = blocks.find( ( b ) => b.name === name );
+	// Add blocks in predefined order (using block ID for matching)
+	for ( const id of order ) {
+		const block = blocks.find( ( b ) => b.id === id );
 		if ( block ) {
 			orderedBlocks.push( block );
 		}
@@ -158,7 +172,7 @@ function orderBlocksInCategory( blocks, category ) {
 
 	// Add remaining blocks in their original order
 	const remainingBlocks = blocks.filter(
-		( block ) => ! order.includes( block.name )
+		( block ) => ! order.includes( block.id )
 	);
 
 	return [ ...orderedBlocks, ...remainingBlocks ];

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -70,6 +70,11 @@ export function getBlockIcon( item ) {
  * Extracts only the properties needed by the native side and ensures
  * proper formatting (e.g., converting React icon elements to SVG strings).
  *
+ * WARNING: This function eliminates 90+% of JSON payload by compacting
+ * otherwise duplicated block variants. Do not add unnecessary properties
+ * or modify the compact format without careful consideration of the
+ * performance impact on the native bridge.
+ *
  * @param {Array} inserterItems Array of block inserter items from WordPress.
  *
  * @return {Array} Array of serialized block objects for native consumption.

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -101,12 +101,7 @@ const BLOCK_ORDER_BY_CATEGORY = {
 		'core/audio',
 		'core/file',
 	],
-	design: [
-		'core/separator',
-		'core/spacer',
-		'core/columns',
-		'core/column',
-	],
+	design: [ 'core/separator', 'core/spacer', 'core/columns', 'core/column' ],
 	embed: [
 		'core/embed', // Generic embed - always first
 		'core/embed/youtube',
@@ -215,7 +210,9 @@ export function preprocessBlockTypesForNativeInserter(
 	// Create ordered categories list with localized names
 	const orderedCategories = ORDERED_CATEGORIES.map( ( { key } ) => ( {
 		key,
-		displayName: categoryMap[ key ] || key.charAt( 0 ).toUpperCase() + key.slice( 1 ),
+		displayName:
+			categoryMap[ key ] ||
+			key.charAt( 0 ).toUpperCase() + key.slice( 1 ),
 	} ) );
 
 	// First, serialize all blocks

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -67,14 +67,15 @@ export function getBlockIcon( item ) {
 
 /**
  * Predefined category ordering.
+ * Display names will be retrieved from WordPress categories for proper localization.
  */
 const ORDERED_CATEGORIES = [
-	{ key: 'text', displayName: 'Text' },
-	{ key: 'media', displayName: 'Media' },
-	{ key: 'design', displayName: 'Design' },
-	{ key: 'widgets', displayName: 'Widgets' },
-	{ key: 'theme', displayName: 'Theme' },
-	{ key: 'embed', displayName: 'Embeds' },
+	{ key: 'text' },
+	{ key: 'media' },
+	{ key: 'design' },
+	{ key: 'widgets' },
+	{ key: 'theme' },
+	{ key: 'embed' },
 ];
 
 /**
@@ -159,6 +160,7 @@ function orderBlocksInCategory( blocks, category ) {
  * - Creating a contextual section for blocks specifically allowed in the current parent
  * - Falling back to most-used blocks when no contextual blocks exist
  * - Serializing block data to a compact format for the native bridge
+ * - Using localized category names from WordPress
  *
  * WARNING: This function eliminates 90+% of JSON payload by compacting
  * otherwise duplicated block variants. Do not add unnecessary properties
@@ -167,13 +169,28 @@ function orderBlocksInCategory( blocks, category ) {
  *
  * @param {Array}  inserterItems        Array of block inserter items from WordPress.
  * @param {string} destinationBlockName Name of the parent block where new blocks will be inserted.
+ * @param {Array}  categories           Array of category objects from WordPress with localized titles.
  *
  * @return {Array} Array of sections, each containing category, name, and blocks array.
  */
 export function preprocessBlockTypesForNativeInserter(
 	inserterItems,
-	destinationBlockName = null
+	destinationBlockName = null,
+	categories = []
 ) {
+	// Build category map with localized names from WordPress
+	// Falls back to hardcoded names if categories not provided
+	const categoryMap = {};
+	for ( const category of categories ) {
+		categoryMap[ category.slug ] = category.title;
+	}
+
+	// Create ordered categories list with localized names
+	const orderedCategories = ORDERED_CATEGORIES.map( ( { key } ) => ( {
+		key,
+		displayName: categoryMap[ key ] || key.charAt( 0 ).toUpperCase() + key.slice( 1 ),
+	} ) );
+
 	// First, serialize all blocks
 	const serializedBlocks = inserterItems.map( ( item ) => {
 		return {
@@ -231,7 +248,7 @@ export function preprocessBlockTypesForNativeInserter(
 	}
 
 	// Add blocks by category in predefined order
-	for ( const { key: category, displayName } of ORDERED_CATEGORIES ) {
+	for ( const { key: category, displayName } of orderedCategories ) {
 		const blocks = blocksByCategory[ category ];
 		if ( blocks ) {
 			const orderedBlocks = orderBlocksInCategory( blocks, category );
@@ -244,13 +261,15 @@ export function preprocessBlockTypesForNativeInserter(
 		}
 	}
 
-	// Add any remaining categories
-	const knownCategories = ORDERED_CATEGORIES.map( ( c ) => c.key );
+	// Add any remaining categories with localized names if available
+	const knownCategories = orderedCategories.map( ( c ) => c.key );
 	for ( const [ category, blocks ] of Object.entries( blocksByCategory ) ) {
 		if ( ! knownCategories.includes( category ) ) {
 			sections.push( {
 				category,
-				name: category.charAt( 0 ).toUpperCase() + category.slice( 1 ),
+				name:
+					categoryMap[ category ] ||
+					category.charAt( 0 ).toUpperCase() + category.slice( 1 ),
 				blocks,
 			} );
 		}

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -151,13 +151,14 @@ function orderBlocksInCategory( blocks, category ) {
 }
 
 /**
- * Serializes inserter items to a format suitable for native consumption.
- * Extracts only the properties needed by the native side and ensures
- * proper formatting (e.g., converting React icon elements to SVG strings).
+ * Preprocesses inserter items for the native block inserter.
+ * Organizes blocks into sections with proper ordering and contextual filtering.
  *
- * This function also handles ordering of blocks by category and within categories,
- * as well as creating a contextual section for blocks that are specifically allowed
- * in the current parent block.
+ * This function handles:
+ * - Ordering blocks by category and within categories
+ * - Creating a contextual section for blocks specifically allowed in the current parent
+ * - Falling back to most-used blocks when no contextual blocks exist
+ * - Serializing block data to a compact format for the native bridge
  *
  * WARNING: This function eliminates 90+% of JSON payload by compacting
  * otherwise duplicated block variants. Do not add unnecessary properties
@@ -167,9 +168,9 @@ function orderBlocksInCategory( blocks, category ) {
  * @param {Array}  inserterItems        Array of block inserter items from WordPress.
  * @param {string} destinationBlockName Name of the parent block where new blocks will be inserted.
  *
- * @return {Array} Array of serialized block objects for native consumption, ordered and with section metadata.
+ * @return {Array} Array of sections, each containing category, name, and blocks array.
  */
-export function serializeBlocksForNative(
+export function preprocessBlockTypesForNativeInserter(
 	inserterItems,
 	destinationBlockName = null
 ) {
@@ -218,15 +219,15 @@ export function serializeBlocksForNative(
 		blocksByCategory[ category ].push( block );
 	}
 
-	const result = [];
+	const sections = [];
 
 	// Add contextual section
 	const hasContextualBlocks = contextualBlocks.length > 0;
-	for ( const block of contextualSectionBlocks ) {
-		result.push( {
-			...block,
-			sectionCategory: 'gbk-contextual',
-			sectionName: null,
+	if ( contextualSectionBlocks.length > 0 ) {
+		sections.push( {
+			category: 'gbk-contextual',
+			name: null,
+			blocks: contextualSectionBlocks,
 		} );
 	}
 
@@ -241,13 +242,11 @@ export function serializeBlocksForNative(
 					? null
 					: displayName;
 
-			for ( const block of orderedBlocks ) {
-				result.push( {
-					...block,
-					sectionCategory: category,
-					sectionName,
-				} );
-			}
+			sections.push( {
+				category,
+				name: sectionName,
+				blocks: orderedBlocks,
+			} );
 		}
 	}
 
@@ -255,17 +254,13 @@ export function serializeBlocksForNative(
 	const knownCategories = ORDERED_CATEGORIES.map( ( c ) => c.key );
 	for ( const [ category, blocks ] of Object.entries( blocksByCategory ) ) {
 		if ( ! knownCategories.includes( category ) ) {
-			for ( const block of blocks ) {
-				result.push( {
-					...block,
-					sectionCategory: category,
-					sectionName:
-						category.charAt( 0 ).toUpperCase() +
-						category.slice( 1 ),
-				} );
-			}
+			sections.push( {
+				category,
+				name: category.charAt( 0 ).toUpperCase() + category.slice( 1 ),
+				blocks,
+			} );
 		}
 	}
 
-	return result;
+	return sections;
 }

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -93,6 +93,9 @@ export function onBlocksChanged( isEmpty = false ) {
  * at window.blockInserter, which automatically stays in sync with the editor
  * via WordPress hooks (useInsertionPoint and useBlockTypesState).
  *
+ * The sections array is preprocessed by preprocessBlockTypesForNativeInserter()
+ * which handles ordering, contextual filtering, and localized section names.
+ *
  * @return {void}
  */
 export function showBlockInserter() {
@@ -103,12 +106,9 @@ export function showBlockInserter() {
 		return;
 	}
 
-	// Send blocks and destination block name to native
-	// The native side will use destinationBlockName to determine contextual blocks
-	// based on the block.parents field
+	// Send preprocessed sections to native
 	dispatchToBridge( 'showBlockInserter', {
-		blocks: window.blockInserter.blocks,
-		destinationBlockName: window.blockInserter.destinationBlockName,
+		sections: window.blockInserter.sections,
 	} );
 }
 


### PR DESCRIPTION
## What?
Closes [CMM-875: Establish the mobile-specific order for blocks](https://linear.app/a8c/issue/CMM-875/establish-the-mobile-specific-order-for-blocks).

## How?
- Refactor the inserter by moving grouping, ordering, contextual blocks, and more from Swift to JS
- Add support for [disabled](https://developer.wordpress.org/news/2024/01/how-to-disable-specific-blocks-in-wordpress/) blocks (`isDisabled`)
- Add "Show More" for sections with more than 16 blocks
- Remove hardcoded `core/missing` block support (no longer needed since https://github.com/wordpress-mobile/GutenbergKit/pull/199)
- Add `MOST_USED_BLOCKS` section (`gbk-most-used`)

## Screenshots or screencast

**Note**: screenshots are pre https://github.com/wordpress-mobile/GutenbergKit/pull/205

<img width="360"  alt="Screenshot 2025-10-29 at 12 42 48 PM" src="https://github.com/user-attachments/assets/ac2eea63-d441-4b6b-9e14-fcba9ef562a3" />
<img width="360" alt="Screenshot 2025-10-29 at 12 43 36 PM" src="https://github.com/user-attachments/assets/9f4abae0-1320-4175-868a-064785345807" />
licable -->
