### PR TITLE
Native Inserter: Add quick camera access

### DIFF
--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.pbxproj
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleURLTypes = "$(INFOPLIST_KEY_CFBundleURLTypes)";
+				INFOPLIST_KEY_NSCameraUsageDescription = "The app needs access to your camera to capture photos and videos for your content.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
@@ -14,6 +14,7 @@ struct BlockInserterView: View {
 
     @State private var selectedMediaItems: [PhotosPickerItem] = []
     @State private var inlineSelectedMediaItems: [PhotosPickerItem] = []
+    @State private var isShowingCamera = false
 
     @ScaledMetric(relativeTo: .largeTitle) private var inlinePickerHeight = 116
 
@@ -45,6 +46,12 @@ struct BlockInserterView: View {
             .environmentObject(iconCache)
             .toolbar {
                 toolbar
+            }
+            .sheet(isPresented: $isShowingCamera) {
+                CameraView { media in
+                    insertCameraMedia(media)
+                }
+                .ignoresSafeArea()
             }
             .animation(.smooth(duration: 2), value: viewModel.isProcessingMedia)
             .animation(.snappy, value: inlineSelectedMediaItems.count)
@@ -108,6 +115,12 @@ struct BlockInserterView: View {
                     insertMedia(selection)
                 }
                 selectedMediaItems = []
+            }
+
+            Button {
+                isShowingCamera = true
+            } label: {
+                Image(systemName: "camera")
             }
 
             if let mediaPicker {
@@ -177,6 +190,16 @@ struct BlockInserterView: View {
     private func insertMedia(_ items: [PhotosPickerItem]) {
         Task {
             let items = await viewModel.processSelectedPhotosPickerItems(items)
+            if !items.isEmpty {
+                dismiss()
+                onMediaSelected(items)
+            }
+        }
+    }
+
+    private func insertCameraMedia(_ media: CameraMedia) {
+        Task {
+            let items = await viewModel.processCameraMedia(media)
             if !items.isEmpty {
                 dismiss()
                 onMediaSelected(items)

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
@@ -14,7 +14,7 @@ class BlockInserterViewModel: ObservableObject {
     private var processingTask: Task<[MediaInfo], Never>?
     private var cancellables = Set<AnyCancellable>()
 
-    struct MediaError: Identifiable {
+    struct MediaError: Identifiable, Error {
         let id = UUID()
         let message: String
     }
@@ -83,6 +83,46 @@ class BlockInserterViewModel: ObservableObject {
             }
 
             return results
+        }
+        processingTask = task
+        return await task.value
+    }
+
+
+    func processCameraMedia(_ media: CameraMedia) async -> [MediaInfo] {
+        isProcessingMedia = true
+        defer { isProcessingMedia = false }
+
+        let task = Task<[MediaInfo], Never> { @MainActor in
+            do {
+                let mediaInfo: MediaInfo
+
+                switch media {
+                case .photo(let image):
+                    guard let imageData = image.jpegData(compressionQuality: 0.8) else {
+                        throw MediaError(message: "Failed to convert image to JPEG")
+                    }
+
+                    let fileURL = try await fileManager.writeData(imageData, withExtension: "jpg")
+                    mediaInfo = MediaInfo(url: fileURL.absoluteString, type: "image/jpeg")
+
+                case .video(let videoURL):
+                    let videoData = try Data(contentsOf: videoURL)
+                    let fileExtension = videoURL.pathExtension.isEmpty ? "mp4" : videoURL.pathExtension
+                    let fileURL = try await fileManager.writeData(videoData, withExtension: fileExtension)
+                    mediaInfo = MediaInfo(url: fileURL.absoluteString, type: "video/\(fileExtension)")
+                }
+
+                guard !Task.isCancelled else {
+                    return []
+                }
+
+                return [mediaInfo]
+
+            } catch {
+                self.error = MediaError(message: error.localizedDescription)
+                return []
+            }
         }
         processingTask = task
         return await task.value

--- a/ios/Sources/GutenbergKit/Sources/Views/CameraView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/CameraView.swift
@@ -1,0 +1,51 @@
+import UIKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+enum CameraMedia {
+    case photo(UIImage)
+    case video(URL)
+}
+
+struct CameraView: UIViewControllerRepresentable {
+    var onMediaCaptured: ((CameraMedia) -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.mediaTypes = [UTType.image.identifier, UTType.movie.identifier]  // Support both photo and video
+        picker.videoQuality = .typeHigh
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let parent: CameraView
+
+        init(_ parent: CameraView) {
+            self.parent = parent
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            parent.dismiss()
+
+            if let image = info[.originalImage] as? UIImage {
+                parent.onMediaCaptured?(.photo(image))
+            } else if let videoURL = info[.mediaURL] as? URL {
+                parent.onMediaCaptured?(.video(videoURL))
+            }
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.dismiss()
+        }
+    }
+}


### PR DESCRIPTION
## What?
Closes [CMM-861: Add trailing bar button item to add media from Camera](https://linear.app/a8c/issue/CMM-861/add-trailing-bar-button-item-to-add-media-from-camera).

## Why?
The "Camera" is not as common as "Photos", but it the second most popular option, so it makes sense to provide quick access to it.

## How?
Similar to "Photos" picker.

## Testing Instructions
(See recording)

It requires a device for testing, so I tested it and recorded it, so you don't have to.

## Screenshots or screencast


https://github.com/user-attachments/assets/212a9bb5-2d7a-4e71-ac1a-1ce8c7566c39

