### PR TITLE
fix: Add type checks before wrapping wp.ajax methods

### DIFF
--- a/src/utils/ajax.js
+++ b/src/utils/ajax.js
@@ -46,35 +46,39 @@ function configureAjaxAuth( authHeader ) {
 		},
 	} );
 
-	const originalSend = window.wp.ajax.send;
-	window.wp.ajax.send = function ( options ) {
-		const originalBeforeSend = options.beforeSend;
+	if ( typeof window.wp.ajax.send === 'function' ) {
+		const originalSend = window.wp.ajax.send;
+		window.wp.ajax.send = function ( options ) {
+			const originalBeforeSend = options.beforeSend;
 
-		options.beforeSend = function ( xhr ) {
-			xhr.setRequestHeader( 'Authorization', authHeader );
+			options.beforeSend = function ( xhr ) {
+				xhr.setRequestHeader( 'Authorization', authHeader );
 
-			if ( typeof originalBeforeSend === 'function' ) {
-				originalBeforeSend( xhr );
-			}
+				if ( typeof originalBeforeSend === 'function' ) {
+					originalBeforeSend( xhr );
+				}
+			};
+
+			return originalSend.call( this, options );
 		};
+	}
 
-		return originalSend.call( this, options );
-	};
+	if ( typeof window.wp.ajax.post === 'function' ) {
+		const originalPost = window.wp.ajax.post;
+		window.wp.ajax.post = function ( options ) {
+			const originalBeforeSend = options.beforeSend;
 
-	const originalPost = window.wp.ajax.post;
-	window.wp.ajax.post = function ( options ) {
-		const originalBeforeSend = options.beforeSend;
+			options.beforeSend = function ( xhr ) {
+				xhr.setRequestHeader( 'Authorization', authHeader );
 
-		options.beforeSend = function ( xhr ) {
-			xhr.setRequestHeader( 'Authorization', authHeader );
+				if ( typeof originalBeforeSend === 'function' ) {
+					originalBeforeSend( xhr );
+				}
+			};
 
-			if ( typeof originalBeforeSend === 'function' ) {
-				originalBeforeSend( xhr );
-			}
+			return originalPost.call( this, options );
 		};
-
-		return originalPost.call( this, options );
-	};
+	}
 
 	debug( 'AJAX auth configured' );
 }

--- a/src/utils/ajax.test.js
+++ b/src/utils/ajax.test.js
@@ -402,6 +402,9 @@ describe( 'configureAjax', () => {
 
 			expect( () => configureAjax() ).not.toThrow();
 
+			// Should not wrap send (it doesn't exist)
+			expect( global.window.wp.ajax.send ).toBeUndefined();
+
 			// Should still wrap post
 			expect( global.window.wp.ajax.post ).not.toBe( originalWpAjaxPost );
 		} );
@@ -420,6 +423,9 @@ describe( 'configureAjax', () => {
 			};
 
 			expect( () => configureAjax() ).not.toThrow();
+
+			// Should not wrap post (it doesn't exist)
+			expect( global.window.wp.ajax.post ).toBeUndefined();
 
 			// Should still wrap send
 			expect( global.window.wp.ajax.send ).not.toBe( originalWpAjaxSend );


### PR DESCRIPTION
## What?
Add type checks before wrapping `wp.ajax.send` and `wp.ajax.post` methods in the AJAX configuration.

## Why?
This addresses PR review feedback about a potential race condition. If `window.wp.ajax.send` or `window.wp.ajax.post` are undefined when `configureAjax()` executes, the wrapped function would throw a `TypeError` when invoked (calling `.call()` on undefined).

References: #181

## How?
- Added `typeof window.wp.ajax.send === 'function'` check before wrapping the `send` method
- Added `typeof window.wp.ajax.post === 'function'` check before wrapping the `post` method
- Methods are only wrapped if they exist as functions, preventing runtime errors
- Updated tests to verify that missing methods remain undefined rather than being wrapped with an undefined reference

## Testing Instructions
1. Run the test suite: `npm run test:unit`
2. Verify all 20 tests in `ajax.test.js` pass
3. Specifically check the "should handle missing wp.ajax.send method" and "should handle missing wp.ajax.post method" tests

### Accessibility Testing Instructions
N/A - This is a JavaScript utility change with no UI impact.

## Screenshots or screencast
N/A - No visual changes.
