### PR TITLE
fix: Await configuration before initializing network logging

### DIFF
--- a/src/utils/editor-environment.js
+++ b/src/utils/editor-environment.js
@@ -21,9 +21,9 @@ import './editor-styles';
 export async function setUpEditorEnvironment() {
 	try {
 		setUpGlobalErrorHandlers();
-		initializeFetchInterceptor();
 		setBodyClasses();
 		await awaitGBKitGlobal();
+		initializeFetchInterceptor();
 		await configureLocale();
 		await initializeWordPressGlobals();
 		await configureApiFetch();

--- a/src/utils/editor-environment.test.js
+++ b/src/utils/editor-environment.test.js
@@ -16,8 +16,10 @@ import { initializeWordPressGlobals } from './wordpress-globals.js';
 import { configureLocale } from './localization.js';
 import { configureApiFetch } from './api-fetch.js';
 import { initializeEditor } from './editor.jsx';
+import { initializeFetchInterceptor } from './fetch-interceptor.js';
 
 vi.mock( './bridge.js' );
+vi.mock( './fetch-interceptor.js' );
 vi.mock( './logger.js' );
 vi.mock( './editor-styles.js' );
 vi.mock( './videopress-bridge.js' );
@@ -55,6 +57,7 @@ describe( 'setUpEditorEnvironment', () => {
 		configureLocale.mockResolvedValue( undefined );
 		initializeWordPressGlobals.mockImplementation( () => {} );
 		configureApiFetch.mockImplementation( () => {} );
+		initializeFetchInterceptor.mockImplementation( () => {} );
 		initializeVideoPressAjaxBridge.mockImplementation( () => {} );
 		initializeEditor.mockImplementation( () => {} );
 		EditorLoadError.mockReturnValue( '<div>Error</div>' );
@@ -69,6 +72,10 @@ describe( 'setUpEditorEnvironment', () => {
 		awaitGBKitGlobal.mockImplementation( () => {
 			callOrder.push( 'awaitGBKitGlobal' );
 			return Promise.resolve();
+		} );
+
+		initializeFetchInterceptor.mockImplementation( () => {
+			callOrder.push( 'initializeFetchInterceptor' );
 		} );
 
 		configureLocale.mockImplementation( () => {
@@ -96,6 +103,7 @@ describe( 'setUpEditorEnvironment', () => {
 
 		expect( callOrder ).toEqual( [
 			'awaitGBKitGlobal',
+			'initializeFetchInterceptor',
 			'configureLocale',
 			'loadRemainingGlobals',
 			'configureApiFetch',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Mitigate a race condition unexpectedly disabling network logging. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Without awaiting the `GBKit` configuration global, a race condition often led to disabled fetch interception, even though the `enableNetworkLogging` configuration was enabled.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Await the `GBKit` configuration global before initializing the `fetch` interceptor. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
> [!important]
> I was only ever to reproduce the race condition while using the WordPress-Android app while using a local production build (`make build`). It was not reproducible in the GutenbergKit Demo app or while using a local development server (`make dev-server`). 
> 
> This requires:
> 1. Pointing the [WordPress-Android branch's](https://github.com/wordpress-mobile/WordPress-Android/pull/22381) `gradle/libs.versions.toml` to this GutenbergKit branch's most recent commit. 
> 1. Running `WordPress-Android` in Android Studio. 

1. Enable WordPress-Android's experimental networking logging feature. 
2. Enable _Track Network Requests_. 
3. Launch the experimental editor. 
4. Insert an _Image_ block and upload an image. 
5. **Verify** the network request is logged as expected. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes. 

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3175d0a4-8896-4760-82e2-c9eb6b95a347
