### PR TITLE
fix: Plugin loading respects `plugins` configuration

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/services/EditorService.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/services/EditorService.kt
@@ -201,7 +201,7 @@ class EditorService(
 
         return coroutineScope {
             val settingsDeferred = async { prepareEditorSettings() }
-            val assetBundleDeferred = async { prepareAssetBundle() }
+            val assetBundleDeferred = async { prepareAssetBundleIfEnabled() }
             val preloadListDeferred = async { preparePreloadList() }
 
             // Automatically clean up old asset bundles
@@ -267,6 +267,15 @@ class EditorService(
         val settings = restRepository.fetchEditorSettings()
         incrementProgress(DependencyWeights.EDITOR_SETTINGS)
         return settings
+    }
+
+    private suspend fun prepareAssetBundleIfEnabled(): EditorAssetBundle {
+        if (!configuration.plugins) {
+            incrementProgress(DependencyWeights.ASSET_BUNDLE)
+            return EditorAssetBundle.empty
+        }
+
+        return prepareAssetBundle()
     }
 
     private suspend fun prepareAssetBundle(): EditorAssetBundle {

--- a/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
@@ -120,7 +120,7 @@ public actor EditorService {
         self.progressCallback = progress
 
         async let settings = try prepareEditorSettings()
-        async let assetBundle = try self.prepareAssetBundle()
+        async let assetBundle = try self.prepareAssetBundleIfEnabled()
         async let preloadList = try preparePreloadList()
 
         // Automatically clean up old asset bundles
@@ -172,6 +172,15 @@ public actor EditorService {
         let settings = try await restRepository.fetchEditorSettings()
         await self.incrementProgress(for: .editorSettings)
         return settings
+    }
+
+    private func prepareAssetBundleIfEnabled() async throws -> EditorAssetBundle {
+        guard configuration.shouldUsePlugins else {
+            await self.incrementProgress(for: .assetBundle)
+            return .empty
+        }
+
+        return try await prepareAssetBundle()
     }
 
     private func prepareAssetBundle() async throws -> EditorAssetBundle {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update the `EditorService` to respect the `plugins` configuration option. The `EditorService` on both iOS and Android was unconditionally calling `prepareAssetBundle()` regardless of the `plugins` configuration setting. This caused plugin assets to always be loaded even when plugins were disabled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix CMM-1173. 

The previous behavior of ignoring the `plugins` configuration effectively disabled the configuration option's ability to control the user experience. This is problematic if a host app needs to selectively disable plugin support. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added `prepareAssetBundleIfEnabled()` method that checks the configuration before attempting to load plugin assets:
- iOS: Checks `configuration.shouldUsePlugins`
- Android: Checks `configuration.plugins`

When plugins are disabled, the method returns an empty asset bundle immediately instead of attempting to download or read from cache.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable the `plugins` configuration. 
2. Load the editor a compatible site so that an asset bundle is created. 
3. Verify plugin blocks are loaded. 
4. Close the editor. 
5. Disable the `plugins` configuration. 
6. Open the editor for the site. 
7. Verify plugin blocks are not loaded. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no UX changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no UX changes. 