### PR TITLE
Native Inserter: Private pattern categories and localizable titles

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorJSMessage.swift
@@ -71,6 +71,7 @@ struct EditorJSMessage {
     struct ShowBlockInserterBody: Decodable {
         let sections: [BlockInserterSection]
         let patterns: [Pattern]
+        let patternCategories: [PatternCategory]
         let sourceRect: SourceRect?
 
         struct SourceRect: Decodable {
@@ -83,6 +84,7 @@ struct EditorJSMessage {
         private enum CodingKeys: String, CodingKey {
             case sections
             case patterns
+            case patternCategories
             case sourceRect
         }
 
@@ -91,6 +93,7 @@ struct EditorJSMessage {
 
             self.sections = try container.decode([BlockInserterSection].self, forKey: .sections)
             self.patterns = try container.decodeSafely([Pattern].self, forKey: .patterns)
+            self.patternCategories = try container.decodeSafely([PatternCategory].self, forKey: .patternCategories)
             self.sourceRect = try container.decodeIfPresent(SourceRect.self, forKey: .sourceRect)
         }
     }

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -265,6 +265,7 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
             BlockInserterView(
                 sections: data.sections,
                 patterns: data.patterns,
+                patternCategories: data.patternCategories,
                 mediaPicker: mediaPicker,
                 presentationContext: context,
                 onSelection: { [weak self] in self?.didSelectBlockInserterItem($0) }

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
@@ -12,6 +12,7 @@ enum BlockInserterSelection {
 struct BlockInserterView: View {
     let sections: [BlockInserterSection]
     let patterns: [Pattern]
+    let patternCategories: [PatternCategory]
     let mediaPicker: MediaPickerController?
     let presentationContext: MediaPickerPresentationContext
     let onSelection: (BlockInserterSelection) -> Void
@@ -36,12 +37,14 @@ struct BlockInserterView: View {
     init(
         sections: [BlockInserterSection],
         patterns: [Pattern],
+        patternCategories: [PatternCategory],
         mediaPicker: MediaPickerController?,
         presentationContext: MediaPickerPresentationContext,
         onSelection: @escaping (BlockInserterSelection) -> Void
     ) {
         self.sections = sections
         self.patterns = patterns
+        self.patternCategories = patternCategories
         self.mediaPicker = mediaPicker
         self.presentationContext = presentationContext
         self.onSelection = onSelection
@@ -77,6 +80,7 @@ struct BlockInserterView: View {
                 NavigationStack {
                     PatternsView(
                         patterns: patterns,
+                        patternCategories: patternCategories,
                         onPatternSelected: { pattern in
                             showingPatterns = false
                             insertPattern(pattern)
@@ -317,6 +321,7 @@ private extension View {
                 BlockInserterSection(category: "text", name: "Text", blocks: Array(BlockType.mocks.prefix(12)))
             ],
             patterns: [],
+            patternCategories: [],
             mediaPicker: MockMediaPickerController(),
             presentationContext: MediaPickerPresentationContext(),
             onSelection: { selection in

--- a/ios/Sources/GutenbergKit/Sources/Views/Patterns/Pattern.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/Patterns/Pattern.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+struct PatternCategory: Decodable {
+    /// Category slug/identifier (e.g., "gallery")
+    let name: String
+    /// Localized display name (e.g., "Galerie" in French)
+    let label: String
+}
+
 struct Pattern: Decodable, Identifiable {
     /// Example: `"core/query-standard-posts"`
     let name: String

--- a/ios/Sources/GutenbergKit/Sources/Views/Patterns/PatternsView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/Patterns/PatternsView.swift
@@ -3,6 +3,7 @@ import WebKit
 
 struct PatternsView: View {
     let patterns: [Pattern]
+    let patternCategories: [PatternCategory]
     let onPatternSelected: (Pattern) -> Void
 
     @StateObject private var viewModel: PatternsViewModel
@@ -11,10 +12,11 @@ struct PatternsView: View {
 
     @Environment(\.dismiss) private var dismiss
 
-    init(patterns: [Pattern], onPatternSelected: @escaping (Pattern) -> Void) {
+    init(patterns: [Pattern], patternCategories: [PatternCategory] = [], onPatternSelected: @escaping (Pattern) -> Void) {
         self.patterns = patterns
+        self.patternCategories = patternCategories
         self.onPatternSelected = onPatternSelected
-        self._viewModel = StateObject(wrappedValue: PatternsViewModel(patterns: patterns))
+        self._viewModel = StateObject(wrappedValue: PatternsViewModel(patterns: patterns, patternCategories: patternCategories))
     }
 
     private var viewportWidth: Int? {

--- a/ios/Sources/GutenbergKit/Sources/Views/Patterns/PatternsViewModel.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/Patterns/PatternsViewModel.swift
@@ -9,7 +9,10 @@ final class PatternsViewModel: ObservableObject {
     private let allSections: [PatternSection]
     private var cancellables = Set<AnyCancellable>()
 
-    init(patterns: [Pattern]) {
+    init(patterns: [Pattern], patternCategories: [PatternCategory] = []) {
+        let categoryLabels = Dictionary(
+            uniqueKeysWithValues: patternCategories.map { ($0.name, $0.label) }
+        )
         // Build a mapping of category -> patterns in input order
         var categoryPatterns: [String: [Pattern]] = [:]
         let uncategorizedKey = "uncategorized"
@@ -35,7 +38,7 @@ final class PatternsViewModel: ObservableObject {
                 // TODO: CMM-874 - Localize "Uncategorized"
                 displayName = "Uncategorized"
             } else {
-                displayName = category.capitalized
+                displayName = categoryLabels[category] ?? category.capitalized
             }
 
             // Separate primary and secondary patterns, then concatenate

--- a/src/components/native-block-inserter-button/index.jsx
+++ b/src/components/native-block-inserter-button/index.jsx
@@ -33,6 +33,7 @@ import useBlockTypesState from '@wordpress/block-editor/build-module/components/
  * Internal dependencies
  */
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreDataStore } from '@wordpress/core-data';
 import { debug } from '../../utils/logger';
 import { preprocessBlockTypesForNativeInserter } from '../../utils/blocks';
 import { showBlockInserter } from '../../utils/bridge';
@@ -99,6 +100,17 @@ export default function NativeBlockInserterButton() {
 		},
 		[ destinationRootClientId ]
 	);
+
+	// Get pattern categories with localized labels
+	const patternCategories = useSelect( ( select ) => {
+		const { getBlockPatternCategories, getUserPatternCategories } =
+			select( coreDataStore );
+
+		return [
+			...( getBlockPatternCategories() || [] ),
+			...( getUserPatternCategories() || [] ),
+		];
+	}, [] );
 
 	const insertBlock = ( blockId ) => {
 		const item = inserterItems.find( ( i ) => i.id === blockId );
@@ -250,9 +262,16 @@ export default function NativeBlockInserterButton() {
 						viewportWidth: pattern.viewportWidth ?? null,
 					} ) ) ?? [];
 
+				const formattedPatternCategories =
+					patternCategories?.map( ( cat ) => ( {
+						name: cat.name,
+						label: cat.label,
+					} ) ) ?? [];
+
 				window.blockInserter = {
 					sections,
 					patterns: formattedPatterns,
+					patternCategories: formattedPatternCategories,
 					insertBlock,
 					insertPattern,
 					insertMedia,

--- a/src/components/native-block-inserter-button/index.jsx
+++ b/src/components/native-block-inserter-button/index.jsx
@@ -255,7 +255,10 @@ export default function NativeBlockInserterButton() {
 						title: pattern.title,
 						content: pattern.content,
 						blockTypes: pattern.blockTypes ?? null,
-						categories: pattern.categories ?? null,
+						categories:
+							pattern.categories?.filter(
+								( cat ) => ! cat.startsWith( '_' )
+							) ?? null,
 						description: pattern.description ?? null,
 						keywords: pattern.keywords ?? null,
 						source: pattern.source ?? null,

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -112,6 +112,7 @@ export function showBlockInserter( sourceRect ) {
 	dispatchToBridge( 'showBlockInserter', {
 		sections: window.blockInserter.sections,
 		patterns: window.blockInserter.patterns,
+		patternCategories: window.blockInserter.patternCategories,
 		sourceRect,
 	} );
 }


### PR DESCRIPTION
## What?
- Fix [CMM-935: Some patterns should not be shown](https://linear.app/a8c/issue/CMM-935/some-patterns-should-not-be-shown)
- Use localizable names for pattern categories

## How?

Evidently, any categories with underscores are private:

```
blockTypes: [] (0)
categories: ["_experimental", "_forms"] (2)
content: "<!-- wp:group {\"align\":\"full\",\"className\":\"is-style-default\",\"style\":{\"spacing\":{\"padding\":{\"top\":\"var:preset|spacing|40\",\"bottom\":\"var:pres…"
description: ""
keywords: null
name: "a8c/subscription-form"
source: null
title: "Subscription Form"
viewportWidth: 1280
```

These categories are not present in `getBlockPatternCategories`.

The web displays these under "Uncategorized":

<img width="560" alt="Screenshot 2025-11-06 at 1 23 51 PM" src="https://github.com/user-attachments/assets/f252540e-cbac-4e76-bd66-fd57a993260f" />

## Screenshots or screencast
<img width="360" alt="Screenshot 2025-11-06 at 1 36 57 PM" src="https://github.com/user-attachments/assets/3a270b6e-dbaa-431a-8aa0-4294d7d35bf5" /> <img width="360" alt="Screenshot 2025-11-06 at 1 37 48 PM" src="https://github.com/user-attachments/assets/9efcd911-8551-484c-a25c-4e4324a65821" />


