### PR TITLE
test: Mock `@wordpress` modules throwing import errors

### DIFF
--- a/src/utils/editor.test.jsx
+++ b/src/utils/editor.test.jsx
@@ -13,12 +13,15 @@ import { getGBKit, getPost } from './bridge';
 import { getDefaultEditorSettings } from './editor-settings';
 import { unregisterDisallowedBlocks } from './blocks';
 
+vi.mock( '@wordpress/blocks', () => ( {} ) );
 vi.mock( '@wordpress/editor', () => ( {
 	store: { name: 'core/editor' },
 } ) );
 vi.mock( import( '@wordpress/data' ), { spy: true } );
 vi.mock( '@wordpress/preferences' );
-vi.mock( '@wordpress/block-library' );
+vi.mock( '@wordpress/block-library', () => ( {
+	registerCoreBlocks: vi.fn(),
+} ) );
 vi.mock( './blocks' );
 vi.mock( './bridge' );
 vi.mock( './editor-settings' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Address JavaScript test failures after merging #286. 

```
 FAIL  src/utils/editor.test.jsx [ src/utils/editor.test.jsx ]
TypeError: Module "file:./GutenbergKit/node_modules/@wordpress/blocks/build-module/api/i18n-block.json" needs an import attribute of type "json"
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Stablize CI checks. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Address an import error by mocking the relevant `@wordpress` modules. This is likely incompatibility between Vitest configuration and the packages.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
CI checks should pass. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no UX changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no visual changes. 