### PR TITLE
test: Fix test failures and reduce noise

### DIFF
--- a/ios/Tests/GutenbergKitTests/Model/EditorAssetBundleTests.swift
+++ b/ios/Tests/GutenbergKitTests/Model/EditorAssetBundleTests.swift
@@ -294,6 +294,7 @@ struct EditorAssetBundleTests {
         #expect(result.path.contains("plugins/script.js"))
     }
 
+    #if os(macOS)
     @Test("assetDataPath crashes for path traversal attempt")
     func assetDataPathCrashesForPathTraversal() async {
         await #expect(processExitsWith: .failure) {
@@ -306,6 +307,7 @@ struct EditorAssetBundleTests {
             _ = bundle.assetDataPath(for: url)
         }
     }
+    #endif
 
     // MARK: - assetData Tests
 

--- a/src/utils/bridge.test.js
+++ b/src/utils/bridge.test.js
@@ -8,6 +8,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
  */
 import { requestLatestContent, getPost } from './bridge';
 
+vi.mock( './logger.js', () => ( {
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+	debug: vi.fn(),
+} ) );
+
 describe( 'requestLatestContent', () => {
 	let originalWindow;
 


### PR DESCRIPTION
## What?
Fix test failures when running `make test-swift-package` and reduce stderr noise in JavaScript tests.

## Why?
- The `processExitsWith` Swift Testing API is only available on macOS, not iOS Simulator. This caused `make test-swift-package` to fail locally even though CI (which uses `swift test` on macOS) passes.
- JavaScript tests for error handling paths were logging expected errors to stderr, creating noisy test output.

## How?
- Wrap the `assetDataPathCrashesForPathTraversal` exit test in `#if os(macOS)` so it only compiles/runs on macOS
- Mock the logger in `bridge.test.js` to silence expected error output during tests (consistent with other test files in the project)

## Testing Instructions
1. Run `make test-swift-package` — should pass without exit test errors
2. Run `make test-js` — should pass without stderr noise

### Accessibility Testing Instructions
N/A — no UI changes.

## Screenshots or screencast
N/A