### PR TITLE
fix: Prevent crash from duplicate category pattern keys

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/Views/Patterns/PatternsViewModel.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/Patterns/PatternsViewModel.swift
@@ -11,7 +11,8 @@ final class PatternsViewModel: ObservableObject {
 
     init(patterns: [Pattern], patternCategories: [PatternCategory] = []) {
         let categoryLabels = Dictionary(
-            uniqueKeysWithValues: patternCategories.map { ($0.name, $0.label) }
+            patternCategories.map { ($0.name, $0.label) },
+            uniquingKeysWith: { first, _ in first }
         )
         // Build a mapping of category -> patterns in input order
         var categoryPatterns: [String: [Pattern]] = [:]


### PR DESCRIPTION
A fatal error was thrown when the logic encountered keys of the same value twice.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixed a crash in PatternsViewModel caused by duplicate pattern category keys when initializing the category labels dictionary.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The app was experiencing a fatal crash: `Swift/NativeDictionary.swift:792: Fatal error: Duplicate values for key: 'about' at PatternsViewModel.swift:13`.

This occurred when the JavaScript/Gutenberg code sent pattern categories with duplicate name values (e.g., multiple entries with the name "about"). The `Dictionary(uniqueKeysWithValues:)` initializer requires all keys to be unique and crashes when duplicates are encountered, making the block inserter completely unusable when this condition occurred.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replaced the crash-prone `Dictionary(uniqueKeysWithValues:)` initializer with `Dictionary(_:uniquingKeysWith:)`, which gracefully handles duplicate keys by keeping the first label value and discarding subsequent duplicates.

Before:
```swift
let categoryLabels = Dictionary(
    uniqueKeysWithValues: patternCategories.map { ($0.name, $0.label) }
)
```

After:
```swift
let categoryLabels = Dictionary(
    patternCategories.map { ($0.name, $0.label) },
    uniquingKeysWith: { first, _ in first }
)
```

This maintains the intended functionality of looking up localized category labels while preventing crashes when duplicate category names are present in the data.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
> [!important]
> I only encountered the crash occurred when using a WPCOM Simple site, which presumably had duplicate keys.

1. Clone the WordPress-iOS app integration logic: https://github.com/wordpress-mobile/WordPress-iOS/pull/24708
1. Configure the project to use the local `GutenbergKit` repository. 
1. Run the WP-iOS app. 
1. Enable the native inserter.
1. Open the post editor for a WPCOM Simple site.
1. Tap the block inserter (+) button.
1. Tap the patterns button in the top-right corner.

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A no UI changes.

## Screenshots or screencast <!-- if applicable -->
N/A no visual changes.
