### PR TITLE
Add support for Editor Settings

### DIFF
--- a/ios/Demo-iOS/Sources/Views/AppRootView.swift
+++ b/ios/Demo-iOS/Sources/Views/AppRootView.swift
@@ -72,7 +72,7 @@ struct AppRootView: View {
                 let canUsePlugins = apiRoot.hasRoute(route: "/wpcom/v2/editor-assets")
                 let canUseEditorStyles = apiRoot.hasRoute(route: "/wp-block-editor/v1/settings")
 
-                let updatedConfiguration = EditorConfigurationBuilder()
+                var updatedConfiguration = EditorConfigurationBuilder()
                     .setShouldUseThemeStyles(canUseEditorStyles)
                     .setShouldUsePlugins(canUsePlugins)
                     .setSiteUrl(config.siteUrl)
@@ -81,6 +81,19 @@ struct AppRootView: View {
                     .setNativeInserterEnabled(isNativeInserterEnabled)
                     .setLogLevel(.debug)
                     .build()
+
+                if let baseURL = URL(string: config.siteApiRoot) {
+                    let service = EditorService(
+                        siteID: config.siteUrl,
+                        baseURL: baseURL,
+                        authHeader: config.authHeader
+                    )
+                    do {
+                        try await service.setup(&updatedConfiguration)
+                    } catch {
+                        print("Failed to setup editor environment, confinuing with the default or cached configuration:", error)
+                    }
+                }
 
                 self.activeEditorConfiguration = updatedConfiguration
             } catch {

--- a/ios/Sources/GutenbergKit/Sources/Helpers/String+SafeDirectoryName.swift
+++ b/ios/Sources/GutenbergKit/Sources/Helpers/String+SafeDirectoryName.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension String {
+    /// Converts a string (such as a URL) into a safe directory name by removing illegal filesystem characters
+    ///
+    /// This method filters out characters that are not allowed in directory names across different filesystems,
+    /// including: `/`, `:`, `\`, `?`, `%`, `*`, `|`, `"`, `<`, `>`, newlines, and control characters.
+    ///
+    /// Example:
+    /// ```swift
+    /// let url = "https://example.com/path?query=1"
+    /// let safeName = url.safeFilename
+    /// // Result: "https---example.com-path-query-1"
+    /// ```
+    var safeFilename: String {
+        // Define illegal characters for directory names
+        let illegalChars = CharacterSet(charactersIn: "/:\\?%*|\"<>")
+            .union(.newlines)
+            .union(.controlCharacters)
+
+        // Remove scheme and other URL components we don't want
+        var cleaned = self
+        if var urlComponents = URLComponents(string: self) {
+            urlComponents.scheme = nil
+            urlComponents.query = nil
+            urlComponents.fragment = nil
+            if let url = urlComponents.url?.absoluteString {
+                cleaned = url
+            }
+        }
+
+        // Trim and replace illegal characters with dashes
+        return cleaned
+            .trimmingCharacters(in: illegalChars)
+            .components(separatedBy: illegalChars)
+            .joined(separator: "-")
+    }
+}

--- a/ios/Sources/GutenbergKit/Sources/Service/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Service/EditorService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Service for fetching the editor settings and other parts of the enrvironment
+/// Service for fetching the editor settings and other parts of the environment
 /// required to launch the editor.
 public actor EditorService {
     enum EditorServiceError: Error {

--- a/ios/Sources/GutenbergKit/Sources/Service/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Service/EditorService.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Service for fetching the editor settings and other parts of the enrvironment
+/// required to launch the editor.
+public actor EditorService {
+    enum EditorServiceError: Error {
+        case invalidResponseData
+    }
+
+    private let siteID: String
+    private let baseURL: URL
+    private let authHeader: String
+    private let urlSession: URLSession
+
+    private let storeURL: URL
+    private var editorSettingsFileURL: URL { storeURL.appendingPathComponent("settings.json") }
+
+    private var refreshTask: Task<Void, Error>?
+
+    /// Creates a new EditorService instance
+    /// - Parameters:
+    ///   - siteID: Unique identifier for the site (used for caching)
+    ///   - baseURL: Root URL for the site API
+    ///   - authHeader: Authorization header value
+    ///   - urlSession: URLSession to use for network requests (defaults to .shared)
+    public init(siteID: String, baseURL: URL, authHeader: String, urlSession: URLSession = .shared) {
+        self.siteID = siteID
+        self.baseURL = baseURL
+        self.authHeader = authHeader
+        self.urlSession = urlSession
+
+        self.storeURL = URL.documentsDirectory
+            .appendingPathComponent("GutenbergKit", isDirectory: true)
+            .appendingPathComponent(siteID.safeFilename, isDirectory: true)
+    }
+
+    /// Set up the editor for the given site.
+    ///
+    /// - warning: The request make take a significant amount of time the first
+    /// time you open the editor.
+    public func setup(_ configuration: inout EditorConfiguration) async throws {
+        var builder = configuration.toBuilder()
+
+        if !isEditorLoaded {
+            try await refresh()
+        }
+
+        if let data = try? Data(contentsOf: editorSettingsFileURL),
+           let settings = String(data: data, encoding: .utf8) {
+            builder = builder.setEditorSettings(settings)
+        }
+
+        return configuration = builder.build()
+    }
+
+    /// Returns `true` is the resources requied for the editor already exist.
+    private var isEditorLoaded: Bool {
+        FileManager.default.fileExists(atPath: editorSettingsFileURL.path())
+    }
+
+    /// Refresh the editor resources.
+    public func refresh() async throws {
+        if let task = refreshTask {
+            return try await task.value
+        }
+        let task = Task {
+            defer { refreshTask = nil }
+            try await actuallyRefresh()
+        }
+        refreshTask = task
+        return try await task.value
+    }
+
+    private func actuallyRefresh() async throws {
+        try await fetchEditorSettings()
+    }
+
+    // MARK: – Editor Settings
+
+    /// Fetches block editor settings from the WordPress REST API
+    ///
+    /// - Returns: Raw settings data from the API
+    @discardableResult
+    private func fetchEditorSettings() async throws -> Data {
+        let data = try await getData(for: baseURL.appendingPathComponent("/wp-block-editor/v1/settings"))
+        do {
+            createStoreDirectoryIfNeeded()
+            try data.write(to: editorSettingsFileURL)
+        } catch {
+            assertionFailure("Failed to save settings: \(error)")
+        }
+        return data
+    }
+
+    // MARK: - Private Helpers
+
+    private func createStoreDirectoryIfNeeded() {
+        if !FileManager.default.fileExists(atPath: storeURL.path) {
+            try? FileManager.default.createDirectory(at: storeURL, withIntermediateDirectories: true)
+        }
+    }
+
+    private func getData(for requestURL: URL) async throws -> Data {
+        var request = URLRequest(url: requestURL)
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let status = (response as? HTTPURLResponse)?.statusCode,
+              (200..<300).contains(status) else {
+            throw URLError(.badServerResponse)
+        }
+        return data
+    }
+}


### PR DESCRIPTION
## What?
The demo app will now honor site's block editor settings (`wp-block-editor/v1/settings`).

## Why?

The idea is to use the newly introduced `EditorService` to manage the initial load and subsequent refresh of all resources required to launch the editor: editor settings and assets. 

In the future PRs, I plan to simplify the code in `EditorAssetsLibrary` and move it to `EditorService`. It will fetch the manifest and the assets before "starting" the editor and will inject the preprocessed manifest using the configuration. This will give the host app control over when and how the assets are loaded and stored. With the new implementation, the requests will run in parallel, cutting the first load time by around 900ms (due to parallelization alone).

I will then generate the Android implementation based on the Swift code.

## How?

The new `EditorService` provides two simply APIs for the host app. 

The `setup` method is what you call to configure the editor. On first load, it will fetch the required resources (blocking operation). On the subsequent loads, it will simply use the previously loaded data (changes infrequently). It's up to the app how to handle errors.

```swift
public func setup(_ configuration: inout EditorConfiguration) async throws
```

The host app will also be responsible for calling `refresh` to update the previously fetched resources (or load the initial ones). It's safe to call `refresh` multiple times as it will attach to the existing task if present.  It's up to the app how to handle errors.

```swift
public func refresh() async throws
```

## Testing Instructions
Add a new "remote" editor and verify that the styles are applied.

## Screenshots or screencast

Before / After
<img width="360" alt="Screenshot 2025-11-20 at 12 41 36 PM" src="https://github.com/user-attachments/assets/0284954c-ed66-4369-9c13-97d3ce4dac3b" /> <img width="360" alt="Screenshot 2025-11-20 at 12 41 05 PM" src="https://github.com/user-attachments/assets/01d48b05-222a-46ac-8c65-64a739451d4e" />


