### PR TITLE
docs: Add PR guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,3 +212,14 @@ make lint-js
 ```
 
 These commands ensure code quality and prevent lint errors from blocking commits.
+
+### Pull Request Guidelines
+
+When creating pull requests, always use the project's PR template (`.github/PULL_REQUEST_TEMPLATE.md`). The template includes:
+
+-   **What?**: Brief description of what the PR does
+-   **Why?**: Why the change is necessary, referencing any issues
+-   **How?**: Implementation details
+-   **Testing Instructions**: Step-by-step instructions to test the PR
+-   **Accessibility Testing Instructions**: Required for UI changes
+-   **Screenshots or screencast**: If applicable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,3 +223,5 @@ When creating pull requests, always use the project's PR template (`.github/PULL
 -   **Testing Instructions**: Step-by-step instructions to test the PR
 -   **Accessibility Testing Instructions**: Required for UI changes
 -   **Screenshots or screencast**: If applicable
+
+**Labels**: Always assign an appropriate label when creating PRs. Use `gh label list` to retrieve available labels and select the most relevant one for the PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,13 +215,7 @@ These commands ensure code quality and prevent lint errors from blocking commits
 
 ### Pull Request Guidelines
 
-When creating pull requests, always use the project's PR template (`.github/PULL_REQUEST_TEMPLATE.md`). The template includes:
+When creating pull requests:
 
--   **What?**: Brief description of what the PR does
--   **Why?**: Why the change is necessary, referencing any issues
--   **How?**: Implementation details
--   **Testing Instructions**: Step-by-step instructions to test the PR
--   **Accessibility Testing Instructions**: Required for UI changes
--   **Screenshots or screencast**: If applicable
-
-**Labels**: Always assign an appropriate label when creating PRs. Use `gh label list` to retrieve available labels and select the most relevant one for the PR.
+1. **Use the PR template**: Read `.github/PULL_REQUEST_TEMPLATE.md` to get the current template structure and follow it when writing the PR body.
+2. **Assign a label**: Use `gh label list` to retrieve available labels and select the most relevant one for the PR.


### PR DESCRIPTION
## What?
Add pull request guidelines to CLAUDE.md to ensure Claude Code follows the project's PR conventions.

## Why?
Claude Code was creating PRs without following the project's PR template or assigning labels. This adds instructions to ensure consistent PR creation.

## How?
Added a "Pull Request Guidelines" section to CLAUDE.md that instructs Claude to:
1. Read and follow the PR template from `.github/PULL_REQUEST_TEMPLATE.md`
2. Use `gh label list` to retrieve and assign appropriate labels

## Testing Instructions
1. Review the CLAUDE.md changes
2. Verify the guidelines are clear and actionable

### Accessibility Testing Instructions
N/A — documentation only.

## Screenshots or screencast
N/A