### PR TITLE
Native Inserter: Show as popover on iPad

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
@@ -70,6 +70,14 @@ struct EditorJSMessage {
 
     struct ShowBlockInserterBody: Decodable {
         let sections: [BlockInserterSection]
+        let sourceRect: SourceRect?
+
+        struct SourceRect: Decodable {
+            let x: CGFloat
+            let y: CGFloat
+            let width: CGFloat
+            let height: CGFloat
+        }
     }
 
     struct LogMessage: Decodable {

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -279,7 +279,23 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
 
         context.viewController = host
 
-        if let sheet = host.sheetPresentationController {
+        if let sourceRect = data.sourceRect {
+            host.modalPresentationStyle = .popover
+
+            if let popover = host.popoverPresentationController {
+                popover.sourceView = webView
+                popover.sourceRect = CGRect(
+                    x: sourceRect.x,
+                    y: sourceRect.y,
+                    width: sourceRect.width,
+                    height: sourceRect.height
+                )
+                popover.permittedArrowDirections = [.up, .down]
+                host.preferredContentSize = CGSize(width: 600, height: 580)
+            }
+        }
+
+        if let sheet = host.popoverPresentationController?.adaptiveSheetPresentationController ?? host.sheetPresentationController {
             sheet.detents = [.custom(identifier: .medium, resolver: { context in
                 context.containerTraitCollection.horizontalSizeClass == .compact ? 536 : 900
             }), .large()]

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
@@ -15,10 +15,15 @@ struct BlockInserterView: View {
     @State private var selectedMediaItems: [PhotosPickerItem] = []
     @State private var inlineSelectedMediaItems: [PhotosPickerItem] = []
     @State private var isShowingCamera = false
+    @State private var availableWidth: CGFloat = 0
 
     @ScaledMetric(relativeTo: .largeTitle) private var inlinePickerHeight = 116
 
     @Environment(\.dismiss) private var dismiss
+
+    private var isLargeWidth: Bool {
+        availableWidth >= 500
+    }
 
     init(
         sections: [BlockInserterSection],
@@ -40,7 +45,7 @@ struct BlockInserterView: View {
     var body: some View {
         content
             .background(Material.ultraThin)
-            .searchable(text: $viewModel.searchText)
+            .conditionallySearchable(text: $viewModel.searchText, isEnabled: !isLargeWidth)
             .navigationBarTitleDisplayMode(.inline)
             .disabled(viewModel.isProcessingMedia)
             .environmentObject(iconCache)
@@ -60,15 +65,32 @@ struct BlockInserterView: View {
                     viewModel.cancelProcessing()
                 }
             }
+            .background(
+                GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            availableWidth = geometry.size.width
+                        }
+                        .onChange(of: geometry.size.width) { _, newWidth in
+                            if availableWidth != newWidth, newWidth > 0.0 {
+                                availableWidth = newWidth
+                            }
+                        }
+                }
+            )
     }
 
     private var content: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
-                ForEach(viewModel.sections, content: makeSection)
+            if viewModel.sections.isEmpty {
+                ContentUnavailableView.search(text: viewModel.searchText)
+            } else {
+                VStack(alignment: .leading, spacing: 24) {
+                    ForEach(viewModel.sections, content: makeSection)
+                }
+                .padding(.vertical, 6)
+                .dynamicTypeSize(...(.accessibility3))
             }
-            .padding(.vertical, 6)
-            .dynamicTypeSize(...(.accessibility3))
         }
         .scrollContentBackground(.hidden)
         .dynamicTypeSize(...DynamicTypeSize.accessibility2)
@@ -103,7 +125,12 @@ struct BlockInserterView: View {
             .tint(Color.primary)
         }
 
+
         ToolbarItemGroup(placement: .topBarTrailing) {
+            if isLargeWidth {
+                customSearchField
+            }
+
             PhotosPicker(
                 selection: $selectedMediaItems,
                 preferredItemEncoding: .compatible
@@ -138,6 +165,32 @@ struct BlockInserterView: View {
         }
     }
 
+    /// We use a custom search field on iPad to reduce the amount of vertical space used.
+    /// The standard `.searchable` behavaior with ` .toolbar` placement doesn't
+    /// achieve that. It defaults to a showing a full-screen search bar in a list
+    /// regardless of the popover size.
+    @ViewBuilder
+    private var customSearchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            /// TODO: CMM-874
+            TextField("Search", text: $viewModel.searchText)
+                .textFieldStyle(.plain)
+                .autocorrectionDisabled()
+            if !viewModel.searchText.isEmpty {
+                Button {
+                    viewModel.searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .frame(maxWidth: 320)
+    }
+
     // MARK: - Inline PhotosPicker (.inline)
 
     @ViewBuilder
@@ -150,7 +203,7 @@ struct BlockInserterView: View {
         )
         .photosPickerStyle(.compact)
         .photosPickerAccessoryVisibility(.hidden)
-        .frame(height: inlinePickerHeight)
+        .frame(height: inlinePickerHeight - (isLargeWidth ? 20 : 0))
     }
 
     @ViewBuilder
@@ -204,6 +257,19 @@ struct BlockInserterView: View {
                 dismiss()
                 onMediaSelected(items)
             }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension View {
+    @ViewBuilder
+    func conditionallySearchable(text: Binding<String>, isEnabled: Bool) -> some View {
+        if isEnabled {
+            self.searchable(text: text)
+        } else {
+            self
         }
     }
 }

--- a/src/components/native-block-inserter-button/index.jsx
+++ b/src/components/native-block-inserter-button/index.jsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { findTransform, getBlockTransforms } from '@wordpress/blocks';
+import { useRef } from '@wordpress/element';
 
 // NOTE: These hooks are internal WordPress APIs not available via public exports
 // or privateApis. We import from build-module as the only way to access the
@@ -45,6 +46,8 @@ import { showBlockInserter } from '../../utils/bridge';
  * state and exposes the current inserter state globally for the native side.
  */
 export default function NativeBlockInserterButton() {
+	const buttonRef = useRef( null );
+
 	// Get current selection for insertion context and destination block info
 	const { selectedBlockClientId, destinationBlockName } = useSelect(
 		( select ) => {
@@ -193,6 +196,7 @@ export default function NativeBlockInserterButton() {
 
 	return (
 		<Button
+			ref={ buttonRef }
 			title={ __( 'Add block' ) }
 			icon={ plus }
 			onClick={ () => {
@@ -206,7 +210,20 @@ export default function NativeBlockInserterButton() {
 					insertBlock,
 					insertMedia,
 				};
-				showBlockInserter();
+
+				// Get button position for popover presentation on iPad
+				let sourceRect;
+				if ( buttonRef.current ) {
+					const rect = buttonRef.current.getBoundingClientRect();
+					sourceRect = {
+						x: rect.left,
+						y: rect.top,
+						width: rect.width,
+						height: rect.height,
+					};
+				}
+
+				showBlockInserter( sourceRect );
 			} }
 			onMouseDown={ ( e ) => {
 				e.preventDefault();

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -96,9 +96,15 @@ export function onBlocksChanged( isEmpty = false ) {
  * The sections array is preprocessed by preprocessBlockTypesForNativeInserter()
  * which handles ordering, contextual filtering, and localized section names.
  *
+ * @param {Object} [sourceRect]      The button's position for popover presentation.
+ * @param {number} sourceRect.x      The x coordinate relative to the webview.
+ * @param {number} sourceRect.y      The y coordinate relative to the webview.
+ * @param {number} sourceRect.width  The width of the button.
+ * @param {number} sourceRect.height The height of the button.
+ *
  * @return {void}
  */
-export function showBlockInserter() {
+export function showBlockInserter( sourceRect ) {
 	if ( ! window.blockInserter ) {
 		debug(
 			'BlockInserterBridge not available. Ensure editor is initialized.'
@@ -109,6 +115,7 @@ export function showBlockInserter() {
 	// Send preprocessed sections to native
 	dispatchToBridge( 'showBlockInserter', {
 		sections: window.blockInserter.sections,
+		sourceRect,
 	} );
 }
 


### PR DESCRIPTION
## What?
- Closes [CMM-864: Show inserter as a popover on iPad](https://linear.app/a8c/issue/CMM-864/show-inserter-as-a-popover-on-ipad)

## How?
Pass the button rect from the web view to the native side.

## Testing Instructions
- **Verify** that the inserter is shown in a popover on iPad. 

**Known issue**: [CMM-932: Popover with the inserter is not re-positioned if you dismiss the keyboard](https://linear.app/a8c/issue/CMM-932/popover-with-the-inserter-is-not-re-positioned-if-you-dismiss-the) – it will require a non-trivial amount of code. I want to implement it separately.

## Screenshots or screencast <!-- if applicable -->

<img width="1336" height="1029" alt="Screenshot 2025-11-05 at 9 52 00 AM" src="https://github.com/user-attachments/assets/958f3230-4cbc-40c4-a4c1-ca56cb57ed73" />
<img width="946" height="1317" alt="Screenshot 2025-11-05 at 10 18 00 AM" src="https://github.com/user-attachments/assets/b139a454-894b-41cd-9bfb-2b73b136af45" />

The new search placement is also effective on iPhone in the landscape mode:

<img width="910" height="518" alt="Screenshot 2025-11-05 at 10 23 28 AM" src="https://github.com/user-attachments/assets/a35cf12c-3d61-4dff-ae9d-3728edd15fc5" />


