### PR TITLE
feat: Discover Android demo app configuration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -50,7 +50,6 @@ dependencies {
     implementation(libs.androidx.recyclerview)
     implementation(libs.wordpress.rs.android)
     implementation(project(":Gutenberg"))
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
     // Compose
     implementation(platform(libs.androidx.compose.bom))

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.androidx.recyclerview)
     implementation(libs.wordpress.rs.android)
     implementation(project(":Gutenberg"))
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
     // Compose
     implementation(platform(libs.androidx.compose.bom))

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -44,14 +44,19 @@ import com.example.gutenbergkit.ui.dialogs.AddConfigurationDialog
 import com.example.gutenbergkit.ui.dialogs.DeleteConfigurationDialog
 import com.example.gutenbergkit.ui.dialogs.DiscoveringSiteDialog
 import com.example.gutenbergkit.ui.theme.AppTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.wordpress.gutenberg.BuildConfig
 import org.wordpress.gutenberg.EditorConfiguration
 
 class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCallback {
     private val configurations = mutableStateListOf<ConfigurationItem>()
     private val isDiscoveringSite = mutableStateOf(false)
+    private val isLoadingCapabilities = mutableStateOf(false)
     private lateinit var configurationStorage: ConfigurationStorage
     private lateinit var authenticationManager: AuthenticationManager
+    private val siteCapabilitiesDiscovery = SiteCapabilitiesDiscovery()
 
     companion object {
         const val EXTRA_CONFIGURATION = "configuration"
@@ -77,7 +82,7 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
                     onConfigurationClick = { config ->
                         when (config) {
                             is ConfigurationItem.BundledEditor -> launchEditor(createBundledConfiguration())
-                            is ConfigurationItem.RemoteEditor -> launchEditor(createRemoteConfiguration(config))
+                            is ConfigurationItem.RemoteEditor -> loadRemoteEditor(config)
                         }
                     },
                     onConfigurationLongClick = { config ->
@@ -95,7 +100,8 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
                         configurationStorage.saveConfigurations(configurations)
                     },
                     isDiscoveringSite = isDiscoveringSite.value,
-                    onDismissDiscovering = { isDiscoveringSite.value = false }
+                    onDismissDiscovering = { isDiscoveringSite.value = false },
+                    isLoadingCapabilities = isLoadingCapabilities.value
                 )
             }
         }
@@ -112,14 +118,43 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
             .setCookies(emptyMap())
             .build()
 
-    private fun createRemoteConfiguration(config: ConfigurationItem.RemoteEditor): EditorConfiguration =
-        createCommonConfigurationBuilder()
-            .setPlugins(true)
-            .setSiteURL(config.siteUrl)
-            .setSiteApiRoot(config.siteApiRoot)
-            .setNamespaceExcludedPaths(arrayOf())
-            .setAuthHeader(config.authHeader)
-            .build()
+    private fun loadRemoteEditor(config: ConfigurationItem.RemoteEditor) {
+        isLoadingCapabilities.value = true
+
+        CoroutineScope(Dispatchers.Main).launch {
+            try {
+                val capabilities = siteCapabilitiesDiscovery.discoverCapabilities(
+                    siteApiRoot = config.siteApiRoot,
+                    authHeader = config.authHeader
+                )
+
+                val editorConfiguration = createCommonConfigurationBuilder()
+                    .setPlugins(capabilities.supportsPlugins)
+                    .setThemeStyles(capabilities.supportsThemeStyles)
+                    .setSiteURL(config.siteUrl)
+                    .setSiteApiRoot(config.siteApiRoot)
+                    .setNamespaceExcludedPaths(arrayOf())
+                    .setAuthHeader(config.authHeader)
+                    .build()
+
+                isLoadingCapabilities.value = false
+                launchEditor(editorConfiguration)
+            } catch (e: Exception) {
+                isLoadingCapabilities.value = false
+                // If capability discovery fails, use default configuration
+                val defaultConfiguration = createCommonConfigurationBuilder()
+                    .setPlugins(false)
+                    .setThemeStyles(false)
+                    .setSiteURL(config.siteUrl)
+                    .setSiteApiRoot(config.siteApiRoot)
+                    .setNamespaceExcludedPaths(arrayOf())
+                    .setAuthHeader(config.authHeader)
+                    .build()
+
+                launchEditor(defaultConfiguration)
+            }
+        }
+    }
 
     private fun createCommonConfigurationBuilder(): EditorConfiguration.Builder =
         EditorConfiguration.builder()
@@ -173,7 +208,8 @@ fun MainScreen(
     onAddConfiguration: (String) -> Unit,
     onDeleteConfiguration: (ConfigurationItem) -> Unit,
     isDiscoveringSite: Boolean = false,
-    onDismissDiscovering: () -> Unit = {}
+    onDismissDiscovering: () -> Unit = {},
+    isLoadingCapabilities: Boolean = false
 ) {
     var showAddDialog = remember { mutableStateOf(false) }
     var showDeleteDialog = remember { mutableStateOf<ConfigurationItem.RemoteEditor?>(null) }
@@ -295,6 +331,12 @@ fun MainScreen(
     if (isDiscoveringSite) {
         DiscoveringSiteDialog(
             onDismiss = onDismissDiscovering
+        )
+    }
+
+    if (isLoadingCapabilities) {
+        DiscoveringSiteDialog(
+            onDismiss = { /* Cannot dismiss while loading */ }
         )
     }
 }

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -124,8 +124,7 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
         CoroutineScope(Dispatchers.Main).launch {
             try {
                 val capabilities = siteCapabilitiesDiscovery.discoverCapabilities(
-                    siteApiRoot = config.siteApiRoot,
-                    authHeader = config.authHeader
+                    siteApiRoot = config.siteApiRoot
                 )
 
                 val editorConfiguration = createCommonConfigurationBuilder()

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -44,8 +44,7 @@ import com.example.gutenbergkit.ui.dialogs.AddConfigurationDialog
 import com.example.gutenbergkit.ui.dialogs.DeleteConfigurationDialog
 import com.example.gutenbergkit.ui.dialogs.DiscoveringSiteDialog
 import com.example.gutenbergkit.ui.theme.AppTheme
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import org.wordpress.gutenberg.BuildConfig
 import org.wordpress.gutenberg.EditorConfiguration
@@ -121,7 +120,7 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
     private fun loadRemoteEditor(config: ConfigurationItem.RemoteEditor) {
         isLoadingCapabilities.value = true
 
-        CoroutineScope(Dispatchers.Main).launch {
+        lifecycleScope.launch {
             try {
                 val capabilities = siteCapabilitiesDiscovery.discoverCapabilities(
                     siteApiRoot = config.siteApiRoot

--- a/android/app/src/main/java/com/example/gutenbergkit/SiteCapabilitiesDiscovery.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SiteCapabilitiesDiscovery.kt
@@ -1,0 +1,103 @@
+package com.example.gutenbergkit
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+
+/**
+ * Data class representing the capabilities discovered from a WordPress site.
+ */
+data class SiteCapabilities(
+    val supportsPlugins: Boolean,
+    val supportsThemeStyles: Boolean
+)
+
+/**
+ * Discovers WordPress site capabilities by querying the API root endpoint.
+ * This mirrors the iOS implementation's capability discovery logic.
+ */
+class SiteCapabilitiesDiscovery {
+
+    companion object {
+        private const val TAG = "SiteCapabilitiesDiscovery"
+
+        // Routes to check for capability support
+        private const val ROUTE_EDITOR_ASSETS = "/wpcom/v2/editor-assets"
+        private const val ROUTE_EDITOR_SETTINGS = "/wp-block-editor/v1/settings"
+    }
+
+    /**
+     * Discovers site capabilities by fetching the API root metadata.
+     *
+     * @param siteApiRoot The WordPress REST API root URL
+     * @param authHeader The authentication header (e.g., "Basic xyz123")
+     * @return SiteCapabilities indicating which features are supported
+     */
+    suspend fun discoverCapabilities(
+        siteApiRoot: String,
+        authHeader: String
+    ): SiteCapabilities = withContext(Dispatchers.IO) {
+        try {
+            val client = OkHttpClient()
+            val request = Request.Builder()
+                .url(siteApiRoot)
+                .addHeader("Authorization", authHeader)
+                .build()
+
+            val response = client.newCall(request).execute()
+
+            if (!response.isSuccessful) {
+                Log.w(TAG, "Failed to fetch API root: ${response.code}")
+                return@withContext getDefaultCapabilities()
+            }
+
+            val responseBody = response.body?.string()
+            if (responseBody == null) {
+                Log.w(TAG, "Empty response body from API root")
+                return@withContext getDefaultCapabilities()
+            }
+
+            val apiRoot = JSONObject(responseBody)
+            val routes = apiRoot.optJSONObject("routes")
+
+            if (routes == null) {
+                Log.w(TAG, "No routes found in API root response")
+                return@withContext getDefaultCapabilities()
+            }
+
+            val supportsPlugins = hasRoute(routes, ROUTE_EDITOR_ASSETS)
+            val supportsThemeStyles = hasRoute(routes, ROUTE_EDITOR_SETTINGS)
+
+            Log.d(TAG, "Discovered capabilities - Plugins: $supportsPlugins, Theme Styles: $supportsThemeStyles")
+
+            SiteCapabilities(
+                supportsPlugins = supportsPlugins,
+                supportsThemeStyles = supportsThemeStyles
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Error discovering site capabilities", e)
+            getDefaultCapabilities()
+        }
+    }
+
+    /**
+     * Checks if a specific route exists in the routes object.
+     */
+    private fun hasRoute(routes: JSONObject, route: String): Boolean {
+        return routes.has(route)
+    }
+
+    /**
+     * Returns default capabilities when discovery fails.
+     * Conservative defaults: no plugins, no theme styles.
+     */
+    private fun getDefaultCapabilities(): SiteCapabilities {
+        return SiteCapabilities(
+            supportsPlugins = false,
+            supportsThemeStyles = false
+        )
+    }
+}

--- a/android/app/src/main/java/com/example/gutenbergkit/SiteCapabilitiesDiscovery.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SiteCapabilitiesDiscovery.kt
@@ -3,9 +3,8 @@ package com.example.gutenbergkit
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import org.json.JSONObject
+import rs.wordpress.api.kotlin.ApiDiscoveryResult
+import rs.wordpress.api.kotlin.WpLoginClient
 
 /**
  * Data class representing the capabilities discovered from a WordPress site.
@@ -30,64 +29,45 @@ class SiteCapabilitiesDiscovery {
     }
 
     /**
-     * Discovers site capabilities by fetching the API root metadata.
+     * Discovers site capabilities via API discovery.
      *
-     * @param siteApiRoot The WordPress REST API root URL
-     * @param authHeader The authentication header (e.g., "Basic xyz123")
+     * @param siteApiRoot The WordPress REST API root URL (e.g., "https://example.com/wp-json")
      * @return SiteCapabilities indicating which features are supported
      */
     suspend fun discoverCapabilities(
         siteApiRoot: String,
-        authHeader: String
     ): SiteCapabilities = withContext(Dispatchers.IO) {
         try {
-            val client = OkHttpClient()
-            val request = Request.Builder()
-                .url(siteApiRoot)
-                .addHeader("Authorization", authHeader)
-                .build()
+            // Extract the site URL from the API root URL
+            // e.g., "https://example.com/wp-json" -> "https://example.com"
+            val siteUrl = siteApiRoot.removeSuffix("/").substringBeforeLast("/wp-json")
 
-            val response = client.newCall(request).execute()
+            // Use WpLoginClient to perform API discovery, which includes API details
+            when (val apiDiscoveryResult = WpLoginClient().apiDiscovery(siteUrl)) {
+                is ApiDiscoveryResult.Success -> {
+                    val success = apiDiscoveryResult.success
+                    val apiDetails = success.apiDetails
 
-            if (!response.isSuccessful) {
-                Log.w(TAG, "Failed to fetch API root: ${response.code}")
-                return@withContext getDefaultCapabilities()
+                    // Check if the site has the required routes using hasRoute() method
+                    val supportsPlugins = apiDetails.hasRoute(ROUTE_EDITOR_ASSETS)
+                    val supportsThemeStyles = apiDetails.hasRoute(ROUTE_EDITOR_SETTINGS)
+
+                    Log.d(TAG, "Discovered capabilities - Plugins: $supportsPlugins, Theme Styles: $supportsThemeStyles")
+
+                    SiteCapabilities(
+                        supportsPlugins = supportsPlugins,
+                        supportsThemeStyles = supportsThemeStyles
+                    )
+                }
+                else -> {
+                    Log.w(TAG, "API discovery failed: $apiDiscoveryResult")
+                    getDefaultCapabilities()
+                }
             }
-
-            val responseBody = response.body?.string()
-            if (responseBody == null) {
-                Log.w(TAG, "Empty response body from API root")
-                return@withContext getDefaultCapabilities()
-            }
-
-            val apiRoot = JSONObject(responseBody)
-            val routes = apiRoot.optJSONObject("routes")
-
-            if (routes == null) {
-                Log.w(TAG, "No routes found in API root response")
-                return@withContext getDefaultCapabilities()
-            }
-
-            val supportsPlugins = hasRoute(routes, ROUTE_EDITOR_ASSETS)
-            val supportsThemeStyles = hasRoute(routes, ROUTE_EDITOR_SETTINGS)
-
-            Log.d(TAG, "Discovered capabilities - Plugins: $supportsPlugins, Theme Styles: $supportsThemeStyles")
-
-            SiteCapabilities(
-                supportsPlugins = supportsPlugins,
-                supportsThemeStyles = supportsThemeStyles
-            )
         } catch (e: Exception) {
             Log.e(TAG, "Error discovering site capabilities", e)
             getDefaultCapabilities()
         }
-    }
-
-    /**
-     * Checks if a specific route exists in the routes object.
-     */
-    private fun hasRoute(routes: JSONObject, route: String): Boolean {
-        return routes.has(route)
     }
 
     /**

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ mockito = "4.1.0"
 robolectric = "4.14.1"
 kotlinx-coroutines = '1.10.2'
 androidx-recyclerview = '1.3.2'
-wordpress-rs = 'trunk-503f1da9e067677d1517d09f926b1d038dfa58a1'
+wordpress-rs = 'trunk-d02efa6d4d56bc5b44dd2191e837163f9fa27095'
 composeBom = "2024.12.01"
 activityCompose = "1.9.3"
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Mirror the [iOS demo app](https://github.com/wordpress-mobile/GutenbergKit/blob/ef47b0924274364611efe3a5d6444ecda92f4905/ios/Demo-iOS/Sources/Views/AppRootView.swift#L61-L91) by configuring `plugins` and `themeStyles` options through site API discovery. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Allows remote editor configurations to match the capabilities of the site itself. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Leverage the `WpApiClient` to retrieve the available routes for a site. Configure the editor for a site when launching the editor. 

> [!note]
> It appears the `WpApiClient` caches the values retrieved, so they become stale after initial retrieval. A future improvement would be updating the `wordpress-rs` project to allow disabling caching for these requests, like [iOS does](https://github.com/wordpress-mobile/GutenbergKit/blob/ef47b0924274364611efe3a5d6444ecda92f4905/ios/Demo-iOS/Sources/Services/AuthenticationManager.swift#L31). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add a remote editor configuration entry. 
2. **Verify** the resulting GBK configuration matches that of the site.[^1]

[^1]: The Gutenberg plugin defines the `/wp-block-editor/v1/settings` route, enabling `themeStyles`; the Jetpack plugin defines the `/wpcom/v2/editor-assets` route, enabling `plugins`.  

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes. 