### PR TITLE
Fix flaky iOS test

### DIFF
--- a/ios/Tests/GutenbergKitTests/Stores/EditorAssetLibraryTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorAssetLibraryTests.swift
@@ -32,13 +32,14 @@ struct EditorAssetLibraryTests {
     private func makeLibrary(
         configuration: EditorConfiguration = EditorAssetLibraryTests.testConfiguration,
         httpClient: EditorHTTPClientProtocol = EditorAssetLibraryMockHTTPClient(),
-        cachePolicy: EditorCachePolicy = .always
+        cachePolicy: EditorCachePolicy = .always,
+        storageRoot: URL = .randomTemporaryDirectory
     ) -> EditorAssetLibrary {
         EditorAssetLibrary(
             configuration: configuration,
             httpClient: httpClient,
             cachePolicy: cachePolicy,
-            storageRoot: .randomTemporaryDirectory
+            storageRoot: storageRoot
         )
     }
 
@@ -267,15 +268,15 @@ struct EditorAssetLibraryTests {
         let mockClient = EditorAssetLibraryMockHTTPClient()
         mockClient.getResponse = Data(manifestJSON.utf8)
 
-        let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
+        let siteCacheRoot = URL.randomTemporaryDirectory
+        let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore, storageRoot: siteCacheRoot)
 
         let manifest = try await library.fetchManifest()
 
         _ = try await library.buildBundle(for: manifest)
 
         // Add a non-directory file to the site root
-        let siteRoot = Paths.cacheRoot(for: Self.testConfiguration)
-        let randomFile = siteRoot.appending(path: "random-file.txt")
+        let randomFile = siteCacheRoot.appending(path: "random-file.txt")
         try Data("random content".utf8).write(to: randomFile, options: .atomic)
 
         let bundles = try await library.readAssetBundles()


### PR DESCRIPTION
## What?
There's a test that's failed a few times when it's run before others.

## How?
The test manually creates an erroneous file in the cache directory, but it was pointing to the wrong cache root.

## Testing Instructions
If CI passes, this should be fine. 

If you really want, you could run the changed test locally in isolation (ie – just that one test). Previously, it would fail. Now it will not.
