### PR TITLE
fix: Toggle the code editor in the iOS Demo app

### DIFF
--- a/ios/Demo-iOS/Sources/Views/EditorView.swift
+++ b/ios/Demo-iOS/Sources/Views/EditorView.swift
@@ -5,7 +5,7 @@ struct EditorView: View {
     private let configuration: EditorConfiguration
     private let dependencies: EditorDependencies?
 
-    @StateObject private var viewModel = EditorViewModel()
+    @State private var viewModel = EditorViewModel()
 
     @Environment(\.dismiss) var dismiss
 
@@ -216,7 +216,8 @@ private struct _EditorView: UIViewControllerRepresentable {
     }
 }
 
-private final class EditorViewModel: ObservableObject {
+@Observable
+private final class EditorViewModel {
     var isModalDialogOpen = false
     var hasUndo = false
     var hasRedo = false


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix toggling the code editor in the iOS demo app. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-1110. The code editor was inaccessible. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Restore the Swift Observation framework pattern that was likely unintentionally removed in PR #250, allowing the code editor toggle to properly trigger `updateUIViewController` when the state changes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the Demo app on iOS. 
2. Launch the editor. 
3. Tap the more menu in the top-right corner. 
4. Tap Code Editor. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes. 
