### PR TITLE
feat: Enable image resizing on mobile devices

### DIFF
--- a/patches/@wordpress+block-library+9.22.0.patch
+++ b/patches/@wordpress+block-library+9.22.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@wordpress/block-library/build-module/image/image.js b/node_modules/@wordpress/block-library/build-module/image/image.js
+index 473b653..8a52e9e 100644
+--- a/node_modules/@wordpress/block-library/build-module/image/image.js
++++ b/node_modules/@wordpress/block-library/build-module/image/image.js
+@@ -282,7 +282,7 @@ export default function Image({
+   const [hasImageErrored, setHasImageErrored] = useState(false);
+   const hasNonContentControls = blockEditingMode === 'default';
+   const isContentOnlyMode = blockEditingMode === 'contentOnly';
+-  const isResizable = allowResize && hasNonContentControls && !isWideAligned && isLargeViewport;
++  const isResizable = allowResize && hasNonContentControls && !isWideAligned;
+   const imageSizeOptions = imageSizes.filter(({
+     slug
+   }) => image?.media_details?.sizes?.[slug]?.source_url).map(({

--- a/patches/README.md
+++ b/patches/README.md
@@ -12,6 +12,10 @@ Existing patches should be described and justified here.
 -   Disable `stripExperimentalSettings` in the `BlockEditorProvider` component so that the Patterns and Media inserter tabs function.
 -   Allow setting popover props for the `Inserter` component, so we can improve the mobile screen reader experience by marking it as a modal dialog.
 
+### `@wordpress/block-library`
+
+-   Enable image resizing on mobile devices by removing the `isLargeViewport` check from the `isResizable` condition in the `Image` component. The resizing feature appears to work well enough now, in contrast to the description in https://github.com/WordPress/gutenberg/issues/2675.
+
 ### `@wordpress/components`
 
 -   Apply workaround to `FormFileUpload` to address iOS Safari's lack of support for a wildcard `audio/*` MIME type. Can be removed once [the issue](https://github.com/WordPress/gutenberg/issues/70119) is resolved in a future release.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allow resizing images on mobile. This reverts explicit disabling of the feature in Gutenberg based on reports in
https://github.com/WordPress/gutenberg/issues/2675.

The resizing feature appears to work well enough today. We should contribute this change upstream.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close CMM-196. Avoid unnecessarily limiting the UX for mobile devices. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add a package patch removing the `isLargeViewport` requirement for resizing images. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add an Image block. 
2. Attach media. 
3. Resize the image with drag handles; change the dimension fields within the block inspector.
4. **Verify** the rendered block is accurate, that the block attributes are saved as expected. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes. 

## Screenshots or screencast <!-- if applicable -->
Before | After
-- | --
![before-image](https://github.com/user-attachments/assets/122e7e19-7d25-4c68-ac1c-2e9b31ee5eed) | ![after-image](https://github.com/user-attachments/assets/c8b7eb8c-c159-4375-a453-34ab4cc0b54a)
![before-controls](https://github.com/user-attachments/assets/5e220ff4-f693-427a-8bf1-948d3e4e8009) | ![after-controls](https://github.com/user-attachments/assets/5e9fb8a5-12a4-48bb-9eaa-3a6efe3ba588)


