### PR TITLE
Disable cookies in EditorService

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/Service/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Service/EditorService.swift
@@ -451,6 +451,10 @@ public actor EditorService {
     private func fetchData(for requestURL: URL, authHeader: String) async throws -> Data {
         var request = URLRequest(url: requestURL)
         request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        // Prevent wordpress_logged_in cookies from being sent, which could interfere with
+        // application password authentication in the Authorization header.
+        // See: https://github.com/wordpress-mobile/GutenbergKit/commit/30ebac210924ecc8e9dee3980c101ef24b1befa6
+        request.httpShouldHandleCookies = false
 
         let (data, response) = try await networkSession.data(for: request)
         guard let status = (response as? HTTPURLResponse)?.statusCode,


### PR DESCRIPTION
## What?

Fix an issue with authentification cookies taking priority over application passwords that are required for the editor  (similar to https://github.com/wordpress-mobile/GutenbergKit/commit/30ebac210924ecc8e9dee3980c101ef24b1befa6).


## Testing Instructions

I tested it by creating a temporary integration branch and verifying that my JN site starts returning 200.

<img width="476" height="58" alt="Screenshot 2025-12-03 at 10 33 44 AM" src="https://github.com/user-attachments/assets/b31994dc-333e-43e2-8e23-500c73b48a57" />

