### PR TITLE
task: Expand error reporting

### DIFF
--- a/src/utils/editor-environment.js
+++ b/src/utils/editor-environment.js
@@ -6,7 +6,7 @@ import { loadEditorAssets } from './editor-loader';
 import { initializeVideoPressAjaxBridge } from './videopress-bridge';
 import EditorLoadError from '../components/editor-load-error';
 import { error } from './logger';
-import { setupGlobalErrorHandlers } from './global-error-handler';
+import { setUpGlobalErrorHandlers } from './global-error-handler';
 import './editor-styles';
 
 /**
@@ -39,7 +39,7 @@ export function setUpEditorEnvironment() {
 		.then( initializeVideoPressAjaxBridge )
 		.then( loadPluginsIfEnabled )
 		.then( initializeEditor )
-		.then( setupGlobalErrorHandlers )
+		.then( setUpGlobalErrorHandlers )
 		.catch( handleError );
 }
 

--- a/src/utils/editor-environment.js
+++ b/src/utils/editor-environment.js
@@ -1,16 +1,12 @@
 /**
  * Internal dependencies
  */
-import {
-	awaitGBKitGlobal,
-	editorLoaded,
-	getGBKit,
-	logException,
-} from './bridge';
+import { awaitGBKitGlobal, editorLoaded, getGBKit } from './bridge';
 import { loadEditorAssets } from './editor-loader';
 import { initializeVideoPressAjaxBridge } from './videopress-bridge';
 import EditorLoadError from '../components/editor-load-error';
 import { error } from './logger';
+import { setupGlobalErrorHandlers } from './global-error-handler';
 import './editor-styles';
 
 /**
@@ -99,94 +95,4 @@ function handleError( err ) {
 	const errorDetails = EditorLoadError( { error: err } );
 	document.body.innerHTML = errorDetails;
 	editorLoaded();
-}
-
-/**
- * Determines if an error originated from GutenbergKit code rather than
- * third-party scripts.
- *
- * @param {string|undefined} filename - The filename from the error event
- * @param {Error|undefined}  errorObj - The error object with stack trace
- * @return {boolean} True if the error appears to be from GutenbergKit code
- */
-function isGutenbergKitError( filename, errorObj ) {
-	// Check the filename first
-	if ( filename ) {
-		// GutenbergKit errors should have /gutenberg/ in the path or be from
-		// the same origin
-		if (
-			filename.includes( '/gutenberg/' ) ||
-			filename.includes( window.location.origin )
-		) {
-			return true;
-		}
-		// If filename is from a different origin, it's likely third-party
-		if ( filename.startsWith( 'http' ) ) {
-			return false;
-		}
-	}
-
-	// If no filename, check the error stack trace
-	if ( errorObj?.stack ) {
-		const stack = errorObj.stack;
-		// Look for GutenbergKit-related paths in the stack
-		if (
-			stack.includes( '/gutenberg/' ) ||
-			stack.includes( window.location.origin )
-		) {
-			return true;
-		}
-	}
-
-	// If we can't determine the origin, report it to be safe
-	// Better to have some noise than miss legitimate errors
-	return true;
-}
-
-/**
- * Sets up global error handlers to catch and report unhandled errors
- * and promise rejections.
- */
-function setupGlobalErrorHandlers() {
-	// Catch unhandled errors
-	window.addEventListener( 'error', ( event ) => {
-		// Filter out errors from third-party scripts
-		if ( ! isGutenbergKitError( event.filename, event.error ) ) {
-			return;
-		}
-
-		const errorObj = event.error || new Error( event.message );
-
-		logException( errorObj, {
-			context: {
-				filename: event.filename,
-				lineno: event.lineno,
-				colno: event.colno,
-			},
-			tags: {},
-			isHandled: false,
-			handledBy: 'window.error',
-		} );
-	} );
-
-	// Catch unhandled promise rejections
-	window.addEventListener( 'unhandledrejection', ( event ) => {
-		// Convert rejection reason to Error if it isn't already
-		const errorObj =
-			event.reason instanceof Error
-				? event.reason
-				: new Error( String( event.reason ) );
-
-		// Filter out errors from third-party scripts
-		if ( ! isGutenbergKitError( undefined, errorObj ) ) {
-			return;
-		}
-
-		logException( errorObj, {
-			context: {},
-			tags: {},
-			isHandled: false,
-			handledBy: 'unhandledrejection',
-		} );
-	} );
 }

--- a/src/utils/editor-environment.js
+++ b/src/utils/editor-environment.js
@@ -16,6 +16,8 @@ import './editor-styles';
  * @return {Promise} Promise that resolves when initialization is complete
  */
 export function setUpEditorEnvironment() {
+	setUpGlobalErrorHandlers();
+
 	// Detect platform and add class to body for platform-specific styling
 	if ( typeof window !== 'undefined' && window.webkit ) {
 		document.body.classList.add( 'is-ios' );
@@ -39,7 +41,6 @@ export function setUpEditorEnvironment() {
 		.then( initializeVideoPressAjaxBridge )
 		.then( loadPluginsIfEnabled )
 		.then( initializeEditor )
-		.then( setUpGlobalErrorHandlers )
 		.catch( handleError );
 }
 

--- a/src/utils/editor-environment.js
+++ b/src/utils/editor-environment.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { awaitGBKitGlobal, editorLoaded, getGBKit } from './bridge';
+import {
+	awaitGBKitGlobal,
+	editorLoaded,
+	getGBKit,
+	logException,
+} from './bridge';
 import { loadEditorAssets } from './editor-loader';
 import { initializeVideoPressAjaxBridge } from './videopress-bridge';
 import EditorLoadError from '../components/editor-load-error';
@@ -38,6 +43,7 @@ export function setUpEditorEnvironment() {
 		.then( initializeVideoPressAjaxBridge )
 		.then( loadPluginsIfEnabled )
 		.then( initializeEditor )
+		.then( setupGlobalErrorHandlers )
 		.catch( handleError );
 }
 
@@ -93,4 +99,94 @@ function handleError( err ) {
 	const errorDetails = EditorLoadError( { error: err } );
 	document.body.innerHTML = errorDetails;
 	editorLoaded();
+}
+
+/**
+ * Determines if an error originated from GutenbergKit code rather than
+ * third-party scripts.
+ *
+ * @param {string|undefined} filename - The filename from the error event
+ * @param {Error|undefined}  errorObj - The error object with stack trace
+ * @return {boolean} True if the error appears to be from GutenbergKit code
+ */
+function isGutenbergKitError( filename, errorObj ) {
+	// Check the filename first
+	if ( filename ) {
+		// GutenbergKit errors should have /gutenberg/ in the path or be from
+		// the same origin
+		if (
+			filename.includes( '/gutenberg/' ) ||
+			filename.includes( window.location.origin )
+		) {
+			return true;
+		}
+		// If filename is from a different origin, it's likely third-party
+		if ( filename.startsWith( 'http' ) ) {
+			return false;
+		}
+	}
+
+	// If no filename, check the error stack trace
+	if ( errorObj?.stack ) {
+		const stack = errorObj.stack;
+		// Look for GutenbergKit-related paths in the stack
+		if (
+			stack.includes( '/gutenberg/' ) ||
+			stack.includes( window.location.origin )
+		) {
+			return true;
+		}
+	}
+
+	// If we can't determine the origin, report it to be safe
+	// Better to have some noise than miss legitimate errors
+	return true;
+}
+
+/**
+ * Sets up global error handlers to catch and report unhandled errors
+ * and promise rejections.
+ */
+function setupGlobalErrorHandlers() {
+	// Catch unhandled errors
+	window.addEventListener( 'error', ( event ) => {
+		// Filter out errors from third-party scripts
+		if ( ! isGutenbergKitError( event.filename, event.error ) ) {
+			return;
+		}
+
+		const errorObj = event.error || new Error( event.message );
+
+		logException( errorObj, {
+			context: {
+				filename: event.filename,
+				lineno: event.lineno,
+				colno: event.colno,
+			},
+			tags: {},
+			isHandled: false,
+			handledBy: 'window.error',
+		} );
+	} );
+
+	// Catch unhandled promise rejections
+	window.addEventListener( 'unhandledrejection', ( event ) => {
+		// Convert rejection reason to Error if it isn't already
+		const errorObj =
+			event.reason instanceof Error
+				? event.reason
+				: new Error( String( event.reason ) );
+
+		// Filter out errors from third-party scripts
+		if ( ! isGutenbergKitError( undefined, errorObj ) ) {
+			return;
+		}
+
+		logException( errorObj, {
+			context: {},
+			tags: {},
+			isHandled: false,
+			handledBy: 'unhandledrejection',
+		} );
+	} );
 }

--- a/src/utils/global-error-handler.js
+++ b/src/utils/global-error-handler.js
@@ -1,0 +1,100 @@
+/**
+ * Internal dependencies
+ */
+import { logException } from './bridge';
+
+/**
+ * Sets up global error handlers to catch and report unhandled errors
+ * and promise rejections.
+ */
+export function setupGlobalErrorHandlers() {
+	// Catch unhandled errors
+	window.addEventListener( 'error', ( event ) => {
+		// Filter out errors from third-party scripts
+		if ( ! isGutenbergKitError( event.filename, event.error ) ) {
+			return;
+		}
+
+		const errorObj = event.error || new Error( event.message );
+
+		logException( errorObj, {
+			context: {
+				filename: event.filename,
+				lineno: event.lineno,
+				colno: event.colno,
+			},
+			tags: {},
+			isHandled: false,
+			handledBy: 'window.error',
+		} );
+
+		// Don't prevent default - let errors also appear in browser console
+		// for debugging purposes
+	} );
+
+	// Catch unhandled promise rejections
+	window.addEventListener( 'unhandledrejection', ( event ) => {
+		// Convert rejection reason to Error if it isn't already
+		const errorObj =
+			event.reason instanceof Error
+				? event.reason
+				: new Error( String( event.reason ) );
+
+		// Filter out errors from third-party scripts
+		if ( ! isGutenbergKitError( undefined, errorObj ) ) {
+			return;
+		}
+
+		logException( errorObj, {
+			context: {},
+			tags: {},
+			isHandled: false,
+			handledBy: 'unhandledrejection',
+		} );
+
+		// Don't prevent default - let rejections also appear in browser console
+		// for debugging purposes
+	} );
+}
+
+/**
+ * Determines if an error originated from GutenbergKit code rather than
+ * third-party scripts.
+ *
+ * @param {string|undefined} filename - The filename from the error event
+ * @param {Error|undefined}  errorObj - The error object with stack trace
+ * @return {boolean} True if the error appears to be from GutenbergKit code
+ */
+function isGutenbergKitError( filename, errorObj ) {
+	// Check the filename first
+	if ( filename ) {
+		// GutenbergKit errors should have /gutenberg/ in the path or be from
+		// the same origin
+		if (
+			filename.includes( '/gutenberg/' ) ||
+			filename.includes( window.location.origin )
+		) {
+			return true;
+		}
+		// If filename is from a different origin, it's likely third-party
+		if ( filename.startsWith( 'http' ) ) {
+			return false;
+		}
+	}
+
+	// If no filename, check the error stack trace
+	if ( errorObj?.stack ) {
+		const stack = errorObj.stack;
+		// Look for GutenbergKit-related paths in the stack
+		if (
+			stack.includes( '/gutenberg/' ) ||
+			stack.includes( window.location.origin )
+		) {
+			return true;
+		}
+	}
+
+	// If we can't determine the origin, report it to be safe
+	// Better to have some noise than miss legitimate errors
+	return true;
+}

--- a/src/utils/global-error-handler.js
+++ b/src/utils/global-error-handler.js
@@ -62,12 +62,8 @@ export function setupGlobalErrorHandlers() {
 function isGutenbergKitError( filename, errorObj ) {
 	// Check the filename first
 	if ( filename ) {
-		// GutenbergKit errors should have /gutenberg/ in the path or be from
-		// the same origin
-		if (
-			filename.includes( '/gutenberg/' ) ||
-			filename.includes( window.location.origin )
-		) {
+		// GutenbergKit errors should be from the same origin
+		if ( filename.includes( window.location.origin ) ) {
 			return true;
 		}
 		// If filename is from a different origin, it's likely third-party
@@ -79,11 +75,8 @@ function isGutenbergKitError( filename, errorObj ) {
 	// If no filename, check the error stack trace
 	if ( errorObj?.stack ) {
 		const stack = errorObj.stack;
-		// Look for GutenbergKit-related paths in the stack
-		if (
-			stack.includes( '/gutenberg/' ) ||
-			stack.includes( window.location.origin )
-		) {
+		// Look for same-origin paths in the stack trace
+		if ( stack.includes( window.location.origin ) ) {
 			return true;
 		}
 	}

--- a/src/utils/global-error-handler.js
+++ b/src/utils/global-error-handler.js
@@ -10,8 +10,7 @@ import { logException } from './bridge';
 export function setupGlobalErrorHandlers() {
 	// Catch unhandled errors
 	window.addEventListener( 'error', ( event ) => {
-		// Filter out errors from third-party scripts
-		if ( ! isGutenbergKitError( event.filename, event.error ) ) {
+		if ( isExternalError( event.filename, event.error ) ) {
 			return;
 		}
 
@@ -37,8 +36,7 @@ export function setupGlobalErrorHandlers() {
 				? event.reason
 				: new Error( String( event.reason ) );
 
-		// Filter out errors from third-party scripts
-		if ( ! isGutenbergKitError( undefined, errorObj ) ) {
+		if ( isExternalError( undefined, errorObj ) ) {
 			return;
 		}
 
@@ -52,36 +50,37 @@ export function setupGlobalErrorHandlers() {
 }
 
 /**
- * Determines if an error originated from GutenbergKit code rather than
- * third-party scripts.
+ * Determines if an error originated from an external third-party script.
+ *
+ * Detects external HTTP(S) URLs from different origins (third-party scripts).
+ * GutenbergKit errors (same-origin, file://, or unknown sources) return false.
  *
  * @param {string|undefined} filename - The filename from the error event
  * @param {Error|undefined}  errorObj - The error object with stack trace
- * @return {boolean} True if the error appears to be from GutenbergKit code
+ * @return {boolean} True if the error is from an external source (should be filtered)
  */
-function isGutenbergKitError( filename, errorObj ) {
-	// Check the filename first
-	if ( filename ) {
-		// GutenbergKit errors should be from the same origin
-		if ( filename.includes( window.location.origin ) ) {
-			return true;
-		}
-		// If filename is from a different origin, it's likely third-party
-		if ( filename.startsWith( 'http' ) ) {
-			return false;
-		}
+function isExternalError( filename, errorObj ) {
+	// Detect external HTTP(S) URLs from different origins (third-party scripts)
+	if (
+		filename?.startsWith( 'http' ) &&
+		! filename.includes( window.location.origin )
+	) {
+		return true;
 	}
 
-	// If no filename, check the error stack trace
+	// Check stack trace for external URLs
 	if ( errorObj?.stack ) {
-		const stack = errorObj.stack;
-		// Look for same-origin paths in the stack trace
-		if ( stack.includes( window.location.origin ) ) {
-			return true;
+		const stackLines = errorObj.stack.split( '\n' );
+		for ( const line of stackLines ) {
+			// Check if any line in stack contains external HTTP URL
+			if (
+				line.includes( 'http' ) &&
+				! line.includes( window.location.origin )
+			) {
+				return true;
+			}
 		}
 	}
 
-	// If we can't determine the origin, report it to be safe
-	// Better to have some noise than miss legitimate errors
-	return true;
+	return false;
 }

--- a/src/utils/global-error-handler.js
+++ b/src/utils/global-error-handler.js
@@ -7,7 +7,7 @@ import { logException } from './bridge';
  * Sets up global error handlers to catch and report unhandled errors
  * and promise rejections.
  */
-export function setupGlobalErrorHandlers() {
+export function setUpGlobalErrorHandlers() {
 	// Catch unhandled errors
 	window.addEventListener( 'error', ( event ) => {
 		if ( isExternalError( event.filename, event.error ) ) {

--- a/src/utils/global-error-handler.js
+++ b/src/utils/global-error-handler.js
@@ -27,9 +27,6 @@ export function setupGlobalErrorHandlers() {
 			isHandled: false,
 			handledBy: 'window.error',
 		} );
-
-		// Don't prevent default - let errors also appear in browser console
-		// for debugging purposes
 	} );
 
 	// Catch unhandled promise rejections
@@ -51,9 +48,6 @@ export function setupGlobalErrorHandlers() {
 			isHandled: false,
 			handledBy: 'unhandledrejection',
 		} );
-
-		// Don't prevent default - let rejections also appear in browser console
-		// for debugging purposes
 	} );
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Improve observability by reporting errors occurring outside of the React tree, and therefore uncaught by the existing `ErrorBoundary` component. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Close CMM-827. There may be disruptive errors occurring outside of React components. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
* Add global error handlers for `error` and `unhandledrejection`. 
* Filter out errors deemed to be "external" to reduce noise. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
### 1. Verify GutenbergKit errors are reported
1. Apply the example errors diff below. 
2. Place a breakpoint on the corresponding [native handler](https://github.com/wordpress-mobile/GutenbergKit/blob/30d21f3e7ef07f878b6b79aec39bec8c5be02733/ios/Demo-iOS/Sources/Views/EditorView.swift#L166-L168). 
3. Open the editor. 
4. **Verify** the errors trigger the breakpoints. 

<details><summary>Example GutenbergKit errors diff</summary>
<p>

```diff
diff --git a/src/utils/editor-environment.js b/src/utils/editor-environment.js
index 91ef3e1..8caf2a5 100644
--- a/src/utils/editor-environment.js
+++ b/src/utils/editor-environment.js
@@ -40,6 +40,7 @@ export function setUpEditorEnvironment() {
 		.then( loadPluginsIfEnabled )
 		.then( initializeEditor )
 		.then( setupGlobalErrorHandlers )
+		.then( testErrorHandlers ) // TEMPORARY: Remove after testing
 		.catch( handleError );
 }
 
@@ -96,3 +97,37 @@ function handleError( err ) {
 	document.body.innerHTML = errorDetails;
 	editorLoaded();
 }
+
+// TEMPORARY: Test error handlers - Remove this entire function after testing
+/**
+ * Triggers test errors to verify global error handlers are working.
+ * This function schedules three different error scenarios with delays
+ * to test both the window.error and unhandledrejection handlers.
+ */
+function testErrorHandlers() {
+	// eslint-disable-next-line no-console
+	console.log( '🧪 GutenbergKit: Testing error handlers in 2 seconds...' );
+
+	// Test 1: Uncaught error (should be caught by window.error handler)
+	setTimeout( () → {
+		// eslint-disable-next-line no-console
+		console.log( '🧪 Test 1: Throwing uncaught error' );
+		throw new Error( 'TEST: Uncaught error from GutenbergKit' );
+	}, 2000 );
+
+	// Test 2: Unhandled promise rejection with Error object
+	// (should be caught by unhandledrejection handler)
+	setTimeout( () → {
+		// eslint-disable-next-line no-console
+		console.log( '🧪 Test 2: Creating unhandled promise rejection' );
+		Promise.reject( new Error( 'TEST: Unhandled promise rejection' ) );
+	}, 4000 );
+
+	// Test 3: Unhandled promise rejection with string
+	// (should be caught by unhandledrejection handler and converted to Error)
+	setTimeout( () → {
+		// eslint-disable-next-line no-console
+		console.log( '🧪 Test 3: Rejecting promise with string' );
+		Promise.reject( 'TEST: String rejection from promise' );
+	}, 6000 );
+}

```

</p>
</details> 

### 2. Verify external errors are not reported
1. Apply the example errors diff below. 
2. Place a breakpoint on the corresponding [native handler](https://github.com/wordpress-mobile/GutenbergKit/blob/30d21f3e7ef07f878b6b79aec39bec8c5be02733/ios/Demo-iOS/Sources/Views/EditorView.swift#L166-L168). 
3. Open the editor for a site with the Jetpack plugin. 
4. Insert the Jetpack Paywall block. 
5. **Verify** the errors **do not** trigger the breakpoints. 

<details><summary>Example external errors diff</summary>
<p>

```diff
diff --git a/src/utils/editor.jsx b/src/utils/editor.jsx
index ac38763..d3f3a1d 100644
--- a/src/utils/editor.jsx
+++ b/src/utils/editor.jsx
@@ -44,7 +44,7 @@ export function initializeEditor( {
 	preferenceDispatch.set( 'core', 'editorMode', 'visual' );
 
 	registerCoreBlocks();
-	unregisterDisallowedBlocks( allowedBlockTypes );
+	// unregisterDisallowedBlocks( allowedBlockTypes );
 	const post = getPost();
 
 	createRoot( document.getElementById( 'root' ) ).render(
diff --git a/src/utils/global-error-handler.js b/src/utils/global-error-handler.js
index 72d1b54..fbb9c33 100644
--- a/src/utils/global-error-handler.js
+++ b/src/utils/global-error-handler.js
@@ -65,6 +65,7 @@ function isExternalError( filename, errorObj ) {
 		filename?.startsWith( 'http' ) &&
 		! filename.includes( window.location.origin )
 	) {
+		console.log( '>>> Detected external error from filename:', filename );
 		return true;
 	}
 
@@ -77,6 +78,10 @@ function isExternalError( filename, errorObj ) {
 				line.includes( 'http' ) &&
 				! line.includes( window.location.origin )
 			) {
+				console.log(
+					'>>> Detected external error from stack line:',
+					line
+				);
 				return true;
 			}
 		}

```

</p>
</details> 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes. 