### PR TITLE
fix: Address Swift compiler warnings

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -174,9 +174,6 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         // This allows JavaScript to request the latest persisted content from the native host.
         config.userContentController.addScriptMessageHandler(controller, contentWorld: .page, name: "requestLatestContent")
 
-        // This is important so they user can't select anything but text across blocks.
-        config.selectionGranularity = .character
-
         self.bundleProvider.bind(to: config)
 
         config.applicationNameForUserAgent = "GutenbergKit/\(GutenbergKitVersion.version)"

--- a/ios/Tests/GutenbergKitTests/Stores/EditorAssetLibraryTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorAssetLibraryTests.swift
@@ -59,7 +59,7 @@ struct EditorAssetLibraryTests {
     func existingBundleReturnsNilForMissingChecksum() async throws {
         let library = makeLibrary()
 
-        let result = try await library.existingBundle(forManifestChecksum: "nonexistent-checksum-12345")
+        let result = await library.existingBundle(forManifestChecksum: "nonexistent-checksum-12345")
         #expect(result == nil)
     }
 


### PR DESCRIPTION
## What?
Fixes two Swift compiler warnings that appear when building the Swift package.

## Why?
These warnings add noise to the build output and indicate code that could be cleaned up:
1. An unnecessary `try` keyword on a non-throwing actor method
2. Use of a deprecated iOS API that has no effect

## How?
- Removed the unnecessary `try` from the `existingBundle(forManifestChecksum:)` call in tests (the method doesn't throw, but `await` is still required since it's an actor)
- Removed the deprecated `selectionGranularity` property assignment, which has been ignored since iOS 11.0

## Testing Instructions
1. Run `make test-swift-package`
2. Verify no warnings appear for `EditorAssetLibraryTests.swift` or `EditorViewController.swift`
3. Verify all tests pass

### Accessibility Testing Instructions
N/A - no UI changes.

## Screenshots or screencast
N/A