### PR TITLE
feat: Block toolbar indicates scrollable area

### DIFF
--- a/src/components/editor-toolbar/index.jsx
+++ b/src/components/editor-toolbar/index.jsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 import {
 	BlockInspector,
 	BlockToolbar,
@@ -29,6 +29,7 @@ import { useModalize } from './use-modalize';
 import { useModalDialogState } from '../editor/use-modal-dialog-state';
 import { getGBKit } from '../../utils/bridge';
 import NativeBlockInserterButton from '../native-block-inserter-button';
+import { useScrollIndicators } from './use-scroll-indicators';
 
 /**
  * Renders the editor toolbar containing block-related actions.
@@ -39,6 +40,10 @@ import NativeBlockInserterButton from '../native-block-inserter-button';
  */
 const EditorToolbar = ( { className } ) => {
 	const { enableNativeBlockInserter } = getGBKit();
+
+	const scrollViewRef = useRef();
+	const { canScrollLeft, canScrollRight } =
+		useScrollIndicators( scrollViewRef );
 
 	const [ isBlockInspectorShown, setBlockInspectorShown ] = useState( false );
 	const { isSelected } = useSelect( ( select ) => {
@@ -81,6 +86,14 @@ const EditorToolbar = ( { className } ) => {
 
 	const classes = clsx( 'gutenberg-kit-editor-toolbar', className );
 
+	const scrollViewClasses = clsx(
+		'gutenberg-kit-editor-toolbar__scroll-view',
+		{
+			'has-scroll-left': canScrollLeft,
+			'has-scroll-right': canScrollRight,
+		}
+	);
+
 	const addBlockButton = enableNativeBlockInserter ? (
 		<NativeBlockInserterButton />
 	) : (
@@ -96,25 +109,28 @@ const EditorToolbar = ( { className } ) => {
 
 	return (
 		<>
-			<Toolbar
-				className={ classes }
-				label="Editor toolbar"
-				variant="unstyled"
-			>
-				<ToolbarGroup>{ addBlockButton }</ToolbarGroup>
+			<div className={ classes }>
+				<Toolbar
+					label="Editor toolbar"
+					variant="unstyled"
+					ref={ scrollViewRef }
+					className={ scrollViewClasses }
+				>
+					<ToolbarGroup>{ addBlockButton }</ToolbarGroup>
 
-				{ isSelected && (
-					<ToolbarGroup>
-						<ToolbarButton
-							title={ __( 'Block Settings' ) }
-							icon={ cog }
-							onClick={ openSettings }
-						/>
-					</ToolbarGroup>
-				) }
+					{ isSelected && (
+						<ToolbarGroup>
+							<ToolbarButton
+								title={ __( 'Block Settings' ) }
+								icon={ cog }
+								onClick={ openSettings }
+							/>
+						</ToolbarGroup>
+					) }
 
-				<BlockToolbar hideDragHandle />
-			</Toolbar>
+					<BlockToolbar hideDragHandle />
+				</Toolbar>
+			</div>
 
 			{ isBlockInspectorShown && (
 				<Popover

--- a/src/components/editor-toolbar/style.scss
+++ b/src/components/editor-toolbar/style.scss
@@ -3,8 +3,9 @@
 $border-color: #c8c7cc;
 $border-radius: 2px;
 $min-touch-target-size: 46px;
+$scroll-indicator-elevation: 32;
 
-.gutenberg-kit-editor-toolbar.is-unstyled {
+.gutenberg-kit-editor-toolbar {
 	background-color: wordpress.$white;
 	border-bottom: none;
 	border-left: none;
@@ -19,9 +20,72 @@ $min-touch-target-size: 46px;
 	width: auto;
 }
 
-// Hide the scrollbar in the toolbar
-.gutenberg-kit-editor-toolbar::-webkit-scrollbar {
-	display: none;
+.gutenberg-kit-editor-toolbar__scroll-view {
+	display: flex;
+	align-items: center;
+	overflow-x: auto;
+	width: 100%;
+
+	// Prevent toolbar from shrinking
+	> .components-accessible-toolbar {
+		flex-shrink: 0;
+	}
+
+	// Hide scrollbar
+	&::-webkit-scrollbar {
+		display: none;
+	}
+
+	// Scroll indicator gradients
+	// Left gradient - shows when there's content to scroll left
+	&::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		width: 32px;
+		background: linear-gradient(
+			to right,
+			rgba(255, 255, 255, 1) 0%,
+			rgba(255, 255, 255, 0.95) 20%,
+			rgba(255, 255, 255, 0) 100%
+		);
+		pointer-events: none;
+		z-index: $scroll-indicator-elevation;
+		opacity: 0;
+		transition: opacity 0.2s ease-in-out;
+	}
+
+	// Right gradient - shows when there's content to scroll right
+	&::after {
+		content: "";
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		width: 32px;
+		background: linear-gradient(
+			to left,
+			rgba(255, 255, 255, 1) 0%,
+			rgba(255, 255, 255, 0.95) 20%,
+			rgba(255, 255, 255, 0) 100%
+		);
+		pointer-events: none;
+		z-index: $scroll-indicator-elevation;
+		opacity: 0;
+		transition: opacity 0.2s ease-in-out;
+	}
+
+	// Show left gradient when can scroll left
+	&.has-scroll-left::before {
+		opacity: 1;
+	}
+
+	// Show right gradient when can scroll right
+	&.has-scroll-right::after {
+		opacity: 1;
+	}
 }
 
 .gutenberg-kit-editor-toolbar .components-toolbar-group {

--- a/src/components/editor-toolbar/use-scroll-indicators.js
+++ b/src/components/editor-toolbar/use-scroll-indicators.js
@@ -1,0 +1,70 @@
+/**
+ * Hook to manage scroll indicator state for horizontally scrollable containers.
+ *
+ * @param {Object} scrollRef - React ref to the scrollable container element
+ * @return {Object} Scroll state with properties:
+ *   - isScrollable: Whether the container has overflow content
+ *   - canScrollLeft: Whether there's content to the left (not at start)
+ *   - canScrollRight: Whether there's content to the right (not at end)
+ */
+
+import { useState, useEffect, useCallback } from '@wordpress/element';
+
+export function useScrollIndicators( scrollRef ) {
+	const [ scrollState, setScrollState ] = useState( {
+		isScrollable: false,
+		canScrollLeft: false,
+		canScrollRight: false,
+	} );
+
+	const updateScrollState = useCallback( () => {
+		const element = scrollRef.current;
+		if ( ! element ) {
+			return;
+		}
+
+		const { scrollLeft, scrollWidth, clientWidth } = element;
+
+		// Small threshold to account for rounding errors
+		const threshold = 1;
+
+		const isScrollable = scrollWidth > clientWidth;
+		const canScrollLeft = scrollLeft > threshold;
+		const canScrollRight =
+			scrollLeft + clientWidth < scrollWidth - threshold;
+
+		setScrollState( {
+			isScrollable,
+			canScrollLeft,
+			canScrollRight,
+		} );
+	}, [ scrollRef ] );
+
+	useEffect( () => {
+		const element = scrollRef.current;
+		if ( ! element ) {
+			return;
+		}
+
+		updateScrollState(); // Initial state
+
+		element.addEventListener( 'scroll', updateScrollState );
+		window.addEventListener( 'resize', updateScrollState );
+
+		let resizeObserver;
+		if ( typeof ResizeObserver !== 'undefined' ) {
+			resizeObserver = new ResizeObserver( updateScrollState );
+			resizeObserver.observe( element );
+		}
+
+		return () => {
+			element.removeEventListener( 'scroll', updateScrollState );
+			window.removeEventListener( 'resize', updateScrollState );
+			if ( resizeObserver ) {
+				resizeObserver.disconnect();
+			}
+		};
+	}, [ scrollRef, updateScrollState ] );
+
+	return scrollState;
+}

--- a/src/components/visual-editor/style.scss
+++ b/src/components/visual-editor/style.scss
@@ -77,10 +77,8 @@
 }
 
 .gutenberg-kit-visual-editor__toolbar {
-	align-items: center;
 	bottom: 0;
 	left: 0;
-	overflow-x: auto;
 	position: fixed;
 	right: 0;
 	z-index: 40; // Ensure the toolbar is above the block canvas and its controls


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Indicate the block toolbar is scrollable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close CMM-924. Mitigate confusion regarding the number of options within the
block toolbar.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add gradients to either side of the horizontal scroll view to communicate the
additional options available. This is only so effective, but may help some. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Select a block.
1. Scroll the block toolbar either direction.
1. **Verify** the gradient appears when additional options are available for a
   given side.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/68e5d6e7-4054-41ec-8200-fe1adc985165


