### PR TITLE
fix: Inline inserter opens native inserter

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -7,7 +7,7 @@ import CryptoKit
 import UIKit
 
 @MainActor
-public final class EditorViewController: UIViewController, GutenbergEditorControllerDelegate {
+public final class EditorViewController: UIViewController, GutenbergEditorControllerDelegate, UIAdaptivePresentationControllerDelegate, UIPopoverPresentationControllerDelegate, UISheetPresentationControllerDelegate {
     public let webView: WKWebView
     let assetsLibrary: EditorAssetsLibrary
 
@@ -288,17 +288,22 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
                 patternCategories: data.patternCategories,
                 mediaPicker: mediaPicker,
                 presentationContext: context,
-                onSelection: { [weak self] in self?.didSelectBlockInserterItem($0) }
+                onSelection: { [weak self] in self?.didSelectBlockInserterItem($0) },
+                onClose: { [weak self] in self?.notifyInserterClosed() }
             )
             .environmentObject(htmlPreviewManager)
         })
 
         context.viewController = host
 
+        // Set presentation delegate to track dismissal
+        host.presentationController?.delegate = self
+
         if let sourceRect = data.sourceRect {
             host.modalPresentationStyle = .popover
 
             if let popover = host.popoverPresentationController {
+                popover.delegate = self
                 popover.sourceView = webView
                 popover.sourceRect = CGRect(
                     x: sourceRect.x,
@@ -312,6 +317,7 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         }
 
         if let sheet = host.popoverPresentationController?.adaptiveSheetPresentationController ?? host.sheetPresentationController {
+            sheet.delegate = self
             sheet.detents = [.custom(identifier: .medium, resolver: { context in
                 context.containerTraitCollection.horizontalSizeClass == .compact ? 536 : 900
             }), .large()]
@@ -323,6 +329,8 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     }
 
     private func didSelectBlockInserterItem(_ selection: BlockInserterSelection) {
+        notifyInserterClosed()
+
         switch selection {
         case .block(let block):
             insertBlockFromInserter(block.id)
@@ -333,6 +341,16 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
                 await insertMediaFromInserter(items)
             }
         }
+    }
+
+    // MARK: - UIAdaptivePresentationControllerDelegate
+
+    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        notifyInserterClosed()
+    }
+
+    private func notifyInserterClosed() {
+        evaluate("window.blockInserter?.onClose?.()")
     }
 
     private func insertBlockFromInserter(_ blockID: String) {

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
@@ -16,6 +16,7 @@ struct BlockInserterView: View {
     let mediaPicker: MediaPickerController?
     let presentationContext: MediaPickerPresentationContext
     let onSelection: (BlockInserterSelection) -> Void
+    let onClose: () -> Void
 
     @StateObject private var viewModel: BlockInserterViewModel
     @StateObject private var iconCache = BlockIconCache()
@@ -40,7 +41,8 @@ struct BlockInserterView: View {
         patternCategories: [PatternCategory],
         mediaPicker: MediaPickerController?,
         presentationContext: MediaPickerPresentationContext,
-        onSelection: @escaping (BlockInserterSelection) -> Void
+        onSelection: @escaping (BlockInserterSelection) -> Void,
+        onClose: @escaping () -> Void
     ) {
         self.sections = sections
         self.patterns = patterns
@@ -48,6 +50,7 @@ struct BlockInserterView: View {
         self.mediaPicker = mediaPicker
         self.presentationContext = presentationContext
         self.onSelection = onSelection
+        self.onClose = onClose
 
         let viewModel = BlockInserterViewModel(sections: sections)
         self._viewModel = StateObject(wrappedValue: viewModel)
@@ -141,6 +144,7 @@ struct BlockInserterView: View {
     private var toolbar: some ToolbarContent {
         ToolbarItem(placement: .cancellationAction) {
             Button {
+                onClose()
                 dismiss()
             } label: {
                 Image(systemName: "xmark")
@@ -325,6 +329,9 @@ private extension View {
             presentationContext: MediaPickerPresentationContext(),
             onSelection: { selection in
                 print("on selected: \(selection)")
+            },
+            onClose: {
+                print("on close")
             }
         )
     }

--- a/src/components/editor-toolbar/index.jsx
+++ b/src/components/editor-toolbar/index.jsx
@@ -98,7 +98,10 @@ const EditorToolbar = ( { className } ) => {
 	);
 
 	const addBlockButton = enableNativeBlockInserter ? (
-		<NativeBlockInserterButton />
+		<NativeBlockInserterButton
+			open={ isInserterOpened }
+			onToggle={ setIsInserterOpened }
+		/>
 	) : (
 		<Inserter
 			popoverProps={ {

--- a/src/components/editor-toolbar/index.jsx
+++ b/src/components/editor-toolbar/index.jsx
@@ -60,10 +60,13 @@ const EditorToolbar = ( { className } ) => {
 	}, [] );
 	const { setIsInserterOpened } = useDispatch( editorStore );
 
-	useModalize( isInserterOpened );
+	useModalize( isInserterOpened && ! enableNativeBlockInserter );
 	useModalize( isBlockInspectorShown );
 
-	useModalDialogState( isInserterOpened, 'block-inserter' );
+	useModalDialogState(
+		isInserterOpened && ! enableNativeBlockInserter,
+		'block-inserter'
+	);
 	useModalDialogState( isBlockInspectorShown, 'block-inspector' );
 
 	function openSettings() {

--- a/src/components/native-block-inserter-button/index.jsx
+++ b/src/components/native-block-inserter-button/index.jsx
@@ -12,7 +12,7 @@ import {
 	createBlock,
 } from '@wordpress/blocks';
 import { getBlockAndPreviewFromMedia } from '@wordpress/block-editor/build-module/components/inserter/media-tab/utils';
-import { useRef } from '@wordpress/element';
+import { useRef, useEffect, useCallback } from '@wordpress/element';
 
 // NOTE: These hooks are internal WordPress APIs not available via public exports
 // or privateApis. We import from build-module as the only way to access the
@@ -52,9 +52,16 @@ import { unlock } from '../../lock-unlock';
  * that manages block insertion state for native platforms. It uses WordPress
  * hooks (useInsertionPoint and useBlockTypesState) to manage block insertion
  * state and exposes the current inserter state globally for the native side.
+ *
+ * Mimics the WordPress Inserter component API with open/onToggle props.
+ *
+ * @param {Object}   props          Component props
+ * @param {boolean}  props.open     Whether the inserter is open
+ * @param {Function} props.onToggle Callback to toggle inserter open state
  */
-export default function NativeBlockInserterButton() {
+export default function NativeBlockInserterButton( { open, onToggle } ) {
 	const buttonRef = useRef( null );
+	const prevOpen = useRef( false );
 
 	// Get current selection for insertion context and destination block info
 	const { selectedBlockClientId, destinationBlockName } = useSelect(
@@ -118,218 +125,314 @@ export default function NativeBlockInserterButton() {
 		];
 	}, [] );
 
-	const insertBlock = ( blockId ) => {
-		const item = inserterItems.find( ( i ) => i.id === blockId );
-		if ( ! item ) {
-			debug( `Block with id "${ blockId }" not found in inserter items` );
-			return false;
-		}
-		try {
-			onSelectItem( item );
-			return true;
-		} catch ( error ) {
-			debug( 'Failed to insert block:', error );
-			return false;
-		}
-	};
+	const insertBlock = useCallback(
+		( blockId ) => {
+			const item = inserterItems.find( ( i ) => i.id === blockId );
+			if ( ! item ) {
+				debug(
+					`Block with id "${ blockId }" not found in inserter items`
+				);
+				return false;
+			}
+			try {
+				onSelectItem( item );
+				return true;
+			} catch ( error ) {
+				debug( 'Failed to insert block:', error );
+				return false;
+			}
+		},
+		[ inserterItems, onSelectItem ]
+	);
 
-	/**
-	 * Get media type from MIME type.
-	 *
-	 * @param {string} mimeType The MIME type of the media
-	 * @return {string|null} Media type ('image', 'video', 'audio') or null
-	 */
-	const getMediaType = ( mimeType ) => {
-		if ( ! mimeType ) {
-			return null;
-		}
-		if ( mimeType.startsWith( 'image/' ) ) {
-			return 'image';
-		}
-		if ( mimeType.startsWith( 'video/' ) ) {
-			return 'video';
-		}
-		if ( mimeType.startsWith( 'audio/' ) ) {
-			return 'audio';
-		}
-		return null;
-	};
-
-	/**
-	 * Insert media from WordPress media library (with existing IDs).
-	 * Creates blocks directly with media attributes, avoiding re-upload.
-	 *
-	 * @param {Array} mediaArray Array of media objects with IDs
-	 * @return {boolean} True if insertion succeeded
-	 */
-	const insertMediaWithIds = ( mediaArray ) => {
-		const blocks = [];
-		const allImages = mediaArray.every(
-			( media ) => getMediaType( media.type ) === 'image'
-		);
-
-		// Create gallery for multiple images
-		if ( allImages && mediaArray.length > 1 ) {
-			if (
-				! canInsertBlockType( 'core/gallery', destinationRootClientId )
-			) {
-				debug( 'Cannot insert gallery block at this location' );
+	const insertPattern = useCallback(
+		( patternName ) => {
+			const pattern = patterns?.find( ( p ) => p.name === patternName );
+			if ( ! pattern ) {
+				debug( `Pattern "${ patternName }" not found` );
 				return false;
 			}
 
-			const galleryBlock = createBlock( 'core/gallery', {
-				images: mediaArray.map( ( media ) => ( {
-					id: String( media.id ),
-					url: media.url,
-					alt: media.alt ?? '',
-					caption: media.caption ?? '',
-				} ) ),
-			} );
-			blocks.push( galleryBlock );
-		} else {
-			// Create individual blocks using WordPress utility
-			for ( const media of mediaArray ) {
-				const mediaType = getMediaType( media.type );
-				if ( ! mediaType ) {
-					debug( `Unsupported media type: ${ media.type }` );
-					continue;
-				}
-
-				if (
-					! canInsertBlockType(
-						`core/${ mediaType }`,
-						destinationRootClientId
-					)
-				) {
-					debug(
-						`Cannot insert core/${ mediaType } block at this location`
-					);
-					continue;
-				}
-
-				const [ block ] = getBlockAndPreviewFromMedia(
-					media,
-					mediaType
-				);
-				blocks.push( block );
+			try {
+				// Parse and insert pattern blocks
+				const blocks = parse( pattern.content );
+				onInsertBlocks( blocks );
+				return true;
+			} catch ( error ) {
+				debug( 'Failed to insert pattern:', error );
+				return false;
 			}
-		}
+		},
+		[ patterns, onInsertBlocks ]
+	);
 
-		if ( blocks.length === 0 ) {
-			return false;
-		}
+	const insertMedia = useCallback(
+		async ( mediaArray ) => {
+			if ( ! Array.isArray( mediaArray ) || mediaArray.length === 0 ) {
+				return false;
+			}
 
-		onInsertBlocks( blocks );
-		return true;
-	};
-
-	/**
-	 * Insert new media files (without IDs) using WordPress file transforms.
-	 * Downloads files and uses transform system for block creation and upload.
-	 *
-	 * @param {Array} mediaArray Array of media objects without IDs
-	 * @return {Promise<boolean>} True if insertion succeeded
-	 */
-	const insertMediaWithoutIds = async ( mediaArray ) => {
-		// Convert media objects to File objects
-		const files = await Promise.all(
-			mediaArray.map( async ( media ) => {
-				try {
-					const response = await fetch( media.url );
-					const blob = await response.blob();
-					const filename = media.url.split( '/' ).pop() || 'media';
-					return new File( [ blob ], filename, {
-						type: media.type ?? 'application/octet-stream',
-					} );
-				} catch ( error ) {
-					debug( `Failed to fetch media: ${ media.url }`, error );
+			/**
+			 * Get media type from MIME type.
+			 *
+			 * @param {string} mimeType The MIME type of the media
+			 * @return {string|null} Media type ('image', 'video', 'audio') or null
+			 */
+			const getMediaType = ( mimeType ) => {
+				if ( ! mimeType ) {
 					return null;
 				}
-			} )
+				if ( mimeType.startsWith( 'image/' ) ) {
+					return 'image';
+				}
+				if ( mimeType.startsWith( 'video/' ) ) {
+					return 'video';
+				}
+				if ( mimeType.startsWith( 'audio/' ) ) {
+					return 'audio';
+				}
+				return null;
+			};
+
+			/**
+			 * Insert media from WordPress media library (with existing IDs).
+			 * Creates blocks directly with media attributes, avoiding re-upload.
+			 *
+			 * @param {Array} items Array of media objects with IDs
+			 * @return {boolean} True if insertion succeeded
+			 */
+			const insertMediaWithIds = ( items ) => {
+				const blocks = [];
+				const allImages = items.every(
+					( media ) => getMediaType( media.type ) === 'image'
+				);
+
+				// Create gallery for multiple images
+				if ( allImages && items.length > 1 ) {
+					if (
+						! canInsertBlockType(
+							'core/gallery',
+							destinationRootClientId
+						)
+					) {
+						debug( 'Cannot insert gallery block at this location' );
+						return false;
+					}
+
+					const galleryBlock = createBlock( 'core/gallery', {
+						images: items.map( ( media ) => ( {
+							id: String( media.id ),
+							url: media.url,
+							alt: media.alt ?? '',
+							caption: media.caption ?? '',
+						} ) ),
+					} );
+					blocks.push( galleryBlock );
+				} else {
+					// Create individual blocks using WordPress utility
+					for ( const media of items ) {
+						const mediaType = getMediaType( media.type );
+						if ( ! mediaType ) {
+							debug( `Unsupported media type: ${ media.type }` );
+							continue;
+						}
+
+						if (
+							! canInsertBlockType(
+								`core/${ mediaType }`,
+								destinationRootClientId
+							)
+						) {
+							debug(
+								`Cannot insert core/${ mediaType } block at this location`
+							);
+							continue;
+						}
+
+						const [ block ] = getBlockAndPreviewFromMedia(
+							media,
+							mediaType
+						);
+						blocks.push( block );
+					}
+				}
+
+				if ( blocks.length === 0 ) {
+					return false;
+				}
+
+				onInsertBlocks( blocks );
+				return true;
+			};
+
+			/**
+			 * Insert new media files (without IDs) using WordPress file transforms.
+			 * Downloads files and uses transform system for block creation and upload.
+			 *
+			 * @param {Array} items Array of media objects without IDs
+			 * @return {Promise<boolean>} True if insertion succeeded
+			 */
+			const insertMediaWithoutIds = async ( items ) => {
+				// Convert media objects to File objects
+				const files = await Promise.all(
+					items.map( async ( media ) => {
+						try {
+							const response = await fetch( media.url );
+							const blob = await response.blob();
+							const filename =
+								media.url.split( '/' ).pop() || 'media';
+							return new File( [ blob ], filename, {
+								type: media.type ?? 'application/octet-stream',
+							} );
+						} catch ( error ) {
+							debug(
+								`Failed to fetch media: ${ media.url }`,
+								error
+							);
+							return null;
+						}
+					} )
+				);
+
+				const validFiles = files.filter( ( f ) => f !== null );
+				if ( validFiles.length === 0 ) {
+					debug( 'No valid files to insert' );
+					return false;
+				}
+
+				// Find and apply file transform
+				const transformation = findTransform(
+					getBlockTransforms( 'from' ),
+					( transform ) =>
+						transform.type === 'files' &&
+						canInsertBlockType(
+							transform.blockName,
+							destinationRootClientId
+						) &&
+						transform.isMatch( validFiles )
+				);
+
+				if ( ! transformation ) {
+					debug( 'No matching transform found', {
+						fileCount: validFiles.length,
+						fileTypes: validFiles.map( ( f ) => f.type ),
+					} );
+					return false;
+				}
+
+				const blocks = transformation.transform(
+					validFiles,
+					updateBlockAttributes
+				);
+
+				if (
+					! blocks ||
+					( Array.isArray( blocks ) && blocks.length === 0 )
+				) {
+					debug( 'Transform produced no blocks' );
+					return false;
+				}
+
+				onInsertBlocks( Array.isArray( blocks ) ? blocks : [ blocks ] );
+				return true;
+			};
+
+			try {
+				// Assume all media have IDs or all don't (not mixed)
+				const hasIds = mediaArray[ 0 ]?.id;
+
+				return hasIds
+					? insertMediaWithIds( mediaArray )
+					: await insertMediaWithoutIds( mediaArray );
+			} catch ( error ) {
+				debug( 'Failed to insert media blocks', error );
+				return false;
+			}
+		},
+		[
+			canInsertBlockType,
+			destinationRootClientId,
+			onInsertBlocks,
+			updateBlockAttributes,
+		]
+	);
+
+	const prepareAndShowInserter = useCallback( () => {
+		const sections = preprocessBlockTypesForNativeInserter(
+			inserterItems,
+			destinationBlockName,
+			categories
 		);
 
-		const validFiles = files.filter( ( f ) => f !== null );
-		if ( validFiles.length === 0 ) {
-			debug( 'No valid files to insert' );
-			return false;
+		// Format patterns for native consumption
+		const formattedPatterns =
+			patterns?.map( ( pattern ) => ( {
+				name: pattern.name,
+				title: pattern.title,
+				content: pattern.content,
+				blockTypes: pattern.blockTypes ?? null,
+				categories:
+					pattern.categories?.filter(
+						( cat ) => ! cat.startsWith( '_' )
+					) ?? null,
+				description: pattern.description ?? null,
+				keywords: pattern.keywords ?? null,
+				source: pattern.source ?? null,
+				viewportWidth: pattern.viewportWidth ?? null,
+			} ) ) ?? [];
+
+		const formattedPatternCategories =
+			patternCategories?.map( ( cat ) => ( {
+				name: cat.name,
+				label: cat.label,
+			} ) ) ?? [];
+
+		window.blockInserter = {
+			sections,
+			patterns: formattedPatterns,
+			patternCategories: formattedPatternCategories,
+			insertBlock,
+			insertPattern,
+			insertMedia,
+			onClose: () => {
+				onToggle( false );
+				return true; // Return valid result type for the native host
+			},
+		};
+
+		// Get button position for popover presentation on iPad
+		let sourceRect;
+		if ( buttonRef.current ) {
+			const rect = buttonRef.current.getBoundingClientRect();
+			sourceRect = {
+				x: rect.left,
+				y: rect.top,
+				width: rect.width,
+				height: rect.height,
+			};
 		}
 
-		// Find and apply file transform
-		const transformation = findTransform(
-			getBlockTransforms( 'from' ),
-			( transform ) =>
-				transform.type === 'files' &&
-				canInsertBlockType(
-					transform.blockName,
-					destinationRootClientId
-				) &&
-				transform.isMatch( validFiles )
-		);
+		showBlockInserter( sourceRect );
+	}, [
+		inserterItems,
+		destinationBlockName,
+		categories,
+		patterns,
+		patternCategories,
+		insertBlock,
+		insertPattern,
+		insertMedia,
+		onToggle,
+	] );
 
-		if ( ! transformation ) {
-			debug( 'No matching transform found', {
-				fileCount: validFiles.length,
-				fileTypes: validFiles.map( ( f ) => f.type ),
-			} );
-			return false;
+	// Watch for controlled open state changes
+	useEffect( () => {
+		// Only trigger when transitioning from false to true
+		if ( open && ! prevOpen.current ) {
+			prepareAndShowInserter();
 		}
-
-		const blocks = transformation.transform(
-			validFiles,
-			updateBlockAttributes
-		);
-
-		if ( ! blocks || ( Array.isArray( blocks ) && blocks.length === 0 ) ) {
-			debug( 'Transform produced no blocks' );
-			return false;
-		}
-
-		onInsertBlocks( Array.isArray( blocks ) ? blocks : [ blocks ] );
-		return true;
-	};
-
-	/**
-	 * Insert media blocks from native media picker.
-	 *
-	 * @param {Array} mediaArray Array of media objects with shape:
-	 *                           { id?, url, type, caption?, alt?, title?, metadata? }
-	 * @return {Promise<boolean>} True if insertion succeeded
-	 */
-	const insertMedia = async ( mediaArray ) => {
-		if ( ! Array.isArray( mediaArray ) || mediaArray.length === 0 ) {
-			return false;
-		}
-
-		try {
-			// Assume all media have IDs or all don't (not mixed)
-			const hasIds = mediaArray[ 0 ]?.id;
-
-			return hasIds
-				? insertMediaWithIds( mediaArray )
-				: await insertMediaWithoutIds( mediaArray );
-		} catch ( error ) {
-			debug( 'Failed to insert media blocks', error );
-			return false;
-		}
-	};
-
-	const insertPattern = ( patternName ) => {
-		const pattern = patterns?.find( ( p ) => p.name === patternName );
-		if ( ! pattern ) {
-			debug( `Pattern "${ patternName }" not found` );
-			return false;
-		}
-
-		try {
-			// Parse and insert pattern blocks
-			const blocks = parse( pattern.content );
-			onInsertBlocks( blocks );
-			return true;
-		} catch ( error ) {
-			debug( 'Failed to insert pattern:', error );
-			return false;
-		}
-	};
+		prevOpen.current = open;
+	}, [ open, prepareAndShowInserter ] );
 
 	return (
 		<Button
@@ -337,57 +440,7 @@ export default function NativeBlockInserterButton() {
 			title={ __( 'Add block' ) }
 			icon={ plus }
 			onClick={ () => {
-				const sections = preprocessBlockTypesForNativeInserter(
-					inserterItems,
-					destinationBlockName,
-					categories
-				);
-
-				// Format patterns for native consumption
-				const formattedPatterns =
-					patterns?.map( ( pattern ) => ( {
-						name: pattern.name,
-						title: pattern.title,
-						content: pattern.content,
-						blockTypes: pattern.blockTypes ?? null,
-						categories:
-							pattern.categories?.filter(
-								( cat ) => ! cat.startsWith( '_' )
-							) ?? null,
-						description: pattern.description ?? null,
-						keywords: pattern.keywords ?? null,
-						source: pattern.source ?? null,
-						viewportWidth: pattern.viewportWidth ?? null,
-					} ) ) ?? [];
-
-				const formattedPatternCategories =
-					patternCategories?.map( ( cat ) => ( {
-						name: cat.name,
-						label: cat.label,
-					} ) ) ?? [];
-
-				window.blockInserter = {
-					sections,
-					patterns: formattedPatterns,
-					patternCategories: formattedPatternCategories,
-					insertBlock,
-					insertPattern,
-					insertMedia,
-				};
-
-				// Get button position for popover presentation on iPad
-				let sourceRect;
-				if ( buttonRef.current ) {
-					const rect = buttonRef.current.getBoundingClientRect();
-					sourceRect = {
-						x: rect.left,
-						y: rect.top,
-						width: rect.width,
-						height: rect.height,
-					};
-				}
-
-				showBlockInserter( sourceRect );
+				onToggle( true );
 			} }
 			onMouseDown={ ( e ) => {
 				e.preventDefault();

--- a/src/components/native-block-inserter-button/index.jsx
+++ b/src/components/native-block-inserter-button/index.jsx
@@ -13,7 +13,8 @@ import {
 } from '@wordpress/blocks';
 import { getBlockAndPreviewFromMedia } from '@wordpress/block-editor/build-module/components/inserter/media-tab/utils';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
-
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreDataStore } from '@wordpress/core-data';
 // NOTE: These hooks are internal WordPress APIs not available via public exports
 // or privateApis. We import from build-module as the only way to access the
 // block insertion logic without reimplementing it ourselves.
@@ -38,8 +39,6 @@ import useBlockTypesState from '@wordpress/block-editor/build-module/components/
 /**
  * Internal dependencies
  */
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { store as coreDataStore } from '@wordpress/core-data';
 import { debug } from '../../utils/logger';
 import { preprocessBlockTypesForNativeInserter } from '../../utils/blocks';
 import { showBlockInserter } from '../../utils/bridge';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Ensure inline inserter's _Browse all_ button opens the native block inserter. 

It's worth noting the current outcome is not perfect. Namely, the quick inserter remains open after opening the native inserter. This occurs because the former relies upon losing focus for its dismissal. The native inserter does not change the WebView's focus state; thus, the quick inserter remains open. 

Long term, I think the most ideal case is that we introduce a new filter hook to the Gutenberg project that allows replacing the inserter used throughout the UI. I.e., when tapping the quick inserter's inline button, it opens the native inserter directly rather than displaying the quick inserter. I captured this as a note in https://github.com/wordpress-mobile/GutenbergKit/issues/106. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-973. The bug made inserting blocks into layout blocks difficult. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
* Control the native inserter visibility via the existing `isInserterOpen` store state, ensuring the state is correct throughout the UI. 
* Memoize various callbacks to avoid unnecessary re-renders—this addresses some of https://github.com/wordpress-mobile/GutenbergKit/pull/199#discussion_r2474322561. 
* Disable existing a11y logic that is unnecessary for the native inserter, as it manages the relevant a11y state itself (e.g., marking content outside the modal dialog inert). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the inserter. 
2. Select _Columns_. 
3. Tap the inline inserter button. 
4. Tap _Browse all_. 
5. Select a block to insert. 
6. **Verify** the selected block is inserted. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Navigate the testing steps. **Verify** content is correct marked inert when the native inserter is opened. 

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/1958ab88-fd42-4dc7-aab0-cedbf2ecfffb
