### PR TITLE
Swift build tool plugin experiment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     name: "GutenbergKit",
     platforms: [.iOS(.v17), .macOS(.v14)],
     products: [
-        .library(name: "GutenbergKit", targets: ["GutenbergKit"])
+        .library(name: "GutenbergKit", targets: ["GutenbergKit"]),
+        .plugin(name: "BuildToolPlugin", targets: ["BuildToolPlugin"])
     ],
     dependencies: [
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.7.5"),
@@ -19,7 +20,10 @@ let package = Package(
             dependencies: ["SwiftSoup", "SVGView"],
             path: "ios/Sources/GutenbergKit",
             exclude: [],
-            resources: [.copy("Gutenberg")]
+            resources: [.copy("Gutenberg")],
+            plugins: [
+                .plugin(name: "BuildToolPlugin")
+            ]
         ),
         .testTarget(
             name: "GutenbergKitTests",
@@ -30,5 +34,10 @@ let package = Package(
                 .copy("GutenbergKitTests/Resources/manifest-test-case-1.json")
             ]
         ),
+        .plugin(
+            name: "BuildToolPlugin",
+            capability: .buildTool(),
+            path: "ios/Sources/BuildToolPlugin"
+        )
     ]
 )

--- a/ios/Sources/BuildToolPlugin/BuildToolPlugin.swift
+++ b/ios/Sources/BuildToolPlugin/BuildToolPlugin.swift
@@ -1,0 +1,32 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct MyBuildToolPlugin: BuildToolPlugin {
+
+  func createBuildCommands(
+      context: PluginContext,
+      target: Target
+  ) throws -> [Command] {
+    // defaults write com.apple.dt.Xcode IDEPackageSupportDisablePluginExecutionSandbox -bool YES
+    let url = URL(string: context.package.directory.string)!
+    let outputFilesDir = url
+      .appendingPathComponent("dist")
+      .path()
+
+    print(outputFilesDir)
+
+    return [
+        .prebuildCommand(
+            displayName: "Running make build",
+            executable: try context.tool(named: "make").path,
+            arguments: [
+              "-C",
+              context.package.directory,
+              "build"
+            ],
+            outputFilesDirectory: context.package.directory
+        )
+    ]
+  }
+}


### PR DESCRIPTION
Fails in Xcode with:

```
/usr/bin/sandbox-exec -p "(version 1)
(deny default)
(import \"system.sb\")
(allow file-read*)
(allow process*)
(allow mach-lookup (global-name \"com.apple.lsd.mapdb\"))
(allow mach-lookup (global-name \"com.apple.mobileassetd.v2\"))
(allow file-write*
    (subpath \"/private/tmp\")
    (subpath \"/private/var/tmp\")
    (subpath \"/private/var/folders/dq/cdqxvx3s5ps75564rpmb_dc00000gn/T\")
    (subpath \"/private/var/folders/dq/cdqxvx3s5ps75564rpmb_dc00000gn/C\")
)
(deny file-write*
    (subpath \"/Users/gio/Developer/a8c/tmp-workbench/GutenbergKit\")
)
(allow file-write*
    (subpath \"/Users/gio/Developer/a8c/tmp-workbench/GutenbergKit/DerivedData/GutenbergKit/Build/Intermediates.noindex/BuildToolPluginIntermediates/gutenbergkit.output/GutenbergKit/BuildToolPlugin\")
    (subpath \"/private/var/folders/dq/cdqxvx3s5ps75564rpmb_dc00000gn/T/TemporaryItems\")
)
" /Applications/Xcode.app/Contents/Developer/usr/bin/make -C /Users/gio/Developer/a8c/tmp-workbench/GutenbergKit build

--- :npm: Installing NPM Dependencies
/bin/sh: npm: command not found
make: *** [npm-dependencies] Error 127
```

Notice that, even if we could make it so the plugin run on a shell where npm is available, we'd still likely run into issues with the `deny file-write*` on the source folder.

Possibly related: https://github.com/swiftlang/swift-package-manager/issues/7121

Cannot currently try to build outside of Xcode/`xcodebuild` because of the UIKit implicit dependency.