### PR TITLE
fix: Android demo app fills viewport

### DIFF
--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -2,6 +2,7 @@ package com.example.gutenbergkit
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.ViewGroup
 import android.webkit.WebView
 import android.content.pm.ApplicationInfo
 import androidx.activity.ComponentActivity
@@ -209,6 +210,12 @@ fun EditorScreen(
         AndroidView(
             factory = { context ->
                 GutenbergView(context).apply {
+                    // Explicitly set layoutParams to MATCH_PARENT to ensure proper
+                    // viewport dimension communication to the WebView for CSS units.
+                    layoutParams = ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT
+                    )
                     gutenbergViewRef = this
                     setModalDialogStateListener(object : GutenbergView.ModalDialogStateListener {
                         override fun onModalDialogOpened(dialogType: String) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Ensure the editor HTML expands to fill the viewport height.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The editor background is clipped if the root element does not expand to fill the entire height. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Set explicit `layoutParams` with MATCH_PARENT on `GutenbergView` when used inside Compose's `AndroidView`. This fixes CSS viewport units (`vh`, `vw`, `dvh`) calculating as zero.

When a WebView is embedded in `AndroidView` without explicit `layoutParams`, the WebView's initial size is calculated as zero during the first composition pass. This causes CSS viewport units to resolve to 0px, even though JavaScript APIs like `window.innerHeight` return correct values.

Setting `MATCH_PARENT` `layoutParams` ensures the WebView knows its intended size constraints before loading content, allowing CSS viewport calculations to work correctly.

This is a known issue with WebView in Jetpack Compose:
- https://issuetracker.google.com/issues/238245846
- https://github.com/google/accompanist/issues/1224

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
This is particularly notable if a theme's styles are applied to the editor via #260. 

<details><summary>Example background clipping</summary>
<p>

<img width="840" height="1876" alt="gbk-android-body-background" src="https://github.com/user-attachments/assets/3f3009e9-bea4-40d4-b15b-35e48c1f4140" />

</p>
</details> 

To verify the fix manually, rely upon the Chrome DevTools to inspect the element height: 

1. Open the demo app editor on Android. 
2. Inspect the WebView via the Chrome DevTools. 
3. Verify the `html` element does not have a height of `0`, but fills the entire viewport. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no navigation changes. 

## Screenshots or screencast <!-- if applicable -->
Before | After 
-- | --
<img width="1569" height="951" alt="before" src="https://github.com/user-attachments/assets/7928787a-72c9-4e35-bae1-813cfde92488" /> | <img width="1588" height="970" alt="after" src="https://github.com/user-attachments/assets/f8d5a114-e9a8-4ac0-ac88-b9a21047d1ef" />
