### PR TITLE
fix: Skip post preloading for non-positive post IDs

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/services/EditorService.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/services/EditorService.kt
@@ -289,7 +289,7 @@ class EditorService(
             val postTypesDataDeferred = async { preparePostTypes() }
 
             val postId = configuration.postId
-            if (postId != null) {
+            if (postId != null && postId > 0) {
                 val postDataDeferred = async { preparePost(postId) }
 
                 EditorPreloadList(

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/services/EditorServiceTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/services/EditorServiceTest.kt
@@ -131,7 +131,7 @@ class EditorServiceTest {
 
     @Test
     fun `prepare does not fetch post when postID is negative`() = runBlocking {
-        val mockClient = EditorServiceURLTrackingMockHTTPClient()
+        val mockClient = EditorServiceMockHTTPClient()
         val configuration = testConfiguration.toBuilder()
             .setPostId(-1)
             .build()
@@ -150,7 +150,7 @@ class EditorServiceTest {
 
     @Test
     fun `prepare does not fetch post when postID is zero`() = runBlocking {
-        val mockClient = EditorServiceURLTrackingMockHTTPClient()
+        val mockClient = EditorServiceMockHTTPClient()
         val configuration = testConfiguration.toBuilder()
             .setPostId(0)
             .build()
@@ -169,7 +169,7 @@ class EditorServiceTest {
 
     @Test
     fun `prepare fetches post when postID is positive`() = runBlocking {
-        val mockClient = EditorServiceURLTrackingMockHTTPClient()
+        val mockClient = EditorServiceMockHTTPClient()
         val configuration = testConfiguration.toBuilder()
             .setPostId(123)
             .build()
@@ -184,85 +184,6 @@ class EditorServiceTest {
 }
 
 /**
- * Mock HTTP client that tracks requested URLs for verification.
- */
-class EditorServiceURLTrackingMockHTTPClient : EditorHTTPClientProtocol {
-
-    private val _requestedURLs = CopyOnWriteArrayList<String>()
-    val requestedURLs: List<String> get() = _requestedURLs.toList()
-
-    private val emptyManifestJson = """
-        {
-            "scripts": "",
-            "styles": "",
-            "allowed_block_types": []
-        }
-    """.trimIndent()
-
-    private val emptyEditorSettingsJson = """
-        {
-            "styles": []
-        }
-    """.trimIndent()
-
-    private val emptyPostTypeJson = """
-        {
-            "name": "Posts",
-            "slug": "post"
-        }
-    """.trimIndent()
-
-    private val emptyPostTypesJson = """
-        {
-            "post": {"name": "Posts", "slug": "post"},
-            "page": {"name": "Pages", "slug": "page"}
-        }
-    """.trimIndent()
-
-    private val emptyThemeJson = """
-        [{"name": "Twenty Twenty-Four"}]
-    """.trimIndent()
-
-    private val emptySettingsJson = """
-        {"title": "Test Site"}
-    """.trimIndent()
-
-    override suspend fun download(url: String, destination: File): EditorHTTPClientDownloadResponse {
-        _requestedURLs.add(url)
-
-        destination.parentFile?.mkdirs()
-        destination.writeText("mock content")
-
-        return EditorHTTPClientDownloadResponse(
-            file = destination,
-            statusCode = 200,
-            headers = EditorHTTPHeaders()
-        )
-    }
-
-    override suspend fun perform(method: EditorHttpMethod, url: String): EditorHTTPClientResponse {
-        _requestedURLs.add(url)
-
-        val responseData = when {
-            url.contains("editor-assets") -> emptyManifestJson
-            url.contains("wp-block-editor/v1/settings") -> emptyEditorSettingsJson
-            url.contains("/wp/v2/types/") && url.contains("context=edit") -> emptyPostTypeJson
-            url.contains("/wp/v2/types?context=view") -> emptyPostTypesJson
-            url.contains("/wp/v2/themes") -> emptyThemeJson
-            url.contains("/wp/v2/settings") -> emptySettingsJson
-            url.contains("/wp/v2/posts/") -> """{"id": 1, "title": {"rendered": "Test"}}"""
-            else -> "{}"
-        }
-
-        return EditorHTTPClientResponse(
-            data = responseData.toByteArray(),
-            statusCode = 200,
-            headers = EditorHTTPHeaders()
-        )
-    }
-}
-
-/**
  * Mock HTTP client for EditorService tests.
  */
 class EditorServiceMockHTTPClient : EditorHTTPClientProtocol {
@@ -273,6 +194,10 @@ class EditorServiceMockHTTPClient : EditorHTTPClientProtocol {
         private set
     var downloadedURLs = CopyOnWriteArrayList<String>()
         private set
+
+    /// URLs requested via `perform()`. Use this to verify which endpoints were called.
+    private val _requestedURLs = CopyOnWriteArrayList<String>()
+    val requestedURLs: List<String> get() = _requestedURLs.toList()
 
     private val lock = Any()
 
@@ -317,6 +242,7 @@ class EditorServiceMockHTTPClient : EditorHTTPClientProtocol {
         synchronized(lock) {
             downloadCallCount++
             downloadedURLs.add(url)
+            _requestedURLs.add(url)
         }
 
         destination.parentFile?.mkdirs()
@@ -334,6 +260,7 @@ class EditorServiceMockHTTPClient : EditorHTTPClientProtocol {
             if (method == EditorHttpMethod.GET) {
                 getCallCount++
             }
+            _requestedURLs.add(url)
         }
 
         val responseData = when {

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/services/EditorServiceTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/services/EditorServiceTest.kt
@@ -126,6 +126,140 @@ class EditorServiceTest {
         assertNotNull(dependencies)
         assertEquals("undefined", dependencies.editorSettings.themeStyles)
     }
+
+    // MARK: - preparePreloadList Tests (negative postID handling)
+
+    @Test
+    fun `prepare does not fetch post when postID is negative`() = runBlocking {
+        val mockClient = EditorServiceURLTrackingMockHTTPClient()
+        val configuration = testConfiguration.toBuilder()
+            .setPostId(-1)
+            .build()
+
+        val service = makeService(configuration = configuration, httpClient = mockClient)
+        service.prepare()
+
+        // Verify no request was made to /posts/-1
+        val postRequests = mockClient.requestedURLs.filter { it.contains("/posts/-1") }
+        assertEquals(
+            "Should not request /posts/-1 for negative post IDs",
+            emptyList<String>(),
+            postRequests
+        )
+    }
+
+    @Test
+    fun `prepare does not fetch post when postID is zero`() = runBlocking {
+        val mockClient = EditorServiceURLTrackingMockHTTPClient()
+        val configuration = testConfiguration.toBuilder()
+            .setPostId(0)
+            .build()
+
+        val service = makeService(configuration = configuration, httpClient = mockClient)
+        service.prepare()
+
+        // Verify no request was made to /posts/0
+        val postRequests = mockClient.requestedURLs.filter { it.contains("/posts/0") }
+        assertEquals(
+            "Should not request /posts/0 for zero post IDs",
+            emptyList<String>(),
+            postRequests
+        )
+    }
+
+    @Test
+    fun `prepare fetches post when postID is positive`() = runBlocking {
+        val mockClient = EditorServiceURLTrackingMockHTTPClient()
+        val configuration = testConfiguration.toBuilder()
+            .setPostId(123)
+            .build()
+
+        val service = makeService(configuration = configuration, httpClient = mockClient)
+        service.prepare()
+
+        // Verify a request was made to /posts/123
+        val postRequests = mockClient.requestedURLs.filter { it.contains("/posts/123") }
+        assert(postRequests.isNotEmpty()) { "Should request /posts/123 for positive post IDs" }
+    }
+}
+
+/**
+ * Mock HTTP client that tracks requested URLs for verification.
+ */
+class EditorServiceURLTrackingMockHTTPClient : EditorHTTPClientProtocol {
+
+    private val _requestedURLs = CopyOnWriteArrayList<String>()
+    val requestedURLs: List<String> get() = _requestedURLs.toList()
+
+    private val emptyManifestJson = """
+        {
+            "scripts": "",
+            "styles": "",
+            "allowed_block_types": []
+        }
+    """.trimIndent()
+
+    private val emptyEditorSettingsJson = """
+        {
+            "styles": []
+        }
+    """.trimIndent()
+
+    private val emptyPostTypeJson = """
+        {
+            "name": "Posts",
+            "slug": "post"
+        }
+    """.trimIndent()
+
+    private val emptyPostTypesJson = """
+        {
+            "post": {"name": "Posts", "slug": "post"},
+            "page": {"name": "Pages", "slug": "page"}
+        }
+    """.trimIndent()
+
+    private val emptyThemeJson = """
+        [{"name": "Twenty Twenty-Four"}]
+    """.trimIndent()
+
+    private val emptySettingsJson = """
+        {"title": "Test Site"}
+    """.trimIndent()
+
+    override suspend fun download(url: String, destination: File): EditorHTTPClientDownloadResponse {
+        _requestedURLs.add(url)
+
+        destination.parentFile?.mkdirs()
+        destination.writeText("mock content")
+
+        return EditorHTTPClientDownloadResponse(
+            file = destination,
+            statusCode = 200,
+            headers = EditorHTTPHeaders()
+        )
+    }
+
+    override suspend fun perform(method: EditorHttpMethod, url: String): EditorHTTPClientResponse {
+        _requestedURLs.add(url)
+
+        val responseData = when {
+            url.contains("editor-assets") -> emptyManifestJson
+            url.contains("wp-block-editor/v1/settings") -> emptyEditorSettingsJson
+            url.contains("/wp/v2/types/") && url.contains("context=edit") -> emptyPostTypeJson
+            url.contains("/wp/v2/types?context=view") -> emptyPostTypesJson
+            url.contains("/wp/v2/themes") -> emptyThemeJson
+            url.contains("/wp/v2/settings") -> emptySettingsJson
+            url.contains("/wp/v2/posts/") -> """{"id": 1, "title": {"rendered": "Test"}}"""
+            else -> "{}"
+        }
+
+        return EditorHTTPClientResponse(
+            data = responseData.toByteArray(),
+            statusCode = 200,
+            headers = EditorHTTPHeaders()
+        )
+    }
 }
 
 /**

--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,24 +1,6 @@
 {
-  "originHash" : "2aee256c0b38622aa9bb903b83d446aa51554bf7f6d1f43aca6d447f82d2a906",
+  "originHash" : "11fbb2cf922b873080bfec9421893617428fff2aba5645ca7121f53f5debada1",
   "pins" : [
-    {
-      "identity" : "svgview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/exyte/SVGView.git",
-      "state" : {
-        "revision" : "6465962facdd25cb96eaebc35603afa2f15d2c0d",
-        "version" : "1.0.6"
-      }
-    },
-    {
-      "identity" : "swiftsoup",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/scinfu/SwiftSoup.git",
-      "state" : {
-        "revision" : "aa85ee96017a730031bafe411cde24a08a17a9c9",
-        "version" : "2.8.8"
-      }
-    },
     {
       "identity" : "wordpress-rs",
       "kind" : "remoteSourceControl",

--- a/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
@@ -191,7 +191,7 @@ public actor EditorService {
         async let postTypeData = try self.preparePost(type: configuration.postType)
         async let postTypesData = try self.preparePostTypes()
 
-        if let postID = self.configuration.postID {
+        if let postID = self.configuration.postID, postID > 0 {
             async let postData = try self.preparePost(id: postID)
 
             return try await EditorPreloadList(

--- a/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
@@ -62,14 +62,14 @@ public actor EditorService {
     ///     location based on the site ID.
     public init(
         configuration: EditorConfiguration,
-        httpClient: EditorHTTPClient? = nil,
+        httpClient: (any EditorHTTPClientProtocol)? = nil,
         cachePolicy: EditorCachePolicy = .always,
         storageRoot: URL? = nil,
         cacheRoot: URL? = nil
     ) {
         self.configuration = configuration
 
-        let httpClient = httpClient ?? EditorHTTPClient(
+        let httpClient: any EditorHTTPClientProtocol = httpClient ?? EditorHTTPClient(
             urlSession: URLSession.shared,
             authHeader: configuration.authHeader,
             delegate: nil

--- a/ios/Tests/GutenbergKitTests/Services/EditorServiceTests.swift
+++ b/ios/Tests/GutenbergKitTests/Services/EditorServiceTests.swift
@@ -52,4 +52,124 @@ struct EditorServiceTests: MakesTestFixtures {
     try await makeService().purge()  // Check that it can be called multiple times
 
   }
+
+  // MARK: - preparePreloadList Tests
+
+  @Test("prepare does not fetch post when postID is negative")
+  func prepareDoesNotFetchPostWhenPostIDIsNegative() async throws {
+    let mockClient = EditorServiceURLTrackingMockHTTPClient()
+    let configuration = makeConfiguration(postID: -1)
+    let service = EditorService(
+      configuration: configuration,
+      httpClient: mockClient,
+      storageRoot: .randomTemporaryDirectory,
+      cacheRoot: .randomTemporaryDirectory
+    )
+
+    _ = try await service.prepare()
+
+    // Verify no request was made to /posts/-1
+    let postRequests = mockClient.requestedURLs.filter { $0.absoluteString.contains("/posts/-1") }
+    #expect(postRequests.isEmpty, "Should not request /posts/-1 for negative post IDs")
+  }
+
+  @Test("prepare does not fetch post when postID is zero")
+  func prepareDoesNotFetchPostWhenPostIDIsZero() async throws {
+    let mockClient = EditorServiceURLTrackingMockHTTPClient()
+    let configuration = makeConfiguration(postID: 0)
+    let service = EditorService(
+      configuration: configuration,
+      httpClient: mockClient,
+      storageRoot: .randomTemporaryDirectory,
+      cacheRoot: .randomTemporaryDirectory
+    )
+
+    _ = try await service.prepare()
+
+    // Verify no request was made to /posts/0
+    let postRequests = mockClient.requestedURLs.filter { $0.absoluteString.contains("/posts/0") }
+    #expect(postRequests.isEmpty, "Should not request /posts/0 for zero post IDs")
+  }
+
+  @Test("prepare fetches post when postID is positive")
+  func prepareFetchesPostWhenPostIDIsPositive() async throws {
+    let mockClient = EditorServiceURLTrackingMockHTTPClient()
+    let configuration = makeConfiguration(postID: 123)
+    let service = EditorService(
+      configuration: configuration,
+      httpClient: mockClient,
+      storageRoot: .randomTemporaryDirectory,
+      cacheRoot: .randomTemporaryDirectory
+    )
+
+    _ = try await service.prepare()
+
+    // Verify a request was made to /posts/123
+    let postRequests = mockClient.requestedURLs.filter { $0.absoluteString.contains("/posts/123") }
+    #expect(!postRequests.isEmpty, "Should request /posts/123 for positive post IDs")
+  }
+}
+
+// MARK: - Mock HTTP Client for URL Tracking
+
+final class EditorServiceURLTrackingMockHTTPClient: EditorHTTPClientProtocol, @unchecked Sendable {
+  private let lock = NSLock()
+  private var _requestedURLs: [URL] = []
+
+  var requestedURLs: [URL] {
+    lock.withLock { _requestedURLs }
+  }
+
+  func perform(_ urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    let url = urlRequest.url!
+    lock.withLock { _requestedURLs.append(url) }
+
+    let responseData: Data
+    let urlString = url.absoluteString
+
+    // Return appropriate mock responses based on URL
+    if urlString.contains("editor-assets") {
+      responseData = Data(#"{"scripts":"","styles":"","allowed_block_types":[]}"#.utf8)
+    } else if urlString.contains("wp-block-editor/v1/settings") {
+      responseData = Data(#"{"styles":[]}"#.utf8)
+    } else if urlString.contains("/wp/v2/types/") && urlString.contains("context=edit") {
+      responseData = Data(#"{"name":"Posts","slug":"post"}"#.utf8)
+    } else if urlString.contains("/wp/v2/types") {
+      responseData = Data(#"{"post":{"name":"Posts","slug":"post"}}"#.utf8)
+    } else if urlString.contains("/wp/v2/themes") {
+      responseData = Data(#"[{"name":"Twenty Twenty-Four"}]"#.utf8)
+    } else if urlString.contains("/wp/v2/settings") {
+      responseData = Data(#"{"title":"Test Site"}"#.utf8)
+    } else if urlString.contains("/wp/v2/posts/") {
+      responseData = Data(#"{"id":123,"title":{"rendered":"Test"}}"#.utf8)
+    } else {
+      responseData = Data("{}".utf8)
+    }
+
+    let response = HTTPURLResponse(
+      url: url,
+      statusCode: 200,
+      httpVersion: "HTTP/1.1",
+      headerFields: nil
+    )!
+
+    return (responseData, response)
+  }
+
+  func download(_ urlRequest: URLRequest) async throws -> (URL, HTTPURLResponse) {
+    let url = urlRequest.url!
+    lock.withLock { _requestedURLs.append(url) }
+
+    let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try Data("mock content".utf8).write(to: tempURL)
+
+    let response = HTTPURLResponse(
+      url: url,
+      statusCode: 200,
+      httpVersion: "HTTP/1.1",
+      headerFields: nil
+    )!
+
+    return (tempURL, response)
+  }
 }

--- a/ios/Tests/GutenbergKitTests/Services/EditorServiceTests.swift
+++ b/ios/Tests/GutenbergKitTests/Services/EditorServiceTests.swift
@@ -118,21 +118,22 @@ struct EditorServiceTests: MakesTestFixtures {
   private static func editorServiceResponseHandler(_ url: URL) -> Data {
     let urlString = url.absoluteString
 
-    if urlString.contains("editor-assets") {
+    switch true {
+    case urlString.contains("editor-assets"):
       return Data(#"{"scripts":"","styles":"","allowed_block_types":[]}"#.utf8)
-    } else if urlString.contains("wp-block-editor/v1/settings") {
+    case urlString.contains("wp-block-editor/v1/settings"):
       return Data(#"{"styles":[]}"#.utf8)
-    } else if urlString.contains("/wp/v2/types/") && urlString.contains("context=edit") {
+    case urlString.contains("/wp/v2/types/") && urlString.contains("context=edit"):
       return Data(#"{"name":"Posts","slug":"post"}"#.utf8)
-    } else if urlString.contains("/wp/v2/types") {
+    case urlString.contains("/wp/v2/types"):
       return Data(#"{"post":{"name":"Posts","slug":"post"}}"#.utf8)
-    } else if urlString.contains("/wp/v2/themes") {
+    case urlString.contains("/wp/v2/themes"):
       return Data(#"[{"name":"Twenty Twenty-Four"}]"#.utf8)
-    } else if urlString.contains("/wp/v2/settings") {
+    case urlString.contains("/wp/v2/settings"):
       return Data(#"{"title":"Test Site"}"#.utf8)
-    } else if urlString.contains("/wp/v2/posts/") {
+    case urlString.contains("/wp/v2/posts/"):
       return Data(#"{"id":123,"title":{"rendered":"Test"}}"#.utf8)
-    } else {
+    default:
       return Data("{}".utf8)
     }
   }

--- a/ios/Tests/GutenbergKitTests/Services/EditorServiceTests.swift
+++ b/ios/Tests/GutenbergKitTests/Services/EditorServiceTests.swift
@@ -57,7 +57,8 @@ struct EditorServiceTests: MakesTestFixtures {
 
   @Test("prepare does not fetch post when postID is negative")
   func prepareDoesNotFetchPostWhenPostIDIsNegative() async throws {
-    let mockClient = EditorServiceURLTrackingMockHTTPClient()
+    let mockClient = EditorAssetLibraryMockHTTPClient()
+    mockClient.urlResponseHandler = Self.editorServiceResponseHandler
     let configuration = makeConfiguration(postID: -1)
     let service = EditorService(
       configuration: configuration,
@@ -75,7 +76,8 @@ struct EditorServiceTests: MakesTestFixtures {
 
   @Test("prepare does not fetch post when postID is zero")
   func prepareDoesNotFetchPostWhenPostIDIsZero() async throws {
-    let mockClient = EditorServiceURLTrackingMockHTTPClient()
+    let mockClient = EditorAssetLibraryMockHTTPClient()
+    mockClient.urlResponseHandler = Self.editorServiceResponseHandler
     let configuration = makeConfiguration(postID: 0)
     let service = EditorService(
       configuration: configuration,
@@ -93,7 +95,8 @@ struct EditorServiceTests: MakesTestFixtures {
 
   @Test("prepare fetches post when postID is positive")
   func prepareFetchesPostWhenPostIDIsPositive() async throws {
-    let mockClient = EditorServiceURLTrackingMockHTTPClient()
+    let mockClient = EditorAssetLibraryMockHTTPClient()
+    mockClient.urlResponseHandler = Self.editorServiceResponseHandler
     let configuration = makeConfiguration(postID: 123)
     let service = EditorService(
       configuration: configuration,
@@ -108,68 +111,29 @@ struct EditorServiceTests: MakesTestFixtures {
     let postRequests = mockClient.requestedURLs.filter { $0.absoluteString.contains("/posts/123") }
     #expect(!postRequests.isEmpty, "Should request /posts/123 for positive post IDs")
   }
-}
 
-// MARK: - Mock HTTP Client for URL Tracking
+  // MARK: - Test Helpers
 
-final class EditorServiceURLTrackingMockHTTPClient: EditorHTTPClientProtocol, @unchecked Sendable {
-  private let lock = NSLock()
-  private var _requestedURLs: [URL] = []
-
-  var requestedURLs: [URL] {
-    lock.withLock { _requestedURLs }
-  }
-
-  func perform(_ urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse) {
-    let url = urlRequest.url!
-    lock.withLock { _requestedURLs.append(url) }
-
-    let responseData: Data
+  /// URL-based response handler for EditorService.prepare() tests.
+  private static func editorServiceResponseHandler(_ url: URL) -> Data {
     let urlString = url.absoluteString
 
-    // Return appropriate mock responses based on URL
     if urlString.contains("editor-assets") {
-      responseData = Data(#"{"scripts":"","styles":"","allowed_block_types":[]}"#.utf8)
+      return Data(#"{"scripts":"","styles":"","allowed_block_types":[]}"#.utf8)
     } else if urlString.contains("wp-block-editor/v1/settings") {
-      responseData = Data(#"{"styles":[]}"#.utf8)
+      return Data(#"{"styles":[]}"#.utf8)
     } else if urlString.contains("/wp/v2/types/") && urlString.contains("context=edit") {
-      responseData = Data(#"{"name":"Posts","slug":"post"}"#.utf8)
+      return Data(#"{"name":"Posts","slug":"post"}"#.utf8)
     } else if urlString.contains("/wp/v2/types") {
-      responseData = Data(#"{"post":{"name":"Posts","slug":"post"}}"#.utf8)
+      return Data(#"{"post":{"name":"Posts","slug":"post"}}"#.utf8)
     } else if urlString.contains("/wp/v2/themes") {
-      responseData = Data(#"[{"name":"Twenty Twenty-Four"}]"#.utf8)
+      return Data(#"[{"name":"Twenty Twenty-Four"}]"#.utf8)
     } else if urlString.contains("/wp/v2/settings") {
-      responseData = Data(#"{"title":"Test Site"}"#.utf8)
+      return Data(#"{"title":"Test Site"}"#.utf8)
     } else if urlString.contains("/wp/v2/posts/") {
-      responseData = Data(#"{"id":123,"title":{"rendered":"Test"}}"#.utf8)
+      return Data(#"{"id":123,"title":{"rendered":"Test"}}"#.utf8)
     } else {
-      responseData = Data("{}".utf8)
+      return Data("{}".utf8)
     }
-
-    let response = HTTPURLResponse(
-      url: url,
-      statusCode: 200,
-      httpVersion: "HTTP/1.1",
-      headerFields: nil
-    )!
-
-    return (responseData, response)
-  }
-
-  func download(_ urlRequest: URLRequest) async throws -> (URL, HTTPURLResponse) {
-    let url = urlRequest.url!
-    lock.withLock { _requestedURLs.append(url) }
-
-    let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-    try Data("mock content".utf8).write(to: tempURL)
-
-    let response = HTTPURLResponse(
-      url: url,
-      statusCode: 200,
-      httpVersion: "HTTP/1.1",
-      headerFields: nil
-    )!
-
-    return (tempURL, response)
   }
 }

--- a/ios/Tests/GutenbergKitTests/Services/RESTAPIRepositoryTests.swift
+++ b/ios/Tests/GutenbergKitTests/Services/RESTAPIRepositoryTests.swift
@@ -13,7 +13,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
     @Test("fetchPost returns response for valid post ID")
     func fetchPostReturnsResponse() async throws {
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(#"{"id":123,"title":{"raw":"Test Post"}}"#.utf8)
+        mockClient.urlResponseHandler = { _ in Data(#"{"id":123,"title":{"raw":"Test Post"}}"#.utf8) }
 
         let repository = makeRepository(httpClient: mockClient)
 
@@ -41,8 +41,8 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
     func fetchEditorSettingsParsesResponse() async throws {
         let mockClient = EditorAssetLibraryMockHTTPClient()
         // InternalEditorSettings expects styles array with css and isGlobalStyles
-        mockClient.getResponse = Data(
-            #"{"styles":[{"css":".test{color:red}","isGlobalStyles":false}]}"#.utf8)
+        mockClient.urlResponseHandler = { _ in Data(
+            #"{"styles":[{"css":".test{color:red}","isGlobalStyles":false}]}"#.utf8) }
 
         let repository = makeRepository(httpClient: mockClient)
 
@@ -54,7 +54,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
     @Test("fetchEditorSettings caches response")
     func fetchEditorSettingsCachesResponse() async throws {
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(#"{"styles":[]}"#.utf8)
+        mockClient.urlResponseHandler = { _ in Data(#"{"styles":[]}"#.utf8) }
 
         let configuration = makeConfiguration()
         let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)
@@ -87,7 +87,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
         let mockClient = EditorAssetLibraryMockHTTPClient()
         let rawJSON =
         #"{"styles":[{"css":".theme-style{color:blue}","isGlobalStyles":true},{"css":".another{margin:0}","isGlobalStyles":false}]}"#
-        mockClient.getResponse = Data(rawJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(rawJSON.utf8) }
 
         let configuration = makeConfiguration()
         let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)
@@ -112,7 +112,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
     @Test("fetchPostType returns response")
     func fetchPostTypeReturnsResponse() async throws {
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(#"{"slug":"post","name":"Posts"}"#.utf8)
+        mockClient.urlResponseHandler = { _ in Data(#"{"slug":"post","name":"Posts"}"#.utf8) }
 
         let repository = makeRepository(httpClient: mockClient)
 
@@ -124,7 +124,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
     @Test("fetchPostType caches response")
     func fetchPostTypeCachesResponse() async throws {
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(#"{"slug":"post"}"#.utf8)
+        mockClient.urlResponseHandler = { _ in Data(#"{"slug":"post"}"#.utf8) }
 
         let configuration = makeConfiguration()
         let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)
@@ -144,7 +144,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
     @Test("fetchActiveTheme returns response")
     func fetchActiveThemeReturnsResponse() async throws {
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(#"[{"stylesheet":"twentytwentyfour"}]"#.utf8)
+        mockClient.urlResponseHandler = { _ in Data(#"[{"stylesheet":"twentytwentyfour"}]"#.utf8) }
 
         let repository = makeRepository(httpClient: mockClient)
 
@@ -156,7 +156,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
     @Test("fetchActiveTheme caches response")
     func fetchActiveThemeCachesResponse() async throws {
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(#"[{"stylesheet":"theme"}]"#.utf8)
+        mockClient.urlResponseHandler = { _ in Data(#"[{"stylesheet":"theme"}]"#.utf8) }
 
         let configuration = makeConfiguration()
         let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)
@@ -176,7 +176,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
     @Test("fetchSettingsOptions returns response")
     func fetchSettingsOptionsReturnsResponse() async throws {
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        // OPTIONS doesn't use getResponse, it uses the OPTIONS method
+        // OPTIONS doesn't use urlResponseHandler, it uses the OPTIONS method
 
         let repository = makeRepository(httpClient: mockClient)
 
@@ -191,7 +191,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
     @Test("fetchPostTypes returns response")
     func fetchPostTypesReturnsResponse() async throws {
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(#"{"post":{"slug":"post"},"page":{"slug":"page"}}"#.utf8)
+        mockClient.urlResponseHandler = { _ in Data(#"{"post":{"slug":"post"},"page":{"slug":"page"}}"#.utf8) }
 
         let repository = makeRepository(httpClient: mockClient)
 
@@ -203,7 +203,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
     @Test("fetchPostTypes caches response")
     func fetchPostTypesCachesResponse() async throws {
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(#"{"post":{}}"#.utf8)
+        mockClient.urlResponseHandler = { _ in Data(#"{"post":{}}"#.utf8) }
 
         let configuration = makeConfiguration()
         let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)

--- a/ios/Tests/GutenbergKitTests/Stores/EditorAssetLibraryTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorAssetLibraryTests.swift
@@ -76,7 +76,7 @@ struct EditorAssetLibraryTests {
       """
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -98,7 +98,7 @@ struct EditorAssetLibraryTests {
       """
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -113,7 +113,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-cached-manifest-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .always)
 
@@ -138,7 +138,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-no-cache-fallback-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .always)
 
@@ -163,7 +163,7 @@ struct EditorAssetLibraryTests {
       """
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .always)
 
@@ -213,7 +213,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-single-bundle-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -234,7 +234,7 @@ struct EditorAssetLibraryTests {
 
         // Create first bundle
         let manifest1JSON = uniqueManifestJSON(identifier: "test-multi-bundle-1-\(UUID().uuidString)")
-        mockClient.getResponse = Data(manifest1JSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifest1JSON.utf8) }
 
         let manifest1 = try await library.fetchManifest()
 
@@ -245,7 +245,7 @@ struct EditorAssetLibraryTests {
 
         // Create second bundle
         let manifest2JSON = uniqueManifestJSON(identifier: "test-multi-bundle-2-\(UUID().uuidString)")
-        mockClient.getResponse = Data(manifest2JSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifest2JSON.utf8) }
 
         let manifest2 = try await library.fetchManifest()
 
@@ -266,7 +266,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-ignores-files-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let siteCacheRoot = URL.randomTemporaryDirectory
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore, storageRoot: siteCacheRoot)
@@ -297,7 +297,7 @@ struct EditorAssetLibraryTests {
       """
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -326,7 +326,7 @@ struct EditorAssetLibraryTests {
       """
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient)
 
@@ -342,7 +342,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-maxage-within-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         // Set maxAge to 1 hour (3600 seconds)
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .maxAge(3600))
@@ -364,7 +364,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-maxage-expired-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         // Set maxAge to 0 seconds (immediately expired)
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .maxAge(0))
@@ -386,7 +386,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-maxage-delay-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         // Set maxAge to 0.05 seconds (50 milliseconds)
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .maxAge(0.05))
@@ -410,7 +410,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-maxage-transition-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         // Set maxAge to 0.1 seconds (100 milliseconds)
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .maxAge(0.1))
@@ -441,7 +441,7 @@ struct EditorAssetLibraryTests {
         let manifestData = try Data.forResource(named: "editor-asset-manifest-test-case-1")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = manifestData
+        mockClient.urlResponseHandler = { _ in manifestData }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -465,7 +465,7 @@ struct EditorAssetLibraryTests {
         let manifestData = try Data.forResource(named: "editor-asset-manifest-test-case-1")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = manifestData
+        mockClient.urlResponseHandler = { _ in manifestData }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -482,7 +482,7 @@ struct EditorAssetLibraryTests {
         let manifestData = try Data.forResource(named: "editor-asset-manifest-test-case-1")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = manifestData
+        mockClient.urlResponseHandler = { _ in manifestData }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -499,7 +499,7 @@ struct EditorAssetLibraryTests {
         let manifestData = try Data.forResource(named: "editor-asset-manifest-test-case-1")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = manifestData
+        mockClient.urlResponseHandler = { _ in manifestData }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -535,7 +535,7 @@ struct EditorAssetLibraryTests {
         let manifestData = try Data.forResource(named: "editor-asset-manifest-test-case-1")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = manifestData
+        mockClient.urlResponseHandler = { _ in manifestData }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -565,7 +565,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-empty-bundle-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -585,7 +585,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-creates-dir-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -603,7 +603,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-saves-manifest-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -625,7 +625,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-discoverable-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -650,7 +650,7 @@ struct EditorAssetLibraryTests {
       """
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -676,7 +676,7 @@ struct EditorAssetLibraryTests {
       """
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -713,7 +713,7 @@ struct EditorAssetLibraryTests {
       """
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -748,7 +748,7 @@ struct EditorAssetLibraryTests {
         let manifestJSON = uniqueManifestJSON(identifier: "test-download-bundle-\(UUID().uuidString)")
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient)
 
@@ -769,7 +769,7 @@ struct EditorAssetLibraryTests {
       """
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient, cachePolicy: .ignore)
 
@@ -804,7 +804,7 @@ struct EditorAssetLibraryTests {
       """
 
         let mockClient = EditorAssetLibraryMockHTTPClient()
-        mockClient.getResponse = Data(manifestJSON.utf8)
+        mockClient.urlResponseHandler = { _ in Data(manifestJSON.utf8) }
 
         let library = makeLibrary(httpClient: mockClient)
 
@@ -841,7 +841,6 @@ final class ProgressTracker: @unchecked Sendable {
 
 final class EditorAssetLibraryMockHTTPClient: EditorHTTPClientProtocol, @unchecked Sendable {
 
-    var getResponse: Data = Data()
     var getCallCount = 0
     var downloadCallCount = 0
     var downloadedURLs: [URL] = []
@@ -855,9 +854,8 @@ final class EditorAssetLibraryMockHTTPClient: EditorHTTPClientProtocol, @uncheck
         lock.withLock { _requestedURLs }
     }
 
-    /// Optional handler for URL-based response routing. If set, this is called to generate
-    /// the response data based on the request URL. If nil, falls back to `getResponse`.
-    var urlResponseHandler: ((URL) -> Data)?
+    /// Handler for generating response data based on request URL. Defaults to returning empty data.
+    var urlResponseHandler: ((URL) -> Data) = { _ in Data() }
 
     func perform(_ urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let url = try #require(urlRequest.url)
@@ -871,7 +869,7 @@ final class EditorAssetLibraryMockHTTPClient: EditorHTTPClientProtocol, @uncheck
             throw error
         }
 
-        let responseData = urlResponseHandler?(url) ?? getResponse
+        let responseData = urlResponseHandler(url)
 
         let response = HTTPURLResponse(
             url: url,

--- a/ios/Tests/GutenbergKitTests/Stores/EditorAssetLibraryTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorAssetLibraryTests.swift
@@ -849,14 +849,30 @@ final class EditorAssetLibraryMockHTTPClient: EditorHTTPClientProtocol, @uncheck
     var shouldThrowError: Error?
     private let lock = NSLock()
 
+    /// URLs requested via `perform(_:)`. Use this to verify which endpoints were called.
+    private var _requestedURLs: [URL] = []
+    var requestedURLs: [URL] {
+        lock.withLock { _requestedURLs }
+    }
+
+    /// Optional handler for URL-based response routing. If set, this is called to generate
+    /// the response data based on the request URL. If nil, falls back to `getResponse`.
+    var urlResponseHandler: ((URL) -> Data)?
+
     func perform(_ urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse) {
-        lock.withLock { getCallCount += 1 }
+        let url = try #require(urlRequest.url)
+
+        lock.withLock {
+            getCallCount += 1
+            _requestedURLs.append(url)
+        }
 
         if let error = shouldThrowError {
             throw error
         }
 
-        let url = try #require(urlRequest.url)
+        let responseData = urlResponseHandler?(url) ?? getResponse
+
         let response = HTTPURLResponse(
             url: url,
             statusCode: 200,
@@ -864,7 +880,7 @@ final class EditorAssetLibraryMockHTTPClient: EditorHTTPClientProtocol, @uncheck
             headerFields: nil
         )!
 
-        return (getResponse, response)
+        return (responseData, response)
     }
 
     func download(_ urlRequest: URLRequest) async throws -> (URL, HTTPURLResponse) {


### PR DESCRIPTION
## What?
Skips preloading post data when the post ID is non-positive (e.g., -1 or 0), which are sentinel values used by host apps for unsaved drafts.

## Why?
Fix CMM-1175.

WordPress-iOS uses `-1` as a sentinel value for new/unsaved draft post IDs. When the user refreshes My Site (pull-to-refresh), the editor's preload cache is invalidated. On the next editor open for a new post, GutenbergKit attempted to fetch `/posts/-1` from the API, which returned a 404 error and caused the editor to fail loading.

The preloading logic only checked for `null`/`nil` post IDs, not for non-positive values like `-1`.

## How?
Added an additional guard in `preparePreloadList()` on both iOS and Android to check that `postID > 0` before attempting to fetch post data:

**iOS** (`EditorService.swift:194`):
```swift
// Before:
if let postID = self.configuration.postID {

// After:
if let postID = self.configuration.postID, postID > 0 {
```

**Android** (`EditorService.kt:292`):
```kotlin
// Before:
if (postId != null) {

// After:
if (postId != null && postId > 0) {
```

Also changed the iOS `EditorService.init` to accept `(any EditorHTTPClientProtocol)?` instead of `EditorHTTPClient?` to enable dependency injection for testing.

## Testing Instructions
1. Open WordPress iOS app
2. Navigate to My Site
3. Pull-to-refresh on the My Site screen (this invalidates the editor cache)
4. Tap to create a new post
5. Verify the editor loads successfully without showing an error

### Unit Tests
New tests added for both platforms:
- `prepare does not fetch post when postID is negative` - verifies no request to `/posts/-1`
- `prepare does not fetch post when postID is zero` - verifies no request to `/posts/0`  
- `prepare fetches post when postID is positive` - verifies normal behavior for valid post IDs

Run tests:
```bash
# iOS
swift test --filter "EditorServiceTests"

# Android
./gradlew :Gutenberg:testDebugUnitTest --tests "org.wordpress.gutenberg.services.EditorServiceTest"
```

## Screenshots or screencast
N/A - Bug fix with no visual changes