### PR TITLE
ci: Enable Dependabot for `npm` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      ignore:
+          - dependency-name: 'eslint' # eslint@>=9.x.x blocked by https://github.com/WordPress/gutenberg/issues/64782
+            update-types: ['version-update:semver-major']
+          - dependency-name: 'react' # react@>=19.x.x blocked by https://github.com/WordPress/gutenberg/issues/71336
+            update-types: ['version-update:semver-major']
+          - dependency-name: 'react-dom' # react@>=19.x.x blocked by https://github.com/WordPress/gutenberg/issues/71336
+            update-types: ['version-update:semver-major']


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Automate updating `npm` dependencies with Dependabot. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Reduce maintenance efforts. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add Dependabot configuration. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A, no user-facing changes. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes. 
