### PR TITLE
feat: Improve editor load resiliency

### DIFF
--- a/__mocks__/@wordpress/components/index.jsx
+++ b/__mocks__/@wordpress/components/index.jsx
@@ -1,14 +1,10 @@
-export const Notice = ( { children, actions } ) => (
+export const Notice = ( { children, onRemove } ) => (
 	<div data-testid="mock-notice">
 		<span>{ children }</span>
-		{ actions?.map( ( action, index ) => (
-			<button
-				key={ index }
-				onClick={ action.onClick }
-				data-variant={ action.variant }
-			>
-				{ action.label }
+		{ onRemove && (
+			<button onClick={ onRemove } data-testid="notice-dismiss">
+				Dismiss
 			</button>
-		) ) }
+		) }
 	</div>
 );

--- a/src/components/editor-load-notice.jsx
+++ b/src/components/editor-load-notice.jsx
@@ -5,29 +5,24 @@ import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 
+const pluginLoadFailedNotice = __(
+	'Loading plugins failed, using default editor configuration.',
+	'gutenberg-kit'
+);
+
 /**
  * Displays a notice with actions to retry or dismiss.
  *
- * @param {Object} props           Component props.
- * @param {string} props.className Additional class names to apply.
+ * @param {Object}  props                  Component props.
+ * @param {string}  props.className        Additional class names to apply.
+ * @param {boolean} props.pluginLoadFailed Whether plugin loading failed.
  *
  * @return {?JSX.Element} The rendered component or null if no notice is present.
  */
-export default function EditorLoadNotice( { className } ) {
-	const { notice, clearNotice } = useEditorLoadNotice();
-
-	const actions = [
-		{
-			label: __( 'Retry', 'gutenberg-kit' ),
-			onClick: () => ( window.location.href = 'remote.html' ),
-			variant: 'primary',
-		},
-		{
-			label: __( 'Dismiss', 'gutenberg-kit' ),
-			onClick: clearNotice,
-			variant: 'secondary',
-		},
-	];
+export default function EditorLoadNotice( { className, pluginLoadFailed } ) {
+	const { notice, clearNotice } = useEditorLoadNotice(
+		pluginLoadFailed ? pluginLoadFailedNotice : null
+	);
 
 	if ( ! notice ) {
 		return null;
@@ -35,11 +30,7 @@ export default function EditorLoadNotice( { className } ) {
 
 	return (
 		<div className={ className }>
-			<Notice
-				actions={ actions }
-				status="warning"
-				isDismissible={ false }
-			>
+			<Notice status="warning" onRemove={ clearNotice }>
 				{ notice }
 			</Notice>
 		</div>
@@ -47,37 +38,14 @@ export default function EditorLoadNotice( { className } ) {
 }
 
 /**
- * Conditionally and temporarily sets a notice message based on the URL.
+ * Conditionally and temporarily sets a notice message.
  *
- * @return {{notice:string, clearNotice:()=>void}} The notice message and a function to clear it.
+ * @param {string|null} initialNotice The initial notice message.
+ *
+ * @return {{notice:string|null, clearNotice:()=>void}} The notice message and a function to clear it.
  */
-function useEditorLoadNotice() {
-	const [ notice, setNotice ] = useState( null );
-
-	useEffect( () => {
-		const url = new URL( window.location.href );
-		const error = url.searchParams.get( 'error' );
-
-		let message = null;
-		switch ( error ) {
-			case REMOTE_EDITOR_LOAD_ERROR:
-				message = __(
-					"Oops! We couldn't load your site's editor and plugins. Don't worry, you can use the default editor for now.",
-					'gutenberg-kit'
-				);
-				break;
-			case GBKIT_GLOBAL_UNAVAILABLE:
-				message = __(
-					"Oops! Configuration for your site editor was unavailable. Don't worry, you can use the default editor for now.",
-					'gutenberg-kit'
-				);
-				break;
-			default:
-				message = null;
-		}
-
-		setNotice( message );
-	}, [] );
+function useEditorLoadNotice( initialNotice ) {
+	const [ notice, setNotice ] = useState( initialNotice );
 
 	useEffect( () => {
 		if ( notice ) {
@@ -90,6 +58,3 @@ function useEditorLoadNotice() {
 
 	return { notice, clearNotice: () => setNotice( null ) };
 }
-
-const REMOTE_EDITOR_LOAD_ERROR = 'remote_editor_load_error';
-const GBKIT_GLOBAL_UNAVAILABLE = 'gbkit_global_unavailable';

--- a/src/components/editor-load-notice.test.jsx
+++ b/src/components/editor-load-notice.test.jsx
@@ -15,14 +15,10 @@ vi.mock( '@wordpress/components' );
 describe( 'EditorLoadNotice', () => {
 	beforeEach( () => {
 		vi.useFakeTimers();
-		vi.stubGlobal( 'location', {
-			href: 'https://example.com',
-		} );
 	} );
 
 	afterEach( () => {
 		vi.useRealTimers();
-		vi.unstubAllGlobals();
 	} );
 
 	it( 'renders nothing when no error is present', () => {
@@ -30,68 +26,29 @@ describe( 'EditorLoadNotice', () => {
 		expect( screen.queryByTestId( 'mock-notice' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders remote editor load error notice', () => {
-		vi.stubGlobal( 'location', {
-			href: 'https://example.com?error=remote_editor_load_error',
-		} );
-
-		render( <EditorLoadNotice /> );
+	it( 'renders plugin load failed notice', () => {
+		render( <EditorLoadNotice pluginLoadFailed={ true } /> );
 
 		expect( screen.getByTestId( 'mock-notice' ) ).toBeInTheDocument();
 		expect(
 			screen.getByText(
-				"Oops! We couldn't load your site's editor and plugins. Don't worry, you can use the default editor for now."
-			)
-		).toBeInTheDocument();
-	} );
-
-	it( 'renders global unavailable error notice', () => {
-		vi.stubGlobal( 'location', {
-			href: 'https://example.com?error=gbkit_global_unavailable',
-		} );
-
-		render( <EditorLoadNotice /> );
-
-		expect( screen.getByTestId( 'mock-notice' ) ).toBeInTheDocument();
-		expect(
-			screen.getByText(
-				"Oops! Configuration for your site editor was unavailable. Don't worry, you can use the default editor for now."
+				'Loading plugins failed, using default editor configuration.'
 			)
 		).toBeInTheDocument();
 	} );
 
 	it( 'clears notice when clicking Dismiss button', () => {
-		vi.stubGlobal( 'location', {
-			href: 'https://example.com?error=remote_editor_load_error',
-		} );
-
-		render( <EditorLoadNotice /> );
+		render( <EditorLoadNotice pluginLoadFailed={ true } /> );
 
 		expect( screen.getByTestId( 'mock-notice' ) ).toBeInTheDocument();
 
-		fireEvent.click( screen.getByText( 'Dismiss' ) );
+		fireEvent.click( screen.getByTestId( 'notice-dismiss' ) );
 
 		expect( screen.queryByTestId( 'mock-notice' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'redirects when clicking Retry button', () => {
-		vi.stubGlobal( 'location', {
-			href: 'https://example.com?error=remote_editor_load_error',
-		} );
-
-		render( <EditorLoadNotice /> );
-
-		fireEvent.click( screen.getByText( 'Retry' ) );
-
-		expect( window.location.href ).toBe( 'remote.html' );
-	} );
-
 	it( 'auto-dismisses notice after 20 seconds', () => {
-		vi.stubGlobal( 'location', {
-			href: 'https://example.com?error=remote_editor_load_error',
-		} );
-
-		render( <EditorLoadNotice /> );
+		render( <EditorLoadNotice pluginLoadFailed={ true } /> );
 
 		expect( screen.getByTestId( 'mock-notice' ) ).toBeInTheDocument();
 
@@ -103,12 +60,11 @@ describe( 'EditorLoadNotice', () => {
 	} );
 
 	it( 'applies custom className to container', () => {
-		vi.stubGlobal( 'location', {
-			href: 'https://example.com?error=remote_editor_load_error',
-		} );
-
 		const { container } = render(
-			<EditorLoadNotice className="custom-class" />
+			<EditorLoadNotice
+				pluginLoadFailed={ true }
+				className="custom-class"
+			/>
 		);
 
 		expect( container.firstChild ).toHaveClass( 'custom-class' );

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -18,18 +18,24 @@ import './style.scss';
 /**
  * Top-level layout, including the Editor component wrapped in an ErrorBoundary.
  *
- * @param {Object} props The settings passed along to the Editor component.
+ * @param {Object}  props                  The settings passed along to the Editor component.
+ * @param {boolean} props.pluginLoadFailed Whether plugin loading failed.
  *
  * @return {JSX.Element} The rendered Layout component.
  */
 export default function Layout( props ) {
+	const { pluginLoadFailed, ...editorProps } = props;
+
 	return (
 		<ErrorBoundary canCopyContent>
 			<AutosaveMonitor autosave={ onEditorContentChanged } />
-			<Editor { ...props }>
+			<Editor { ...editorProps }>
 				<EditorSnackbars />
 			</Editor>
-			<EditorLoadNotice className="gutenberg-kit-layout__load-notice" />
+			<EditorLoadNotice
+				className="gutenberg-kit-layout__load-notice"
+				pluginLoadFailed={ pluginLoadFailed }
+			/>
 		</ErrorBoundary>
 	);
 }

--- a/src/utils/bundled-editor.jsx
+++ b/src/utils/bundled-editor.jsx
@@ -58,18 +58,24 @@ function loadPluginsIfEnabled() {
 	const { plugins } = getGBKit();
 
 	if ( plugins ) {
-		return loadEditorAssets().then( ( { allowedBlockTypes } ) =>
-			import( './blocks' ).then( ( { unregisterDisallowedBlocks } ) =>
-				unregisterDisallowedBlocks( allowedBlockTypes )
+		return loadEditorAssets()
+			.then( ( { allowedBlockTypes } ) =>
+				import( './blocks' ).then( ( { unregisterDisallowedBlocks } ) =>
+					unregisterDisallowedBlocks( allowedBlockTypes )
+				)
 			)
-		);
+			.catch( () => {
+				return Promise.resolve( { pluginLoadFailed: true } );
+			} );
 	}
 }
 
-function initializeEditor() {
+function initializeEditor( pluginLoadResult ) {
 	return import( './editor' ).then(
 		( { initializeEditor: _initializeEditor } ) => {
-			_initializeEditor();
+			_initializeEditor( {
+				pluginLoadFailed: pluginLoadResult?.pluginLoadFailed,
+			} );
 		}
 	);
 }

--- a/src/utils/bundled-editor.jsx
+++ b/src/utils/bundled-editor.jsx
@@ -59,21 +59,22 @@ function loadPluginsIfEnabled() {
 
 	if ( plugins ) {
 		return loadEditorAssets()
-			.then( ( { allowedBlockTypes } ) =>
-				import( './blocks' ).then( ( { unregisterDisallowedBlocks } ) =>
-					unregisterDisallowedBlocks( allowedBlockTypes )
-				)
-			)
+			.then( ( { allowedBlockTypes } ) => {
+				return { allowedBlockTypes };
+			} )
 			.catch( () => {
 				return Promise.resolve( { pluginLoadFailed: true } );
 			} );
 	}
+
+	return Promise.resolve( {} );
 }
 
-function initializeEditor( pluginLoadResult ) {
+function initializeEditor( pluginLoadResult = {} ) {
 	return import( './editor' ).then(
 		( { initializeEditor: _initializeEditor } ) => {
 			_initializeEditor( {
+				allowedBlockTypes: pluginLoadResult?.allowedBlockTypes,
 				pluginLoadFailed: pluginLoadResult?.pluginLoadFailed,
 			} );
 		}

--- a/src/utils/editor-loader.js
+++ b/src/utils/editor-loader.js
@@ -138,6 +138,25 @@ async function loadAssets(
 			return ! excludedScriptIDs.test( asset.id );
 		}
 
+		/**
+		 * TODO: Remove this once the relevant Jetpack plugin release is available.
+		 *
+		 * Exclude WordPress core and Gutenberg assets to avoid loading duplicate
+		 * assets, which causes editor loading failures.
+		 *
+		 * This is a temporary measure until users update to the latest Jetpack REST
+		 * API endpoint that excludes these assets. This can be removed a few weeks
+		 * after the relevant Jetpack plugin release.
+		 *
+		 * See: https://github.com/Automattic/jetpack/pull/45715
+		 */
+		const coreOrGutenbergRegex = new RegExp(
+			'wp-(includes|admin)/(js|css)|plugins/gutenberg(-core)?/'
+		);
+		if ( coreOrGutenbergRegex.test( asset.src || asset.href ) ) {
+			return false;
+		}
+
 		return true;
 	} );
 

--- a/src/utils/editor-loader.js
+++ b/src/utils/editor-loader.js
@@ -2,8 +2,7 @@
  * Internal dependencies
  */
 import { fetchEditorAssets } from './bridge';
-import { error, warn } from './logger';
-import { isDevMode } from './dev-mode';
+import { error } from './logger';
 
 /**
  * Cache for editor assets to avoid unnecessary network requests
@@ -50,14 +49,7 @@ export async function loadEditorAssets( {
 		} );
 	} catch ( err ) {
 		error( 'Error loading editor assets', err );
-		if ( isDevMode() ) {
-			warn( 'Dev mode disabled automatic redirect to the local editor.' );
-		} else {
-			// Fallback to the local editor and display a notice. Because the remote
-			// editor loading failed, it is more practical to rely upon the local
-			// editor's scripts and styles for displaying the notice.
-			window.location.href = 'index.html?error=remote_editor_load_error';
-		}
+		throw err;
 	}
 }
 

--- a/src/utils/editor.jsx
+++ b/src/utils/editor.jsx
@@ -19,10 +19,14 @@ import { setLogLevel } from './logger';
  * that this utility can be used in both the local and remote editor, which
  * rely upon ES modules and global variables, respectively.
  *
- * @param {Object} [options]
- * @param {Array}  [options.allowedBlockTypes]
+ * @param {Object}  [options]
+ * @param {Array}   [options.allowedBlockTypes] Array of allowed block types
+ * @param {boolean} [options.pluginLoadFailed]  Whether plugin loading failed
  */
-export function initializeEditor( { allowedBlockTypes } = {} ) {
+export function initializeEditor( {
+	allowedBlockTypes,
+	pluginLoadFailed,
+} = {} ) {
 	const { themeStyles, hideTitle, editorSettings, logLevel } = getGBKit();
 
 	const settings = editorSettings || getDefaultEditorSettings();
@@ -49,7 +53,11 @@ export function initializeEditor( { allowedBlockTypes } = {} ) {
 
 	createRoot( document.getElementById( 'root' ) ).render(
 		<StrictMode>
-			<Layout post={ post } hideTitle={ hideTitle } />
+			<Layout
+				post={ post }
+				hideTitle={ hideTitle }
+				pluginLoadFailed={ pluginLoadFailed }
+			/>
 		</StrictMode>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Improve editor load resiliency, particularly when plugin loading fails.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-939. Fix CMM-899. Handle unexpected failures--e.g., legacy REST API implementations.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Filter duplicative WordPress core/Gutenberg assets.
- On plugin load failure, load the default editor configuration.
- Remove redundant un-registering of block types.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
## 1. Editor loads for sites with legacy REST API endpoints
1. In the Demo app, add a remote site with the latest stable Jetpack plugin release.
1. Open the editor for the site.
1. **Verify** the editor loads and does not display error messages.

## 2. Editor falls back to default configurations when plugin loading fails
1. In the Demo app, add a remote site with the latest stable Jetpack plugin release.
1. Introduce an intentional failure.
   <details><summary>Example failure diff</summary>

   ```diff
   diff --git a/src/utils/editor-loader.js b/src/utils/editor-loader.js
   index 6903c1b..40fd2e1 100644
   --- a/src/utils/editor-loader.js
   +++ b/src/utils/editor-loader.js
   @@ -30,6 +30,7 @@ export async function loadEditorAssets( {
      disallowedPackages = [],
   } = {} ) {
      try {
   +		throw new Error( 'Plugin loading failed.' );
         // Return cached response if available
         if ( editorAssetsCache ) {
            return processEditorAssets( editorAssetsCache, {

   ```

   </details>
1. **Verify** the editor loads with the default configurations (i.e., without
   plugins).

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes.

## Screenshots or screencast <!-- if applicable -->
<img width="380" height="756" alt="plugin-load-failure" src="https://github.com/user-attachments/assets/53bd91af-13c3-431e-97bd-2538d0c03bef" />
