### PR TITLE
test: Prevent log noise in results

### DIFF
--- a/src/utils/editor.test.jsx
+++ b/src/utils/editor.test.jsx
@@ -59,6 +59,7 @@ describe( 'initializeEditor', () => {
 			themeStyles: true,
 			hideTitle: false,
 			editorSettings: null,
+			logLevel: 'INFO',
 		} );
 		getPost.mockReturnValue( {
 			id: 1,
@@ -98,6 +99,7 @@ describe( 'initializeEditor', () => {
 			themeStyles: false,
 			hideTitle: false,
 			editorSettings: null,
+			logLevel: 'INFO',
 		} );
 
 		initializeEditor();
@@ -127,6 +129,7 @@ describe( 'initializeEditor', () => {
 			themeStyles: true,
 			hideTitle: false,
 			editorSettings: customSettings,
+			logLevel: 'INFO',
 		} );
 
 		initializeEditor();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Reduce noise in test output.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Follow up to #202. 

The absence of a mocked log level resulted in unnecessary noise in test
logs:

```
Invalid log level: 2. Using default level INFO.
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Set mocked log level in tests.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
`npm test` should not log warnings about log levels.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
