### PR TITLE
fix: Incorrect media attachment position

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -550,14 +550,11 @@ class GutenbergView : WebView {
                 null
             }
 
-            // Parse contextId (required)
-            val contextId = jsonObj.getString("contextId")
-
             // Store contextId to pass back when media is selected
+            val contextId = jsonObj.getString("contextId")
             currentMediaContextId = contextId
 
             val config = OpenMediaLibraryConfig(allowedTypes = allowedTypes, multiple = multiple, value = value, contextId = contextId)
-
             openMediaLibraryListener?.onOpenMediaLibrary(config)
         } catch (e: JSONException) {
             e.printStackTrace()
@@ -576,11 +573,9 @@ class GutenbergView : WebView {
             return
         }
 
-        // Pass the contextId back to JavaScript so it can route to the correct callback
         val escapedContextId = contextId.replace("'", "\\'")
         this.evaluateJavascript("editor.setMediaUploadAttachment($media, '$escapedContextId');", null)
 
-        // Clear the contextId after use
         currentMediaContextId = null
     }
 

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -56,6 +56,12 @@ class GutenbergView : WebView {
     private var autocompleterTriggeredListener: AutocompleterTriggeredListener? = null
     private var modalDialogStateListener: ModalDialogStateListener? = null
 
+    /**
+     * Stores the contextId from the most recent openMediaLibrary call
+     * to pass back to JavaScript when media is selected
+     */
+    private var currentMediaContextId: String? = null
+
     var textEditorEnabled: Boolean = false
         set(value) {
             field = value
@@ -374,7 +380,8 @@ class GutenbergView : WebView {
     data class OpenMediaLibraryConfig(
         val allowedTypes: Array<MediaType>,
         val multiple: Boolean,
-        val value: Value?
+        val value: Value?,
+        val contextId: String?
     )
 
     interface OpenMediaLibraryListener {
@@ -543,7 +550,17 @@ class GutenbergView : WebView {
                 null
             }
 
-            val config = OpenMediaLibraryConfig(allowedTypes = allowedTypes, multiple = multiple, value = value)
+            // Parse contextId
+            val contextId = if (jsonObj.has("contextId")) {
+                jsonObj.getString("contextId")
+            } else {
+                null
+            }
+
+            // Store contextId to pass back when media is selected
+            currentMediaContextId = contextId
+
+            val config = OpenMediaLibraryConfig(allowedTypes = allowedTypes, multiple = multiple, value = value, contextId = contextId)
 
             openMediaLibraryListener?.onOpenMediaLibrary(config)
         } catch (e: JSONException) {
@@ -556,7 +573,16 @@ class GutenbergView : WebView {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
-        this.evaluateJavascript("editor.setMediaUploadAttachment($media);", null)
+        // Pass the contextId back to JavaScript so it can route to the correct callback
+        if (currentMediaContextId != null) {
+            val escapedContextId = currentMediaContextId!!.replace("'", "\\'")
+            this.evaluateJavascript("editor.setMediaUploadAttachment($media, '$escapedContextId');", null)
+            // Clear the contextId after use
+            currentMediaContextId = null
+        } else {
+            // Fallback for backward compatibility (no contextId)
+            this.evaluateJavascript("editor.setMediaUploadAttachment($media);", null)
+        }
     }
 
     @JavascriptInterface

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -381,7 +381,7 @@ class GutenbergView : WebView {
         val allowedTypes: Array<MediaType>,
         val multiple: Boolean,
         val value: Value?,
-        val contextId: String?
+        val contextId: String
     )
 
     interface OpenMediaLibraryListener {
@@ -550,12 +550,8 @@ class GutenbergView : WebView {
                 null
             }
 
-            // Parse contextId
-            val contextId = if (jsonObj.has("contextId")) {
-                jsonObj.getString("contextId")
-            } else {
-                null
-            }
+            // Parse contextId (required)
+            val contextId = jsonObj.getString("contextId")
 
             // Store contextId to pass back when media is selected
             currentMediaContextId = contextId
@@ -573,16 +569,19 @@ class GutenbergView : WebView {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
             return
         }
-        // Pass the contextId back to JavaScript so it can route to the correct callback
-        if (currentMediaContextId != null) {
-            val escapedContextId = currentMediaContextId!!.replace("'", "\\'")
-            this.evaluateJavascript("editor.setMediaUploadAttachment($media, '$escapedContextId');", null)
-            // Clear the contextId after use
-            currentMediaContextId = null
-        } else {
-            // Fallback for backward compatibility (no contextId)
-            this.evaluateJavascript("editor.setMediaUploadAttachment($media);", null)
+
+        val contextId = currentMediaContextId
+        if (contextId == null) {
+            Log.e("GutenbergView", "setMediaUploadAttachment called without contextId")
+            return
         }
+
+        // Pass the contextId back to JavaScript so it can route to the correct callback
+        val escapedContextId = contextId.replace("'", "\\'")
+        this.evaluateJavascript("editor.setMediaUploadAttachment($media, '$escapedContextId');", null)
+
+        // Clear the contextId after use
+        currentMediaContextId = null
     }
 
     @JavascriptInterface

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -347,16 +347,17 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     }
 
     public func setMediaUploadAttachment(_ media: String) {
-        // Pass the contextId back to JavaScript so it can route to the correct callback
-        if let contextId = currentMediaContextId {
-            let escapedContextId = contextId.replacingOccurrences(of: "'", with: "\\'")
-            evaluate("editor.setMediaUploadAttachment(\(media), '\(escapedContextId)');")
-            // Clear the contextId after use
-            currentMediaContextId = nil
-        } else {
-            // Fallback for backward compatibility (no contextId)
-            evaluate("editor.setMediaUploadAttachment(\(media));")
+        guard let contextId = currentMediaContextId else {
+            NSLog("setMediaUploadAttachment called without contextId")
+            return
         }
+
+        // Pass the contextId back to JavaScript so it can route to the correct callback
+        let escapedContextId = contextId.replacingOccurrences(of: "'", with: "\\'")
+        evaluate("editor.setMediaUploadAttachment(\(media), '\(escapedContextId)');")
+
+        // Clear the contextId after use
+        currentMediaContextId = nil
     }
 
     /// Appends text at the current cursor position in the editor.

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -24,6 +24,10 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
 
     private var cancellables: [AnyCancellable] = []
 
+    /// Stores the contextId from the most recent openMediaLibrary call
+    /// to pass back to JavaScript when media is selected
+    private var currentMediaContextId: String?
+
     /// Warmup mode preloads resources into memory to make the UI transition seamless when displaying the editor for the first time
     ///
     private let isWarmupMode: Bool
@@ -337,11 +341,22 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     }
 
     private func openMediaLibrary(_ config: OpenMediaLibraryAction) {
+        // Store the contextId to pass back when media is selected
+        currentMediaContextId = config.contextId
         delegate?.editor(self, didRequestMediaFromSiteMediaLibrary: config)
     }
 
     public func setMediaUploadAttachment(_ media: String) {
-        evaluate("editor.setMediaUploadAttachment(\(media));")
+        // Pass the contextId back to JavaScript so it can route to the correct callback
+        if let contextId = currentMediaContextId {
+            let escapedContextId = contextId.replacingOccurrences(of: "'", with: "\\'")
+            evaluate("editor.setMediaUploadAttachment(\(media), '\(escapedContextId)');")
+            // Clear the contextId after use
+            currentMediaContextId = nil
+        } else {
+            // Fallback for backward compatibility (no contextId)
+            evaluate("editor.setMediaUploadAttachment(\(media));")
+        }
     }
 
     /// Appends text at the current cursor position in the editor.

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -29,7 +29,6 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     private var currentMediaContextId: String?
 
     /// Warmup mode preloads resources into memory to make the UI transition seamless when displaying the editor for the first time
-    ///
     private let isWarmupMode: Bool
 
     /// HTML Preview Manager instance for rendering pattern previews
@@ -352,11 +351,9 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
             return
         }
 
-        // Pass the contextId back to JavaScript so it can route to the correct callback
         let escapedContextId = contextId.replacingOccurrences(of: "'", with: "\\'")
         evaluate("editor.setMediaUploadAttachment(\(media), '\(escapedContextId)');")
 
-        // Clear the contextId after use
         currentMediaContextId = nil
     }
 
@@ -510,4 +507,3 @@ private final class GutenbergEditorController: NSObject, WKNavigationDelegate, W
 
 
 #endif
-

--- a/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
@@ -121,15 +121,17 @@ public struct OpenMediaLibraryAction: Codable {
     public let allowedTypes: [MediaType]?
     public let multiple: Bool
     public let value: Value?
+    public let contextId: String?
 
     private enum CodingKeys: String, CodingKey {
-        case allowedTypes, multiple, value
+        case allowedTypes, multiple, value, contextId
     }
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.allowedTypes = try container.decodeIfPresent([OpenMediaLibraryAction.MediaType].self, forKey: .allowedTypes)
         self.multiple = try container.decode(Bool.self, forKey: .multiple)
+        self.contextId = try container.decodeIfPresent(String.self, forKey: .contextId)
 
         // Decode value as either Int? or [Int]?
         if let singleValue = try? container.decodeIfPresent(Int.self, forKey: .value) {

--- a/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
@@ -121,7 +121,7 @@ public struct OpenMediaLibraryAction: Codable {
     public let allowedTypes: [MediaType]?
     public let multiple: Bool
     public let value: Value?
-    public let contextId: String?
+    public let contextId: String
 
     private enum CodingKeys: String, CodingKey {
         case allowedTypes, multiple, value, contextId
@@ -131,7 +131,7 @@ public struct OpenMediaLibraryAction: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.allowedTypes = try container.decodeIfPresent([OpenMediaLibraryAction.MediaType].self, forKey: .allowedTypes)
         self.multiple = try container.decode(Bool.self, forKey: .multiple)
-        self.contextId = try container.decodeIfPresent(String.self, forKey: .contextId)
+        self.contextId = try container.decode(String.self, forKey: .contextId)
 
         // Decode value as either Int? or [Int]?
         if let singleValue = try? container.decodeIfPresent(Int.self, forKey: .value) {

--- a/src/components/editor/test/use-media-upload.test.jsx
+++ b/src/components/editor/test/use-media-upload.test.jsx
@@ -244,34 +244,6 @@ describe( 'useMediaUpload', () => {
 			expect( onSelectBefore ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'should warn when contextId is missing', () => {
-			let MediaUploadComponent;
-			addFilter.mockImplementation( ( name, namespace, callback ) => {
-				MediaUploadComponent = callback();
-			} );
-
-			const onSelect = vi.fn();
-
-			renderHook( () => useMediaUpload() );
-
-			render(
-				<MediaUploadComponent
-					render={ ( { open } ) => open() }
-					onSelect={ onSelect }
-					multiple={ false }
-				/>
-			);
-
-			// Call without contextId
-			window.editor.setMediaUploadAttachment( [ 'test-image.jpg' ] );
-
-			// Should warn and not call the callback
-			expect( warn ).toHaveBeenCalledWith(
-				'setMediaUploadAttachment called without contextId'
-			);
-			expect( onSelect ).not.toHaveBeenCalled();
-		} );
-
 		it( 'should warn when an invalid contextId is provided', () => {
 			let MediaUploadComponent;
 			addFilter.mockImplementation( ( name, namespace, callback ) => {

--- a/src/components/editor/test/use-media-upload.test.jsx
+++ b/src/components/editor/test/use-media-upload.test.jsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
-import { render, renderHook } from '@testing-library/react';
+import { render, renderHook, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -18,9 +18,16 @@ import {
 	afterEach,
 } from 'vitest';
 import { openMediaLibrary } from '../../../utils/bridge';
+import { warn } from '../../../utils/logger';
 
 vi.mock( '@wordpress/hooks' );
 vi.mock( '../../../utils/bridge', { spy: true } );
+vi.mock( '../../../utils/logger', () => ( {
+	warn: vi.fn(),
+	error: vi.fn(),
+	info: vi.fn(),
+	debug: vi.fn(),
+} ) );
 
 describe( 'useMediaUpload', () => {
 	beforeAll( () => {
@@ -137,6 +144,229 @@ describe( 'useMediaUpload', () => {
 			/>
 		);
 
-		expect( openMediaLibrary ).toHaveBeenCalledWith( { multiple: false } );
+		expect( openMediaLibrary ).toHaveBeenCalledWith(
+			expect.objectContaining( { multiple: false } )
+		);
+	} );
+
+	describe( 'Context ID routing for multiple MediaPlaceholder instances', () => {
+		it( 'should route media to the correct callback when multiple instances exist', async () => {
+			let MediaUploadComponent;
+			addFilter.mockImplementation( ( name, namespace, callback ) => {
+				MediaUploadComponent = callback();
+			} );
+
+			const onSelectBefore = vi.fn();
+			const onSelectAfter = vi.fn();
+			let openBefore;
+			let openAfter;
+
+			renderHook( () => useMediaUpload() );
+
+			// Render two MediaPlaceholder instances (like in Image Compare block)
+			render(
+				<>
+					<MediaUploadComponent
+						render={ ( { open } ) => {
+							openBefore = open;
+							return null;
+						} }
+						onSelect={ onSelectBefore }
+						multiple={ false }
+					/>
+					<MediaUploadComponent
+						render={ ( { open } ) => {
+							openAfter = open;
+							return null;
+						} }
+						onSelect={ onSelectAfter }
+						multiple={ false }
+					/>
+				</>
+			);
+
+			// Wait for effects to run and call open() after component is mounted
+			await waitFor( () => {
+				openBefore();
+				openAfter();
+			} );
+
+			// Get the contextId from the openMediaLibrary calls
+			const firstCallArgs = openMediaLibrary.mock.calls[ 0 ][ 0 ];
+			const contextIdBefore = firstCallArgs.contextId;
+
+			const secondCallArgs = openMediaLibrary.mock.calls[ 1 ][ 0 ];
+			const contextIdAfter = secondCallArgs.contextId;
+
+			// Verify both contextIds are unique
+			expect( contextIdBefore ).toBeDefined();
+			expect( contextIdAfter ).toBeDefined();
+			expect( contextIdBefore ).not.toBe( contextIdAfter );
+
+			// Simulate native returning media to the "before" slot
+			window.editor.setMediaUploadAttachment(
+				[ 'image-before.jpg' ],
+				contextIdBefore
+			);
+
+			expect( onSelectBefore ).toHaveBeenCalledWith( 'image-before.jpg' );
+			expect( onSelectAfter ).not.toHaveBeenCalled();
+
+			// Simulate native returning media to the "after" slot
+			window.editor.setMediaUploadAttachment(
+				[ 'image-after.jpg' ],
+				contextIdAfter
+			);
+
+			expect( onSelectAfter ).toHaveBeenCalledWith( 'image-after.jpg' );
+			expect( onSelectBefore ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should use the last callback as fallback when no contextId is provided (backward compatibility)', () => {
+			let MediaUploadComponent;
+			addFilter.mockImplementation( ( name, namespace, callback ) => {
+				MediaUploadComponent = callback();
+			} );
+
+			const onSelectFirst = vi.fn();
+			const onSelectSecond = vi.fn();
+
+			renderHook( () => useMediaUpload() );
+
+			render(
+				<>
+					<MediaUploadComponent
+						render={ ( { open } ) => open() }
+						onSelect={ onSelectFirst }
+						multiple={ false }
+					/>
+					<MediaUploadComponent
+						render={ ( { open } ) => open() }
+						onSelect={ onSelectSecond }
+						multiple={ false }
+					/>
+				</>
+			);
+
+			// Call without contextId (backward compatibility)
+			window.editor.setMediaUploadAttachment( [ 'test-image.jpg' ] );
+
+			// Should call the last registered callback
+			expect( onSelectSecond ).toHaveBeenCalledWith( 'test-image.jpg' );
+			expect( onSelectFirst ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should warn when an invalid contextId is provided', () => {
+			let MediaUploadComponent;
+			addFilter.mockImplementation( ( name, namespace, callback ) => {
+				MediaUploadComponent = callback();
+			} );
+
+			renderHook( () => useMediaUpload() );
+			render(
+				<MediaUploadComponent
+					render={ ( { open } ) => open() }
+					onSelect={ vi.fn() }
+					multiple={ false }
+				/>
+			);
+
+			// Call with an invalid contextId
+			window.editor.setMediaUploadAttachment(
+				[ 'test-image.jpg' ],
+				'invalid-context-id'
+			);
+
+			expect( warn ).toHaveBeenCalledWith(
+				expect.stringContaining( 'No callback found for contextId' )
+			);
+		} );
+
+		it( 'should clean up callback from registry when component unmounts', () => {
+			let MediaUploadComponent;
+			addFilter.mockImplementation( ( name, namespace, callback ) => {
+				MediaUploadComponent = callback();
+			} );
+
+			const onSelectFirst = vi.fn();
+			const onSelectSecond = vi.fn();
+
+			renderHook( () => useMediaUpload() );
+
+			const { unmount } = render(
+				<>
+					<MediaUploadComponent
+						render={ ( { open } ) => open() }
+						onSelect={ onSelectFirst }
+						multiple={ false }
+					/>
+					<MediaUploadComponent
+						render={ ( { open } ) => open() }
+						onSelect={ onSelectSecond }
+						multiple={ false }
+					/>
+				</>
+			);
+
+			// Get contextIds before unmounting
+			const firstCallArgs = openMediaLibrary.mock.calls[ 0 ][ 0 ];
+			const secondCallArgs = openMediaLibrary.mock.calls[ 1 ][ 0 ];
+			const contextIdFirst = firstCallArgs.contextId;
+			const contextIdSecond = secondCallArgs.contextId;
+
+			// Unmount both components
+			unmount();
+
+			// Try to use the contextIds after unmount
+			window.editor.setMediaUploadAttachment(
+				[ 'image1.jpg' ],
+				contextIdFirst
+			);
+			window.editor.setMediaUploadAttachment(
+				[ 'image2.jpg' ],
+				contextIdSecond
+			);
+
+			// Neither callback should be called since they were cleaned up
+			expect( onSelectFirst ).not.toHaveBeenCalled();
+			expect( onSelectSecond ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should pass contextId to openMediaLibrary when opening picker', async () => {
+			let MediaUploadComponent;
+			addFilter.mockImplementation( ( name, namespace, callback ) => {
+				MediaUploadComponent = callback();
+			} );
+
+			let openPicker;
+
+			renderHook( () => useMediaUpload() );
+			render(
+				<MediaUploadComponent
+					render={ ( { open } ) => {
+						openPicker = open;
+						return null;
+					} }
+					onSelect={ vi.fn() }
+					allowedTypes={ [ 'image' ] }
+					multiple={ false }
+					value={ 123 }
+				/>
+			);
+
+			// Wait for effects to run and then call open()
+			await waitFor( () => {
+				openPicker();
+			} );
+
+			expect( openMediaLibrary ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					allowedTypes: [ 'image' ],
+					multiple: false,
+					value: 123,
+					contextId: expect.stringMatching( /^media-upload-\d+$/ ),
+				} )
+			);
+		} );
 	} );
 } );

--- a/src/components/editor/test/use-media-upload.test.jsx
+++ b/src/components/editor/test/use-media-upload.test.jsx
@@ -65,49 +65,71 @@ describe( 'useMediaUpload', () => {
 		);
 	} );
 
-	it( 'should define the setMediaUploadAttachment function', () => {
+	it( 'should define the setMediaUploadAttachment function', async () => {
 		let MediaUploadComponent;
 		addFilter.mockImplementation( ( name, namespace, callback ) => {
 			MediaUploadComponent = callback();
 		} );
 		const onSelect = vi.fn();
+		let openPicker;
 
 		renderHook( () => useMediaUpload() );
 		render(
 			<MediaUploadComponent
-				render={ ( { open } ) => open() }
+				render={ ( { open } ) => {
+					openPicker = open;
+					return null;
+				} }
 				onSelect={ onSelect }
 				multiple={ false }
 			/>
 		);
-		window.editor.setMediaUploadAttachment( [ 'test' ] );
+
+		// Wait for effects to run and get the contextId
+		await waitFor( () => {
+			openPicker();
+		} );
+
+		const contextId = openMediaLibrary.mock.calls[ 0 ][ 0 ].contextId;
+		window.editor.setMediaUploadAttachment( [ 'test' ], contextId );
 
 		expect( onSelect ).toHaveBeenCalledWith( 'test' );
 	} );
 
-	it( 'should clear the setMediaUploadAttachment function when the component is unmounted', () => {
+	it( 'should clear the setMediaUploadAttachment function when the component is unmounted', async () => {
 		let MediaUploadComponent;
 		addFilter.mockImplementation( ( name, namespace, callback ) => {
 			MediaUploadComponent = callback();
 		} );
 		const onSelect = vi.fn();
+		let openPicker;
 
 		renderHook( () => useMediaUpload() );
 		const { unmount } = render(
 			<MediaUploadComponent
-				render={ ( { open } ) => open() }
+				render={ ( { open } ) => {
+					openPicker = open;
+					return null;
+				} }
 				onSelect={ onSelect }
 				multiple={ false }
 			/>
 		);
 
-		window.editor.setMediaUploadAttachment( [ 'test' ] );
+		// Wait for effects to run and get the contextId
+		await waitFor( () => {
+			openPicker();
+		} );
+
+		const contextId = openMediaLibrary.mock.calls[ 0 ][ 0 ].contextId;
+		window.editor.setMediaUploadAttachment( [ 'test' ], contextId );
 
 		expect( onSelect ).toHaveBeenCalledWith( 'test' );
 
 		unmount();
 
-		window.editor.setMediaUploadAttachment( [ 'test' ] );
+		// After unmount, calling with the same contextId should not trigger callback
+		window.editor.setMediaUploadAttachment( [ 'test' ], contextId );
 
 		expect( onSelect ).toHaveBeenCalledTimes( 1 );
 	} );
@@ -222,38 +244,32 @@ describe( 'useMediaUpload', () => {
 			expect( onSelectBefore ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'should use the last callback as fallback when no contextId is provided (backward compatibility)', () => {
+		it( 'should warn when contextId is missing', () => {
 			let MediaUploadComponent;
 			addFilter.mockImplementation( ( name, namespace, callback ) => {
 				MediaUploadComponent = callback();
 			} );
 
-			const onSelectFirst = vi.fn();
-			const onSelectSecond = vi.fn();
+			const onSelect = vi.fn();
 
 			renderHook( () => useMediaUpload() );
 
 			render(
-				<>
-					<MediaUploadComponent
-						render={ ( { open } ) => open() }
-						onSelect={ onSelectFirst }
-						multiple={ false }
-					/>
-					<MediaUploadComponent
-						render={ ( { open } ) => open() }
-						onSelect={ onSelectSecond }
-						multiple={ false }
-					/>
-				</>
+				<MediaUploadComponent
+					render={ ( { open } ) => open() }
+					onSelect={ onSelect }
+					multiple={ false }
+				/>
 			);
 
-			// Call without contextId (backward compatibility)
+			// Call without contextId
 			window.editor.setMediaUploadAttachment( [ 'test-image.jpg' ] );
 
-			// Should call the last registered callback
-			expect( onSelectSecond ).toHaveBeenCalledWith( 'test-image.jpg' );
-			expect( onSelectFirst ).not.toHaveBeenCalled();
+			// Should warn and not call the callback
+			expect( warn ).toHaveBeenCalledWith(
+				'setMediaUploadAttachment called without contextId'
+			);
+			expect( onSelect ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should warn when an invalid contextId is provided', () => {

--- a/src/components/editor/test/use-media-upload.test.jsx
+++ b/src/components/editor/test/use-media-upload.test.jsx
@@ -8,15 +8,7 @@ import { render, renderHook, waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import { useMediaUpload } from '../use-media-upload';
-import {
-	describe,
-	it,
-	expect,
-	vi,
-	beforeAll,
-	afterAll,
-	afterEach,
-} from 'vitest';
+import { describe, it, expect, vi, afterAll, afterEach } from 'vitest';
 import { openMediaLibrary } from '../../../utils/bridge';
 import { warn } from '../../../utils/logger';
 
@@ -30,12 +22,6 @@ vi.mock( '../../../utils/logger', () => ( {
 } ) );
 
 describe( 'useMediaUpload', () => {
-	beforeAll( () => {
-		vi.stubGlobal( 'editor', {
-			setMediaUploadAttachment: vi.fn(),
-		} );
-	} );
-
 	afterEach( () => {
 		vi.clearAllMocks();
 	} );

--- a/src/components/editor/test/use-media-upload.test.jsx
+++ b/src/components/editor/test/use-media-upload.test.jsx
@@ -342,5 +342,116 @@ describe( 'useMediaUpload', () => {
 				} )
 			);
 		} );
+
+		it( 'should maintain stable contextId when onSelect changes', async () => {
+			let MediaUploadComponent;
+			addFilter.mockImplementation( ( name, namespace, callback ) => {
+				MediaUploadComponent = callback();
+			} );
+
+			const onSelectFirst = vi.fn();
+			const onSelectSecond = vi.fn();
+			let openPicker;
+
+			renderHook( () => useMediaUpload() );
+			const { rerender } = render(
+				<MediaUploadComponent
+					render={ ( { open } ) => {
+						openPicker = open;
+						return null;
+					} }
+					onSelect={ onSelectFirst }
+					multiple={ false }
+				/>
+			);
+
+			// Wait for effects to run and get the contextId
+			await waitFor( () => {
+				openPicker();
+			} );
+
+			const firstContextId =
+				openMediaLibrary.mock.calls[ 0 ][ 0 ].contextId;
+
+			// Re-render with a new onSelect callback (simulating parent re-render)
+			rerender(
+				<MediaUploadComponent
+					render={ ( { open } ) => {
+						openPicker = open;
+						return null;
+					} }
+					onSelect={ onSelectSecond }
+					multiple={ false }
+				/>
+			);
+
+			// Open the media library again with the new callback
+			await waitFor( () => {
+				openPicker();
+			} );
+
+			const secondContextId =
+				openMediaLibrary.mock.calls[ 1 ][ 0 ].contextId;
+
+			// The contextId should remain the same across re-renders when only onSelect changes
+			expect( firstContextId ).toBe( secondContextId );
+		} );
+
+		it( 'should handle media insertion after re-render simulating block reordering', async () => {
+			let MediaUploadComponent;
+			addFilter.mockImplementation( ( name, namespace, callback ) => {
+				MediaUploadComponent = callback();
+			} );
+
+			const onSelectOriginal = vi.fn();
+			const onSelectAfterReorder = vi.fn();
+			let openPicker;
+
+			renderHook( () => useMediaUpload() );
+			const { rerender } = render(
+				<MediaUploadComponent
+					render={ ( { open } ) => {
+						openPicker = open;
+						return null;
+					} }
+					onSelect={ onSelectOriginal }
+					multiple={ false }
+				/>
+			);
+
+			// Wait for effects to run and open the media library
+			await waitFor( () => {
+				openPicker();
+			} );
+
+			const contextId = openMediaLibrary.mock.calls[ 0 ][ 0 ].contextId;
+
+			// Simulate a block reordering event that causes re-render with new onSelect
+			// (This would have caused the bug before the fix)
+			rerender(
+				<MediaUploadComponent
+					render={ ( { open } ) => {
+						openPicker = open;
+						return null;
+					} }
+					onSelect={ onSelectAfterReorder }
+					multiple={ false }
+				/>
+			);
+
+			// Native returns media with the original contextId
+			// This should still work despite the re-render
+			window.editor.setMediaUploadAttachment(
+				[ 'inserted-media.jpg' ],
+				contextId
+			);
+
+			// Should call the NEW callback (not warn about missing contextId)
+			expect( onSelectAfterReorder ).toHaveBeenCalledWith(
+				'inserted-media.jpg'
+			);
+			expect( onSelectOriginal ).not.toHaveBeenCalled();
+			expect( warn ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/src/components/editor/use-dev-mode-notice.js
+++ b/src/components/editor/use-dev-mode-notice.js
@@ -15,8 +15,7 @@ import { isDevMode } from '../../utils/dev-mode';
 let noticeShown = false;
 
 export function useDevModeNotice() {
-	const { createWarningNotice, removeAllNotices } =
-		useDispatch( noticesStore );
+	const { createWarningNotice } = useDispatch( noticesStore );
 
 	useEffect( () => {
 		const hasDevMode = isDevMode();
@@ -34,5 +33,5 @@ export function useDevModeNotice() {
 				}
 			);
 		}
-	}, [ createWarningNotice, removeAllNotices ] );
+	}, [ createWarningNotice ] );
 }

--- a/src/components/editor/use-media-upload.js
+++ b/src/components/editor/use-media-upload.js
@@ -2,12 +2,25 @@
  * WordPress dependencies
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { openMediaLibrary } from '../../utils/bridge';
+import { warn } from '../../utils/logger';
+
+/**
+ * Global registry for media upload callbacks indexed by context ID.
+ * This allows multiple MediaPlaceholder instances to coexist without
+ * overwriting each other's callbacks.
+ */
+const callbackRegistry = {};
+
+/**
+ * Counter for generating unique context IDs.
+ */
+let contextIdCounter = 0;
 
 /**
  * @typedef {Object} MediaUploadConfig
@@ -54,14 +67,53 @@ function MediaUpload( { render, ...config } ) {
  */
 function useNativeMediaLibrary( { onSelect, ...config } ) {
 	const { allowedTypes, multiple = false, value } = config;
+	const contextIdRef = useRef( null );
 
 	useEffect( () => {
-		window.editor.setMediaUploadAttachment = ( attachment ) => {
+		// Generate a unique context ID for this MediaPlaceholder instance
+		const contextId = `media-upload-${ ++contextIdCounter }`;
+		contextIdRef.current = contextId;
+
+		// Register this instance's callback in the global registry
+		callbackRegistry[ contextId ] = ( attachment ) => {
 			onSelect( config.multiple ? attachment : attachment[ 0 ] );
 		};
 
+		// Set up the global bridge function that routes to the correct callback
+		// based on the contextId returned from the native layer
+		if (
+			! window.editor.setMediaUploadAttachment ||
+			! window.editor.setMediaUploadAttachment.__isRegistry
+		) {
+			window.editor.setMediaUploadAttachment = (
+				attachment,
+				receivedContextId
+			) => {
+				// If contextId is provided, use the registry (new behavior)
+				if (
+					receivedContextId &&
+					callbackRegistry[ receivedContextId ]
+				) {
+					callbackRegistry[ receivedContextId ]( attachment );
+				} else if ( receivedContextId ) {
+					warn(
+						`No callback found for contextId: ${ receivedContextId }`
+					);
+				} else {
+					// Fallback: If no contextId, use the last registered callback (backward compatibility)
+					const callbacks = Object.values( callbackRegistry );
+					if ( callbacks.length > 0 ) {
+						callbacks[ callbacks.length - 1 ]( attachment );
+					}
+				}
+			};
+			// Mark this function as the registry-based implementation
+			window.editor.setMediaUploadAttachment.__isRegistry = true;
+		}
+
 		return () => {
-			window.editor.setMediaUploadAttachment = () => {};
+			// Clean up this instance's callback when unmounted
+			delete callbackRegistry[ contextIdRef.current ];
 		};
 	}, [ onSelect, config.multiple ] );
 
@@ -71,6 +123,7 @@ function useNativeMediaLibrary( { onSelect, ...config } ) {
 				allowedTypes,
 				multiple,
 				value,
+				contextId: contextIdRef.current,
 			} ),
 		[ allowedTypes, multiple, value ]
 	);

--- a/src/components/editor/use-media-upload.js
+++ b/src/components/editor/use-media-upload.js
@@ -89,22 +89,17 @@ function useNativeMediaLibrary( { onSelect, ...config } ) {
 				attachment,
 				receivedContextId
 			) => {
-				// If contextId is provided, use the registry (new behavior)
-				if (
-					receivedContextId &&
-					callbackRegistry[ receivedContextId ]
-				) {
+				if ( ! receivedContextId ) {
+					warn( 'setMediaUploadAttachment called without contextId' );
+					return;
+				}
+
+				if ( callbackRegistry[ receivedContextId ] ) {
 					callbackRegistry[ receivedContextId ]( attachment );
-				} else if ( receivedContextId ) {
+				} else {
 					warn(
 						`No callback found for contextId: ${ receivedContextId }`
 					);
-				} else {
-					// Fallback: If no contextId, use the last registered callback (backward compatibility)
-					const callbacks = Object.values( callbackRegistry );
-					if ( callbacks.length > 0 ) {
-						callbacks[ callbacks.length - 1 ]( attachment );
-					}
 				}
 			};
 			// Mark this function as the registry-based implementation

--- a/src/components/editor/use-media-upload.js
+++ b/src/components/editor/use-media-upload.js
@@ -74,13 +74,11 @@ function useNativeMediaLibrary( { onSelect, ...config } ) {
 		const contextId = `media-upload-${ ++contextIdCounter }`;
 		contextIdRef.current = contextId;
 
-		// Register this instance's callback in the global registry
 		callbackRegistry[ contextId ] = ( attachment ) => {
 			onSelect( config.multiple ? attachment : attachment[ 0 ] );
 		};
 
-		// Set up the global bridge function that routes to the correct callback
-		// based on the contextId returned from the native layer
+		window.editor = window.editor || {};
 		window.editor.setMediaUploadAttachment = (
 			attachment,
 			receivedContextId
@@ -90,17 +88,18 @@ function useNativeMediaLibrary( { onSelect, ...config } ) {
 				return;
 			}
 
-			if ( callbackRegistry[ receivedContextId ] ) {
-				callbackRegistry[ receivedContextId ]( attachment );
-			} else {
+			const callback = callbackRegistry[ receivedContextId ];
+			if ( ! callback ) {
 				warn(
 					`No callback found for contextId: ${ receivedContextId }`
 				);
+				return;
 			}
+
+			callback( attachment );
 		};
 
 		return () => {
-			// Clean up this instance's callback when unmounted
 			delete callbackRegistry[ contextIdRef.current ];
 		};
 	}, [ onSelect, config.multiple ] );

--- a/src/components/editor/use-media-upload.js
+++ b/src/components/editor/use-media-upload.js
@@ -87,9 +87,7 @@ function useNativeMediaLibrary( { onSelect, ...config } ) {
 		contextIdRef.current = contextId;
 
 		callbackRegistry[ contextId ] = ( attachment ) => {
-			onSelectRef.current(
-				config.multiple ? attachment : attachment[ 0 ]
-			);
+			onSelectRef.current( multiple ? attachment : attachment[ 0 ] );
 		};
 
 		window.editor = window.editor || {};
@@ -116,7 +114,7 @@ function useNativeMediaLibrary( { onSelect, ...config } ) {
 		return () => {
 			delete callbackRegistry[ contextIdRef.current ];
 		};
-	}, [ config.multiple ] );
+	}, [ multiple ] );
 
 	const open = useCallback(
 		() =>

--- a/src/components/editor/use-media-upload.js
+++ b/src/components/editor/use-media-upload.js
@@ -81,30 +81,23 @@ function useNativeMediaLibrary( { onSelect, ...config } ) {
 
 		// Set up the global bridge function that routes to the correct callback
 		// based on the contextId returned from the native layer
-		if (
-			! window.editor.setMediaUploadAttachment ||
-			! window.editor.setMediaUploadAttachment.__isRegistry
-		) {
-			window.editor.setMediaUploadAttachment = (
-				attachment,
-				receivedContextId
-			) => {
-				if ( ! receivedContextId ) {
-					warn( 'setMediaUploadAttachment called without contextId' );
-					return;
-				}
+		window.editor.setMediaUploadAttachment = (
+			attachment,
+			receivedContextId
+		) => {
+			if ( ! receivedContextId ) {
+				warn( 'setMediaUploadAttachment called without contextId' );
+				return;
+			}
 
-				if ( callbackRegistry[ receivedContextId ] ) {
-					callbackRegistry[ receivedContextId ]( attachment );
-				} else {
-					warn(
-						`No callback found for contextId: ${ receivedContextId }`
-					);
-				}
-			};
-			// Mark this function as the registry-based implementation
-			window.editor.setMediaUploadAttachment.__isRegistry = true;
-		}
+			if ( callbackRegistry[ receivedContextId ] ) {
+				callbackRegistry[ receivedContextId ]( attachment );
+			} else {
+				warn(
+					`No callback found for contextId: ${ receivedContextId }`
+				);
+			}
+		};
 
 		return () => {
 			// Clean up this instance's callback when unmounted

--- a/src/components/editor/use-media-upload.js
+++ b/src/components/editor/use-media-upload.js
@@ -68,6 +68,18 @@ function MediaUpload( { render, ...config } ) {
 function useNativeMediaLibrary( { onSelect, ...config } ) {
 	const { allowedTypes, multiple = false, value } = config;
 	const contextIdRef = useRef( null );
+	// Stored as ref to avoid recreating a new context ID on every render, which
+	// can lead to stale callbacks.
+	const onSelectRef = useRef( onSelect );
+
+	// Keep the onSelect ref up to date with the latest callback
+	useEffect( () => {
+		onSelectRef.current = onSelect;
+
+		return () => {
+			onSelectRef.current = () => {};
+		};
+	}, [ onSelect ] );
 
 	useEffect( () => {
 		// Generate a unique context ID for this MediaPlaceholder instance
@@ -75,7 +87,9 @@ function useNativeMediaLibrary( { onSelect, ...config } ) {
 		contextIdRef.current = contextId;
 
 		callbackRegistry[ contextId ] = ( attachment ) => {
-			onSelect( config.multiple ? attachment : attachment[ 0 ] );
+			onSelectRef.current(
+				config.multiple ? attachment : attachment[ 0 ]
+			);
 		};
 
 		window.editor = window.editor || {};
@@ -102,7 +116,7 @@ function useNativeMediaLibrary( { onSelect, ...config } ) {
 		return () => {
 			delete callbackRegistry[ contextIdRef.current ];
 		};
-	}, [ onSelect, config.multiple ] );
+	}, [ config.multiple ] );
 
 	const open = useCallback(
 		() =>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Ensure the selected media is attached to the correct location in the editor canvas. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-925. Previously, selected media would always be placed in the last open media placeholder slot. This resulted in incorrect media attachments. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replace the singleton media upload callback with callbacks unique to each media placeholder slot. A unique ID is associated with each media placeholder, which is then used as a unique callback once the native host has selected media. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
> [!note]
> Testing likely requires the WordPress host app for accessing the _Media Library_ source. 

**1. Multiple media uploads instances**
1. Open the editor. 
2. Insert more than one _Image_ blocks. 
3. Select the an _Image_ block that is not the last one. 
4. Attach media to the block. 
5. **Verify** the media is attached to the correct block. 

**2. Reordered media upload instances**
1. Open the editor. 
2. Insert an _Image_ block. 
3. Insert an _Video_ block. 
4. Press the "move block upward" button to move the _Video_ block to the first position. 
6. Attach media to the block. 
7. **Verify** the media is attached to the correct block. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes. 