### PR TITLE
Add native navigation bar overlay so modals better fit in

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -28,6 +28,16 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     ///
     private let isWarmupMode: Bool
 
+    /// Overlay view shown over the navigation bar when modal dialogs are open
+    private lazy var navigationOverlayView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.3)
+        view.isUserInteractionEnabled = true
+        view.isHidden =  true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     /// HTML Preview Manager instance for rendering pattern previews
     private(set) lazy var htmlPreviewManager = HTMLPreviewManager(themeStyles: configuration.extractThemeStyles())
 
@@ -96,6 +106,16 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
             setUpEditor()
             loadEditor()
         }
+    }
+
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        setupNavigationOverlay()
+    }
+
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        removeNavigationOverlay()
     }
 
     private func setUpEditor() {
@@ -352,6 +372,32 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         evaluate("editor.appendTextAtCursor(decodeURIComponent('\(escapedText)'));")
     }
 
+    // MARK: - Navigation Overlay
+
+    private func setupNavigationOverlay() {
+        guard let navigationController = navigationController,
+                navigationOverlayView.superview == nil else { return }
+        navigationController.view.addSubview(navigationOverlayView)
+        NSLayoutConstraint.activate([
+            navigationOverlayView.leadingAnchor.constraint(equalTo: navigationController.view.leadingAnchor),
+            navigationOverlayView.trailingAnchor.constraint(equalTo: navigationController.view.trailingAnchor),
+            navigationOverlayView.topAnchor.constraint(equalTo: navigationController.view.topAnchor),
+            navigationOverlayView.bottomAnchor.constraint(equalTo: navigationController.navigationBar.bottomAnchor)
+        ])
+    }
+
+    private func removeNavigationOverlay() {
+        navigationOverlayView.removeFromSuperview()
+    }
+
+    private func showNavigationOverlay() {
+        navigationOverlayView.isHidden = false
+    }
+
+    private func hideNavigationOverlay() {
+        navigationOverlayView.isHidden = true
+    }
+
     // MARK: - GutenbergEditorControllerDelegate
 
     fileprivate func controller(_ controller: GutenbergEditorController, didReceiveMessage message: EditorJSMessage) {
@@ -387,9 +433,11 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
                 delegate?.editor(self, didTriggerAutocompleter: body.type)
             case .onModalDialogOpened:
                 let body = try message.decode(EditorJSMessage.ModalDialogBody.self)
+                showNavigationOverlay()
                 delegate?.editor(self, didOpenModalDialog: body.dialogType)
             case .onModalDialogClosed:
                 let body = try message.decode(EditorJSMessage.ModalDialogBody.self)
+                hideNavigationOverlay()
                 delegate?.editor(self, didCloseModalDialog: body.dialogType)
             case .log:
                 let log = try message.decode(EditorJSMessage.LogMessage.self)

--- a/src/index.scss
+++ b/src/index.scss
@@ -237,3 +237,16 @@ $baseline-interactive-font-size: 17px;
 		min-width: 274px !important;
 	}
 }
+
+// iOS-specific styling for block settings menu
+body.is-ios.gutenberg-kit {
+	.block-settings-menu {
+		background-color: rgba(0, 0, 0, 0.3) !important;
+	}
+
+	.block-settings-menu .components-popover__content {
+		border-top-left-radius: 26px !important;
+		border-top-right-radius: 26px !important;
+		background-color: #ffffff !important;
+	}
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -239,14 +239,12 @@ $baseline-interactive-font-size: 17px;
 }
 
 // iOS-specific styling for block settings menu
-body.is-ios.gutenberg-kit {
-	.block-settings-menu {
-		background-color: rgba(0, 0, 0, 0.3) !important;
-	}
+.gutenberg-kit.is-ios .block-settings-menu {
+	background-color: rgba(0, 0, 0, 0.3);
 
-	.block-settings-menu .components-popover__content {
-		border-top-left-radius: 26px !important;
-		border-top-right-radius: 26px !important;
-		background-color: #ffffff !important;
+	& .components-popover__content {
+		background-color: #ffffff;
+		border-top-left-radius: 26px;
+		border-top-right-radius: 26px;
 	}
 }

--- a/src/utils/editor-environment.js
+++ b/src/utils/editor-environment.js
@@ -15,6 +15,13 @@ import './editor-styles';
  * @return {Promise} Promise that resolves when initialization is complete
  */
 export function setUpEditorEnvironment() {
+	// Detect platform and add class to body for platform-specific styling
+	if ( typeof window !== 'undefined' && window.webkit ) {
+		document.body.classList.add( 'is-ios' );
+	} else if ( typeof window !== 'undefined' && window.editorDelegate ) {
+		document.body.classList.add( 'is-android' );
+	}
+
 	// Rely upon promises rather than async/await to avoid timeouts caused by
 	// circular dependencies. Addressing the circular dependencies is quite
 	// challenging due to Vite's preload helpers and bugs in `manualChunks`


### PR DESCRIPTION
## What?
Fake the bottom sheet presentation style on iOS by using the existing modal show/hide events.

## Why?
It makes it visually clear to the user that the "Block Inspector" is a modal and make it blend in better with the native navigation controls.

## How?
Adds `is-ios` class for iOS-specific styles.

## Screenshots or screencast 

Before / After

<img width="360"  alt="Screenshot 2025-11-19 at 6 06 56 AM" src="https://github.com/user-attachments/assets/ca9d7d19-891b-4f1f-94e2-ddde318655ee" /> <img width="360" alt="Screenshot 2025-11-18 at 11 06 32 AM" src="https://github.com/user-attachments/assets/54ec4d67-ce71-4d23-8cd0-deddef609707" />


## Alternatives Considered

Show "Block Inspector" covering only half of the screen and keep the rest of the editor interactive, which is challenging to achieve without introducing a lot of small little bugs. This PR is a stop-gap solution for the initial release, or maybe is a long-term solution since there are also advantages of showing this screen fullscreen.
