### PR TITLE
task: Log plugin load and editor initialization failures

### DIFF
--- a/src/utils/editor-environment.js
+++ b/src/utils/editor-environment.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { awaitGBKitGlobal, editorLoaded, getGBKit } from './bridge';
+import {
+	awaitGBKitGlobal,
+	editorLoaded,
+	getGBKit,
+	logException,
+} from './bridge';
 import { configureLocale } from './localization';
 import { loadEditorAssets } from './editor-loader';
 import { initializeVideoPressAjaxBridge } from './videopress-bridge';
@@ -100,7 +105,11 @@ async function loadPluginsIfEnabled() {
 		try {
 			const { allowedBlockTypes } = await loadEditorAssets();
 			return { allowedBlockTypes, pluginLoadFailed: false };
-		} catch {
+		} catch ( err ) {
+			logException( err, {
+				isHandled: true,
+				handledBy: 'loadPluginsIfEnabled',
+			} );
 			return { pluginLoadFailed: true };
 		}
 	}

--- a/src/utils/editor-environment.js
+++ b/src/utils/editor-environment.js
@@ -151,6 +151,10 @@ async function initializeEditor( pluginLoadResult = {} ) {
  * @param {Error} err - The error that occurred
  */
 function handleError( err ) {
+	logException( err, {
+		isHandled: true,
+		handledBy: 'setUpEditorEnvironment',
+	} );
 	error( 'Error initializing editor', err );
 	const errorDetails = EditorLoadError( { error: err } );
 	document.body.innerHTML = errorDetails;

--- a/src/utils/editor-environment.js
+++ b/src/utils/editor-environment.js
@@ -12,7 +12,7 @@ import { loadEditorAssets } from './editor-loader';
 import { initializeVideoPressAjaxBridge } from './videopress-bridge';
 import { initializeFetchInterceptor } from './fetch-interceptor';
 import EditorLoadError from '../components/editor-load-error';
-import { error } from './logger';
+import { setLogLevel, error } from './logger';
 import { setUpGlobalErrorHandlers } from './global-error-handler';
 import { Platform } from './platform';
 import './editor-styles';
@@ -28,6 +28,7 @@ export async function setUpEditorEnvironment() {
 		setUpGlobalErrorHandlers();
 		setBodyClasses();
 		await awaitGBKitGlobal();
+		setLogLevelFromGBKit();
 		initializeFetchInterceptor();
 		await configureLocale();
 		await initializeWordPressGlobals();
@@ -59,6 +60,18 @@ function setBodyClasses() {
 	}
 
 	window.document.body.classList.add( ...classNames );
+}
+
+/**
+ * Set the log level based on GBKit configuration.
+ *
+ * @return {void}
+ */
+function setLogLevelFromGBKit() {
+	const { logLevel } = getGBKit();
+	if ( logLevel ) {
+		setLogLevel( logLevel );
+	}
 }
 
 /**

--- a/src/utils/editor-environment.test.js
+++ b/src/utils/editor-environment.test.js
@@ -7,7 +7,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  * Internal dependencies
  */
 import { setUpEditorEnvironment } from './editor-environment';
-import { awaitGBKitGlobal, getGBKit, editorLoaded } from './bridge.js';
+import {
+	awaitGBKitGlobal,
+	getGBKit,
+	editorLoaded,
+	logException,
+} from './bridge.js';
 import { loadEditorAssets } from './editor-loader.js';
 import EditorLoadError from '../components/editor-load-error/index.jsx';
 import { error } from './logger.js';
@@ -208,5 +213,23 @@ describe( 'setUpEditorEnvironment', () => {
 
 		expect( result ).toBeInstanceOf( Promise );
 		await expect( result ).resolves.toBeUndefined();
+	} );
+
+	it( 'logs exception when plugin loading fails', async () => {
+		getGBKit.mockReturnValue( { plugins: true } );
+
+		const testError = new Error( 'Asset loading failed' );
+		loadEditorAssets.mockRejectedValue( testError );
+
+		await setUpEditorEnvironment();
+
+		expect( logException ).toHaveBeenCalledWith( testError, {
+			isHandled: true,
+			handledBy: 'loadPluginsIfEnabled',
+		} );
+		expect( initializeEditor ).toHaveBeenCalledWith( {
+			allowedBlockTypes: undefined,
+			pluginLoadFailed: true,
+		} );
 	} );
 } );

--- a/src/utils/editor-environment.test.js
+++ b/src/utils/editor-environment.test.js
@@ -152,6 +152,10 @@ describe( 'setUpEditorEnvironment', () => {
 
 		await setUpEditorEnvironment();
 
+		expect( logException ).toHaveBeenCalledWith( testError, {
+			isHandled: true,
+			handledBy: 'setUpEditorEnvironment',
+		} );
 		expect( error ).toHaveBeenCalledWith(
 			'Error initializing editor',
 			testError
@@ -169,6 +173,10 @@ describe( 'setUpEditorEnvironment', () => {
 
 		await setUpEditorEnvironment();
 
+		expect( logException ).toHaveBeenCalledWith( testError, {
+			isHandled: true,
+			handledBy: 'setUpEditorEnvironment',
+		} );
 		expect( error ).toHaveBeenCalledWith(
 			'Error initializing editor',
 			testError
@@ -184,6 +192,10 @@ describe( 'setUpEditorEnvironment', () => {
 
 		await setUpEditorEnvironment();
 
+		expect( logException ).toHaveBeenCalledWith( testError, {
+			isHandled: true,
+			handledBy: 'setUpEditorEnvironment',
+		} );
 		expect( error ).toHaveBeenCalledWith(
 			'Error initializing editor',
 			testError
@@ -201,6 +213,10 @@ describe( 'setUpEditorEnvironment', () => {
 
 		await setUpEditorEnvironment();
 
+		expect( logException ).toHaveBeenCalledWith( testError, {
+			isHandled: true,
+			handledBy: 'setUpEditorEnvironment',
+		} );
 		expect( error ).toHaveBeenCalledWith(
 			'Error initializing editor',
 			testError

--- a/src/utils/editor.jsx
+++ b/src/utils/editor.jsx
@@ -10,7 +10,6 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 import { unregisterDisallowedBlocks } from './blocks';
 import { getGBKit, getPost } from './bridge';
 import { getDefaultEditorSettings } from './editor-settings';
-import { setLogLevel, LOG_LEVELS } from './logger';
 
 /**
  * Configure editor settings and styles, and render the editor.
@@ -23,12 +22,7 @@ export function initializeEditor( {
 	allowedBlockTypes,
 	pluginLoadFailed,
 } = {} ) {
-	const {
-		themeStyles,
-		hideTitle,
-		editorSettings,
-		logLevel = LOG_LEVELS.INFO,
-	} = getGBKit();
+	const { themeStyles, hideTitle, editorSettings } = getGBKit();
 
 	const settings = editorSettings || getDefaultEditorSettings();
 	dispatch( editorStore ).updateEditorSettings( settings );
@@ -40,8 +34,6 @@ export function initializeEditor( {
 	preferenceDispatch.setDefaults( 'core/edit-post', {
 		themeStyles,
 	} );
-
-	setLogLevel( logLevel );
 
 	// Force visual mode on initialization to ensure consistency with native UI,
 	// which defaults to visual mode. In the future, we could allow the native

--- a/src/utils/exception-parser.js
+++ b/src/utils/exception-parser.js
@@ -76,10 +76,7 @@ const parseException = ( originalException ) => {
 		message: extractMessage( originalException ),
 	};
 
-	const stacktrace = parseStacktrace( originalException );
-	if ( stacktrace.length ) {
-		exception.stacktrace = stacktrace;
-	}
+	exception.stacktrace = parseStacktrace( originalException );
 
 	if ( exception.type === undefined && exception.message === '' ) {
 		exception.message = 'Unknown error';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Log exceptions from failed plugin loading and editor initialization. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Ref CMM-887. Improve failure observability. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Log handled plugin load failures. 
- Log handled editor initialization failures. 
- Always set the `stacktrace` value for exceptions sent across the bridge. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Remove the demo editor app from your testing device to clear cached editor assets. 
7. Block the editor assets endpoint via Proxyman or some other mechanism. 
2. Run the demo editor app on your device.  
7. Open the editor for a site with the Jetpack plugin activated. 
8. Note the warning toast message: _Plugin loading failed, using default editor configuration._
9. **Verify** the logged exception arrives in the host app via a breakpoint—e.g., [`ios/Demo-iOS/Sources/Views/EditorView.swift:163`](https://github.com/wordpress-mobile/GutenbergKit/blob/3dd8b9abb55f853f5f2c1d31480e5020f8cf637f/ios/Demo-iOS/Sources/Views/EditorView.swift#L163).

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes. 