### PR TITLE
fix: Display drag-and-drop indicator

### DIFF
--- a/patches/@wordpress+block-editor+14.17.0.patch
+++ b/patches/@wordpress+block-editor+14.17.0.patch
@@ -1,3 +1,27 @@
+diff --git a/node_modules/@wordpress/block-editor/build-module/components/inserter-list-item/index.js b/node_modules/@wordpress/block-editor/build-module/components/inserter-list-item/index.js
+index 89a3bbc..8564798 100644
+--- a/node_modules/@wordpress/block-editor/build-module/components/inserter-list-item/index.js
++++ b/node_modules/@wordpress/block-editor/build-module/components/inserter-list-item/index.js
+@@ -28,6 +28,10 @@ function InserterListItem({
+   ...props
+ }) {
+   const isDraggingRef = useRef(false);
++  const isTouchDeviceRef = useRef(
++    window.matchMedia( '(hover: none)' ).matches ||
++    window.matchMedia( '(pointer: coarse)' ).matches
++  );
+   const itemIconStyle = item.icon ? {
+     backgroundColor: item.icon.background,
+     color: item.icon.foreground
+@@ -80,7 +84,7 @@ function InserterListItem({
+           }
+         },
+         onMouseEnter: () => {
+-          if (isDraggingRef.current) {
++          if (isDraggingRef.current || isTouchDeviceRef.current) {
+             return;
+           }
+           onHover(item);
 diff --git a/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js b/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js
 index 78b9b8f..9a8efb8 100644
 --- a/node_modules/@wordpress/block-editor/build-module/components/inserter/index.js

--- a/patches/README.md
+++ b/patches/README.md
@@ -11,6 +11,7 @@ Existing patches should be described and justified here.
 -   Expose an `open` prop on the `Inserter` component, allowing toggling the inserter visibility via the quick inserter's "Browse all" button.
 -   Disable `stripExperimentalSettings` in the `BlockEditorProvider` component so that the Patterns and Media inserter tabs function.
 -   Allow setting popover props for the `Inserter` component, so we can improve the mobile screen reader experience by marking it as a modal dialog.
+-   Prevent the insertion point popover from appearing on touch devices in `InserterListItem`. The popover (triggered by `onMouseEnter`) disrupts tap/click events, requiring users to tap inserter items twice before they are inserted.
 
 ### `@wordpress/block-library`
 

--- a/src/components/visual-editor/style.scss
+++ b/src/components/visual-editor/style.scss
@@ -92,11 +92,12 @@
 	width: 100%;
 }
 
-// Hide the inserter popover displayed between blocks when hovering between
-// blocks or hovering over a block type in the inserter. Its presence is less
-// useful for touch devices and steals focus away from the inserter, which
-// results in needing to tap a block type twice to insert it.
-.gutenberg-kit-visual-editor .block-editor-block-popover {
+// Hide the inline inserter popover displayed from the "Add block" button
+// positioned alongside empty text blocks. Its presence is less useful for touch
+// devices and steals focus away from the inserter, which results in needing to
+// tap a block type twice to insert it.
+.gutenberg-kit-visual-editor
+	.block-editor-block-list__block-side-inserter-popover {
 	display: none;
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -73,11 +73,6 @@ $baseline-interactive-font-size: 17px;
 		width: 320px;
 	}
 
-	// Hide the inline insterter shown inside the block list
-	.block-editor-block-list__block-side-inserter-popover {
-		display: none;
-	}
-
 	/* Inserter (Mobile Design) */
 
 	// Inserter tab buttons


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Display the block insertion point indicator when dragging blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close CMM-731. Communicate the destination position for a dragged block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The popover used for this feature was hidden previously because it
disrupts tap/click events in the block inserter, requiring two taps to
insert a block.

These changes continue hiding the "add block" button popover displayed
alongside empty text blocks, but allows the insertion point indicator to
now be displayed. We disable the insertion point display from the block
inserter only by detecting touch devices (as best possible) and prevent
the relevant `onMouseEnter` event callback triggering the `onHover`
callback.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### 1. Drag insertion point indicator is displayed
1. Insert several blocks, including a non-text block[^1].
1. Attempt to drag and drop the non-text block.
1. **Verify** the insertion point indicator (wide blue line) is displayed at the target location
   between the blocks.

### 2. Inserting blocks from the block inserter requires a single tap
1. Open the editor. 
2. Focus the placeholder block to insert a Paragraph block. 
3. Tap the `+` button open the block inserter. 
4. Tap a block. 
5. **Verify** the block is inserted after a single tap. a

[^1]: Dragging text blocks is difficult on web due to the `contenteditable`
    generally stealing focus and activate cursor/text actions.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/60063cce-6986-44dc-954b-c08fd19be26d

