### PR TITLE
fix: Ensure EditorAssetBundleProvider always replies to JavaScript

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/Services/EditorAssetBundleProvider.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/EditorAssetBundleProvider.swift
@@ -82,6 +82,7 @@ extension EditorAssetBundleProvider: WKScriptMessageHandlerWithReply {
                 replyHandler(reply, nil)
             } catch {
                 Logger.assetLibrary.error("📚 Failed to fetch asset manifest: \(error.localizedDescription)")
+                replyHandler(nil, error.localizedDescription)
             }
         }
     }


### PR DESCRIPTION
## What?

Ensures that `EditorAssetBundleProvider` always calls the `replyHandler` when handling JavaScript message requests, even when an error occurs.

## Why?

When `getEditorRepresentation()` throws an error, the `replyHandler` was not being called. This would leave JavaScript waiting indefinitely for a response that never comes, potentially causing the editor to hang or behave unexpectedly.

## How?

Added the missing `replyHandler(nil, error.localizedDescription)` call in the catch block of `userContentController(_:didReceive:replyHandler:)`.

## Testing Instructions

No specific reproduction steps are known. This fix was identified during code review.

### Accessibility Testing Instructions

N/A - This is an internal fix with no UI changes.

## Screenshots or screencast

N/A