### PR TITLE
Remove unused setup method

### DIFF
--- a/ios/Demo-iOS/Sources/Views/AppRootView.swift
+++ b/ios/Demo-iOS/Sources/Views/AppRootView.swift
@@ -76,7 +76,7 @@ struct AppRootView: View {
                 let canUsePlugins = apiRoot.hasRoute(route: "/wpcom/v2/editor-assets")
                 let canUseEditorStyles = apiRoot.hasRoute(route: "/wp-block-editor/v1/settings")
 
-                var updatedConfiguration = EditorConfigurationBuilder()
+                self.activeEditorConfiguration = EditorConfigurationBuilder()
                     .setShouldUseThemeStyles(canUseEditorStyles)
                     .setShouldUsePlugins(canUsePlugins)
                     .setSiteUrl(config.siteUrl)
@@ -86,21 +86,6 @@ struct AppRootView: View {
                     .setLogLevel(.debug)
                     .setEnableNetworkLogging(true)
                     .build()
-
-                if let baseURL = URL(string: config.siteApiRoot) {
-                    let service = EditorService(
-                        siteURL: config.siteUrl,
-                        networkSession: URLSession.shared
-                    )
-
-                    do {
-                        try await service.setup(&updatedConfiguration)
-                    } catch {
-                        print("Failed to setup editor environment, confinuing with the default or cached configuration:", error)
-                    }
-                }
-
-                self.activeEditorConfiguration = updatedConfiguration
             } catch {
                 self.hasError = true
                 self.error = AppError(errorDescription: error.localizedDescription)

--- a/ios/Sources/GutenbergKit/Sources/Service/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Service/EditorService.swift
@@ -197,25 +197,6 @@ public actor EditorService {
         log(.info, "Editor refresh completed in \(String(format: "%.2f", totalTime))s")
     }
 
-    /// Set up the editor for the given site.
-    ///
-    /// - warning: The request make take a significant amount of time the first
-    /// time you open the editor.
-    public func setup(_ configuration: inout EditorConfiguration) async throws {
-        var builder = configuration.toBuilder()
-
-        if !isEditorLoaded {
-            try await refresh(configuration: configuration)
-        }
-
-        if let data = try? Data(contentsOf: editorSettingsFileURL),
-           let settings = String(data: data, encoding: .utf8) {
-            builder = builder.setEditorSettings(settings)
-        }
-
-        return configuration = builder.build()
-    }
-
     // MARK: – Editor Settings
 
     /// Fetches block editor settings from the WordPress REST API


### PR DESCRIPTION
It looks like a change from https://github.com/wordpress-mobile/GutenbergKit/pull/232 that resurfaced due to the rebase – removing it.