### PR TITLE
fix: Open external URLs in system browser on iOS

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorLogging.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorLogging.swift
@@ -19,6 +19,9 @@ extension Logger {
     
     /// Logs editor HTTP activity
     public static let http = Logger(subsystem: "GutenbergKit", category: "http")
+
+    /// Logs editor navigation activity
+    public static let navigation = Logger(subsystem: "GutenbergKit", category: "navigation")
 }
 
 public struct SignpostMonitor: Sendable {

--- a/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WebKit
 
 /// Determines how URLs should be handled during WebView navigation.
 ///
@@ -19,23 +20,60 @@ struct EditorNavigationPolicy {
         self.devServerURL = devServerURL
     }
 
-    /// Evaluates whether a URL should be allowed to load within the WebView.
+    /// Evaluates whether a navigation action should be allowed within the WebView.
     ///
-    /// - Parameter url: The URL being navigated to.
-    /// - Returns: `true` if the URL should load in the WebView, `false` if it should
-    ///   be opened in the system browser.
-    func shouldAllowNavigation(to url: URL) -> Bool {
+    /// - Parameter navigationAction: The navigation action to evaluate.
+    /// - Returns: `true` if the navigation should proceed in the WebView, `false` if it
+    ///   should be opened in the system browser.
+    @MainActor
+    func shouldAllowNavigation(for navigationAction: WKNavigationAction) -> Bool {
+        guard let url = navigationAction.request.url else {
+            return true
+        }
+
         // Allow local editor resources and custom URL schemes
-        if let scheme = url.scheme, Self.allowedSchemes.contains(scheme) {
+        if isAllowedScheme(url) {
             return true
         }
 
         // Allow navigation to dev server URL if configured
-        if let devServerURL, url.host == devServerURL.host {
+        if isDevServerURL(url) {
             return true
         }
 
-        // All other URLs (http/https) should open externally
-        return false
+        // Allow subframe navigation (iframes, video embeds, etc.)
+        // Only block main frame navigation to external URLs
+        if navigationAction.targetFrame?.isMainFrame == false {
+            return true
+        }
+
+        // Block user-initiated link clicks - open in system browser
+        if navigationAction.navigationType == .linkActivated {
+            return false
+        }
+
+        // Block JavaScript-initiated main frame navigation to external URLs.
+        // This catches upsell buttons that use window.top.location.href.
+        // Navigation type .other with a main frame target indicates programmatic navigation.
+        if navigationAction.navigationType == .other && navigationAction.targetFrame?.isMainFrame == true {
+            return false
+        }
+
+        // Allow other navigation types (reload, back/forward, form submission within editor)
+        return true
+    }
+
+    // MARK: - Internal helpers (exposed for testing)
+
+    /// Returns `true` if the URL uses an allowed scheme.
+    func isAllowedScheme(_ url: URL) -> Bool {
+        guard let scheme = url.scheme else { return false }
+        return Self.allowedSchemes.contains(scheme)
+    }
+
+    /// Returns `true` if the URL matches the configured dev server host.
+    func isDevServerURL(_ url: URL) -> Bool {
+        guard let devServerURL else { return false }
+        return url.host == devServerURL.host
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
@@ -11,7 +11,7 @@ struct EditorNavigationPolicy {
     /// - `file`: Local bundled editor resources
     /// - `gbk-cache-https`: Cached remote assets served via custom scheme handler
     /// - `gbk-media-file`: Local media files from the device's photo library
-    static let allowedSchemes: Set<String> = ["file", "gbk-cache-https", "gbk-media-file"]
+    private static let allowedSchemes: Set<String> = ["file", "gbk-cache-https", "gbk-media-file"]
 
     /// Optional development server URL. Navigation to this host is always allowed.
     let devServerURL: URL?

--- a/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
@@ -45,7 +45,7 @@ struct EditorNavigationPolicy {
     /// - Returns: `true` if the navigation should proceed in the WebView, `false` if it should open externally.
     func shouldAllowNavigation(url: URL?, navigationType: WKNavigationType, isMainFrame: Bool?) -> Bool {
         guard let url else {
-            return true
+            return false
         }
 
         // Allow local editor resources and custom URL schemes

--- a/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Determines how URLs should be handled during WebView navigation.
+///
+/// This policy controls whether navigation requests should be allowed within the WebView
+/// or redirected to the system browser. It's used to ensure external URLs (like upgrade
+/// flows and help links) open in Safari while editor resources load normally.
+struct EditorNavigationPolicy {
+    /// URL schemes that are always allowed to load within the WebView.
+    /// - `file`: Local bundled editor resources
+    /// - `gbk-cache-https`: Cached remote assets served via custom scheme handler
+    /// - `gbk-media-file`: Local media files from the device's photo library
+    static let allowedSchemes: Set<String> = ["file", "gbk-cache-https", "gbk-media-file"]
+
+    /// Optional development server URL. Navigation to this host is always allowed.
+    let devServerURL: URL?
+
+    init(devServerURL: URL? = nil) {
+        self.devServerURL = devServerURL
+    }
+
+    /// Evaluates whether a URL should be allowed to load within the WebView.
+    ///
+    /// - Parameter url: The URL being navigated to.
+    /// - Returns: `true` if the URL should load in the WebView, `false` if it should
+    ///   be opened in the system browser.
+    func shouldAllowNavigation(to url: URL) -> Bool {
+        // Allow local editor resources and custom URL schemes
+        if let scheme = url.scheme, Self.allowedSchemes.contains(scheme) {
+            return true
+        }
+
+        // Allow navigation to dev server URL if configured
+        if let devServerURL, url.host == devServerURL.host {
+            return true
+        }
+
+        // All other URLs (http/https) should open externally
+        return false
+    }
+}

--- a/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
@@ -59,7 +59,8 @@ struct EditorNavigationPolicy {
         }
 
         // Allow subframe navigation (iframes, video embeds, etc.)
-        // Only block main frame navigation to external URLs
+        // When targetFrame is nil (e.g., target="_blank" or window.open()), treat
+        // as external navigation since it's attempting to open a new window.
         if isMainFrame == false {
             return true
         }

--- a/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
@@ -64,20 +64,16 @@ struct EditorNavigationPolicy {
             return true
         }
 
-        // Block user-initiated link clicks - open in system browser
-        if navigationType == .linkActivated {
-            return false
+        // Allow reload navigation (e.g., pull-to-refresh, manual reload)
+        if navigationType == .reload {
+            return true
         }
 
-        // Block JavaScript-initiated main frame navigation to external URLs.
-        // This catches upsell buttons that use window.top.location.href.
-        // Navigation type .other with a main frame target indicates programmatic navigation.
-        if navigationType == .other && isMainFrame == true {
-            return false
-        }
-
-        // Allow other navigation types (reload, back/forward, form submission within editor)
-        return true
+        // Block all other main frame navigation to external URLs:
+        // - .linkActivated: User tapped a link
+        // - .other: JavaScript navigation (e.g., window.top.location.href for upsell buttons)
+        // - .backForward, .formSubmitted, .formResubmitted: Not expected in the editor
+        return false
     }
 
     // MARK: - Internal helpers (exposed for testing)

--- a/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorNavigationPolicy.swift
@@ -27,7 +27,24 @@ struct EditorNavigationPolicy {
     ///   should be opened in the system browser.
     @MainActor
     func shouldAllowNavigation(for navigationAction: WKNavigationAction) -> Bool {
-        guard let url = navigationAction.request.url else {
+        shouldAllowNavigation(
+            url: navigationAction.request.url,
+            navigationType: navigationAction.navigationType,
+            isMainFrame: navigationAction.targetFrame?.isMainFrame
+        )
+    }
+
+    /// Evaluates whether a navigation should be allowed based on its properties.
+    ///
+    /// This method extracts the decision logic from WKNavigationAction to enable unit testing.
+    ///
+    /// - Parameters:
+    ///   - url: The URL being navigated to.
+    ///   - navigationType: The type of navigation (link click, JavaScript, etc.).
+    ///   - isMainFrame: Whether the navigation targets the main frame (`true`), a subframe (`false`), or unknown (`nil`).
+    /// - Returns: `true` if the navigation should proceed in the WebView, `false` if it should open externally.
+    func shouldAllowNavigation(url: URL?, navigationType: WKNavigationType, isMainFrame: Bool?) -> Bool {
+        guard let url else {
             return true
         }
 
@@ -43,19 +60,19 @@ struct EditorNavigationPolicy {
 
         // Allow subframe navigation (iframes, video embeds, etc.)
         // Only block main frame navigation to external URLs
-        if navigationAction.targetFrame?.isMainFrame == false {
+        if isMainFrame == false {
             return true
         }
 
         // Block user-initiated link clicks - open in system browser
-        if navigationAction.navigationType == .linkActivated {
+        if navigationType == .linkActivated {
             return false
         }
 
         // Block JavaScript-initiated main frame navigation to external URLs.
         // This catches upsell buttons that use window.top.location.href.
         // Navigation type .other with a main frame target indicates programmatic navigation.
-        if navigationAction.navigationType == .other && navigationAction.targetFrame?.isMainFrame == true {
+        if navigationType == .other && isMainFrame == true {
             return false
         }
 

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -798,6 +798,7 @@ private final class GutenbergEditorController: NSObject, WKNavigationDelegate, W
 
         // External main frame navigation should open in the system browser.
         if let url = navigationAction.request.url {
+            Logger.navigation.debug("Opening external URL in system browser: \(url.absoluteString)")
             await UIApplication.shared.open(url)
         }
         return .cancel

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -795,13 +795,22 @@ private final class GutenbergEditorController: NSObject, WKNavigationDelegate, W
             return .allow
         }
 
-        if navigationAction.navigationType == .linkActivated {
-            // Open the request in OS browser
-            await UIApplication.shared.open(url)
-            return .cancel
+        // Allow local editor resources and custom URL schemes
+        let allowedSchemes = ["file", "gbk-cache-https", "gbk-media-file"]
+        if allowedSchemes.contains(url.scheme ?? "") {
+            return .allow
         }
 
-        return .allow
+        // Allow navigation to dev server URL if configured
+        if let editorURL, url.host == editorURL.host {
+            return .allow
+        }
+
+        // Any other navigation (http/https URLs) should open in the system browser.
+        // This catches both user-initiated link clicks (.linkActivated) and JavaScript-based
+        // navigation (.other) such as upsell buttons that use window.top.location.href.
+        await UIApplication.shared.open(url)
+        return .cancel
     }
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -792,18 +792,14 @@ private final class GutenbergEditorController: NSObject, WKNavigationDelegate, W
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {
-        guard let url = navigationAction.request.url else {
+        if navigationPolicy.shouldAllowNavigation(for: navigationAction) {
             return .allow
         }
 
-        if navigationPolicy.shouldAllowNavigation(to: url) {
-            return .allow
+        // External main frame navigation should open in the system browser.
+        if let url = navigationAction.request.url {
+            await UIApplication.shared.open(url)
         }
-
-        // External URLs should open in the system browser.
-        // This catches both user-initiated link clicks (.linkActivated) and JavaScript-based
-        // navigation (.other) such as upsell buttons that use window.top.location.href.
-        await UIApplication.shared.open(url)
         return .cancel
     }
 

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -747,11 +747,12 @@ private protocol GutenbergEditorControllerDelegate: AnyObject {
 private final class GutenbergEditorController: NSObject, WKNavigationDelegate, WKScriptMessageHandler, WKScriptMessageHandlerWithReply {
     weak var delegate: GutenbergEditorControllerDelegate?
     let configuration: EditorConfiguration
-    private let editorURL: URL?
+    private let navigationPolicy: EditorNavigationPolicy
 
     init(configuration: EditorConfiguration) {
         self.configuration = configuration
-        self.editorURL = ProcessInfo.processInfo.environment["GUTENBERG_EDITOR_URL"].flatMap(URL.init)
+        let devServerURL = ProcessInfo.processInfo.environment["GUTENBERG_EDITOR_URL"].flatMap(URL.init)
+        self.navigationPolicy = EditorNavigationPolicy(devServerURL: devServerURL)
         super.init()
     }
 
@@ -795,18 +796,11 @@ private final class GutenbergEditorController: NSObject, WKNavigationDelegate, W
             return .allow
         }
 
-        // Allow local editor resources and custom URL schemes
-        let allowedSchemes = ["file", "gbk-cache-https", "gbk-media-file"]
-        if allowedSchemes.contains(url.scheme ?? "") {
+        if navigationPolicy.shouldAllowNavigation(to: url) {
             return .allow
         }
 
-        // Allow navigation to dev server URL if configured
-        if let editorURL, url.host == editorURL.host {
-            return .allow
-        }
-
-        // Any other navigation (http/https URLs) should open in the system browser.
+        // External URLs should open in the system browser.
         // This catches both user-initiated link clicks (.linkActivated) and JavaScript-based
         // navigation (.other) such as upsell buttons that use window.top.location.href.
         await UIApplication.shared.open(url)

--- a/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
+++ b/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
@@ -130,18 +130,26 @@ struct EditorNavigationPolicyTests {
         #expect(!policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true))
     }
 
-    // MARK: - Navigation Policy: Other Navigation Types (Should Allow)
+    // MARK: - Navigation Policy: Other Navigation Types
 
-    @Test("allows reload, back/forward, and form navigation types")
-    func allowsOtherNavigationTypes() {
+    @Test("allows reload navigation")
+    func allowsReloadNavigation() {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "https://example.com/editor")!
 
-        let allowedTypes: [WKNavigationType] = [.reload, .backForward, .formSubmitted, .formResubmitted]
-        for navigationType in allowedTypes {
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .reload, isMainFrame: true))
+    }
+
+    @Test("blocks back/forward and form navigation types")
+    func blocksOtherNavigationTypes() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://example.com/page")!
+
+        let blockedTypes: [WKNavigationType] = [.backForward, .formSubmitted, .formResubmitted]
+        for navigationType in blockedTypes {
             #expect(
-                policy.shouldAllowNavigation(url: url, navigationType: navigationType, isMainFrame: true),
-                "Should allow navigation type: \(navigationType)"
+                !policy.shouldAllowNavigation(url: url, navigationType: navigationType, isMainFrame: true),
+                "Should block navigation type: \(navigationType)"
             )
         }
     }
@@ -155,13 +163,13 @@ struct EditorNavigationPolicyTests {
         #expect(policy.shouldAllowNavigation(url: nil, navigationType: .other, isMainFrame: true))
     }
 
-    @Test("handles nil isMainFrame: allows .other, blocks .linkActivated")
-    func handlesNilMainFrame() {
+    @Test("blocks external navigation when isMainFrame is nil")
+    func blocksExternalNavigationWithNilMainFrame() {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "https://example.com/page")!
 
-        // When targetFrame is nil (unknown), allow .other but block link clicks
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: nil))
+        // When targetFrame is nil (unknown), block external navigation
+        #expect(!policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: nil))
         #expect(!policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: nil))
     }
 

--- a/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
+++ b/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
@@ -182,4 +182,14 @@ struct EditorNavigationPolicyTests {
         #expect(policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true))
         #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true))
     }
+
+    @Test("blocks protocol-relative URLs in main frame")
+    func blocksProtocolRelativeUrls() {
+        let policy = EditorNavigationPolicy()
+        // Protocol-relative URLs have a nil scheme, which should not be allowed
+        let url = URL(string: "//example.com/path")!
+
+        #expect(!policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true))
+        #expect(!policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true))
+    }
 }

--- a/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
+++ b/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import WebKit
 
 @testable import GutenbergKit
 
@@ -32,7 +33,15 @@ struct EditorNavigationPolicyTests {
         #expect(policy.isAllowedScheme(url))
     }
 
-    // MARK: - External URLs
+    @Test("allowedSchemes contains expected values")
+    func allowedSchemesContainsExpectedValues() {
+        #expect(EditorNavigationPolicy.allowedSchemes.contains("file"))
+        #expect(EditorNavigationPolicy.allowedSchemes.contains("gbk-cache-https"))
+        #expect(EditorNavigationPolicy.allowedSchemes.contains("gbk-media-file"))
+        #expect(EditorNavigationPolicy.allowedSchemes.count == 3)
+    }
+
+    // MARK: - External URL Schemes
 
     @Test("does not allow https:// scheme")
     func doesNotAllowHttpsScheme() {
@@ -50,19 +59,12 @@ struct EditorNavigationPolicyTests {
         #expect(!policy.isAllowedScheme(url))
     }
 
-    @Test("does not allow WordPress.com upgrade URLs by scheme")
-    func doesNotAllowUpgradeUrlSchemes() {
+    @Test("does not allow URLs with nil scheme")
+    func doesNotAllowNilScheme() {
         let policy = EditorNavigationPolicy()
-        let upgradeUrls = [
-            "https://wordpress.com/checkout/example.wordpress.com/premium",
-            "https://wordpress.com/plans/example.wordpress.com",
-            "https://wordpress.com/checkout/example.wordpress.com/videopress"
-        ]
+        let url = URL(string: "//example.com/path")!
 
-        for urlString in upgradeUrls {
-            let url = URL(string: urlString)!
-            #expect(!policy.isAllowedScheme(url), "Should not allow scheme for: \(urlString)")
-        }
+        #expect(!policy.isAllowedScheme(url))
     }
 
     // MARK: - Dev Server
@@ -105,29 +107,31 @@ struct EditorNavigationPolicyTests {
         #expect(!policy.isDevServerURL(url))
     }
 
-    // MARK: - Edge Cases
+    // MARK: - Navigation Policy: Allowed Schemes Always Pass
 
-    @Test("does not allow URLs with nil scheme")
-    func doesNotAllowNilScheme() {
+    @Test("allows file:// URLs regardless of navigation type")
+    func allowsFileUrlsRegardlessOfNavigationType() {
         let policy = EditorNavigationPolicy()
-        // URL without scheme
-        let url = URL(string: "//example.com/path")!
+        let url = URL(string: "file:///path/to/editor.html")!
 
-        #expect(!policy.isAllowedScheme(url))
+        // Should allow even for link clicks or JS navigation
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true))
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true))
     }
 
-    @Test("allowedSchemes contains expected values")
-    func allowedSchemesContainsExpectedValues() {
-        #expect(EditorNavigationPolicy.allowedSchemes.contains("file"))
-        #expect(EditorNavigationPolicy.allowedSchemes.contains("gbk-cache-https"))
-        #expect(EditorNavigationPolicy.allowedSchemes.contains("gbk-media-file"))
-        #expect(EditorNavigationPolicy.allowedSchemes.count == 3)
+    @Test("allows gbk-cache-https:// URLs regardless of navigation type")
+    func allowsCacheUrlsRegardlessOfNavigationType() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "gbk-cache-https://example.com/asset.js")!
+
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true))
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true))
     }
 
-    // MARK: - Video/Media URL Schemes
+    // MARK: - Navigation Policy: Subframe Navigation (Video/Embed Support)
 
-    @Test("does not treat video URLs as allowed scheme")
-    func doesNotAllowVideoUrlScheme() {
+    @Test("allows subframe navigation to video URLs")
+    func allowsSubframeVideoNavigation() {
         let policy = EditorNavigationPolicy()
         let videoUrls = [
             "https://videos.files.wordpress.com/abc123/video.mp4",
@@ -137,9 +141,162 @@ struct EditorNavigationPolicyTests {
 
         for urlString in videoUrls {
             let url = URL(string: urlString)!
-            // Video URLs use https, which is not in allowedSchemes
-            // They should be allowed via subframe navigation, not scheme
-            #expect(!policy.isAllowedScheme(url), "Video URL should not match allowed scheme: \(urlString)")
+            // Subframe navigation (isMainFrame = false) should be allowed
+            #expect(
+                policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: false),
+                "Should allow subframe navigation to: \(urlString)"
+            )
         }
+    }
+
+    @Test("allows subframe navigation to YouTube embeds")
+    func allowsSubframeYouTubeNavigation() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://www.youtube.com/embed/dQw4w9WgXcQ")!
+
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: false))
+    }
+
+    @Test("allows subframe navigation to Twitter embeds")
+    func allowsSubframeTwitterNavigation() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://platform.twitter.com/embed/Tweet.html")!
+
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: false))
+    }
+
+    @Test("allows subframe navigation to Vimeo embeds")
+    func allowsSubframeVimeoNavigation() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://player.vimeo.com/video/123456")!
+
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: false))
+    }
+
+    // MARK: - Navigation Policy: Link Clicks (Should Open in Browser)
+
+    @Test("blocks link clicks to external URLs")
+    func blocksLinkClicksToExternalUrls() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://example.com/page")!
+
+        #expect(!policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true))
+    }
+
+    @Test("blocks link clicks to WordPress.com checkout URLs")
+    func blocksLinkClicksToCheckout() {
+        let policy = EditorNavigationPolicy()
+        let checkoutUrls = [
+            "https://wordpress.com/checkout/example.wordpress.com/premium",
+            "https://wordpress.com/plans/example.wordpress.com",
+            "https://wordpress.com/checkout/example.wordpress.com/videopress"
+        ]
+
+        for urlString in checkoutUrls {
+            let url = URL(string: urlString)!
+            #expect(
+                !policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true),
+                "Should block link click to: \(urlString)"
+            )
+        }
+    }
+
+    // MARK: - Navigation Policy: JavaScript Navigation (Upsell Buttons)
+
+    @Test("blocks JavaScript main frame navigation to external URLs")
+    func blocksJavaScriptMainFrameNavigation() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://wordpress.com/checkout/example.wordpress.com/videopress")!
+
+        // This simulates window.top.location.href = url (upsell button behavior)
+        #expect(!policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true))
+    }
+
+    @Test("blocks JavaScript navigation to upgrade URLs in main frame")
+    func blocksJavaScriptUpgradeNavigation() {
+        let policy = EditorNavigationPolicy()
+        let upgradeUrls = [
+            "https://wordpress.com/checkout/example.wordpress.com/premium",
+            "https://wordpress.com/plans/example.wordpress.com",
+            "https://wordpress.com/checkout/example.wordpress.com/videopress"
+        ]
+
+        for urlString in upgradeUrls {
+            let url = URL(string: urlString)!
+            #expect(
+                !policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true),
+                "Should block JS navigation to: \(urlString)"
+            )
+        }
+    }
+
+    // MARK: - Navigation Policy: Other Navigation Types (Should Allow)
+
+    @Test("allows reload navigation")
+    func allowsReloadNavigation() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://example.com/editor")!
+
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .reload, isMainFrame: true))
+    }
+
+    @Test("allows back/forward navigation")
+    func allowsBackForwardNavigation() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://example.com/editor")!
+
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .backForward, isMainFrame: true))
+    }
+
+    @Test("allows form submitted navigation")
+    func allowsFormSubmittedNavigation() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://example.com/form-handler")!
+
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .formSubmitted, isMainFrame: true))
+    }
+
+    @Test("allows form resubmitted navigation")
+    func allowsFormResubmittedNavigation() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://example.com/form-handler")!
+
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .formResubmitted, isMainFrame: true))
+    }
+
+    // MARK: - Navigation Policy: Edge Cases
+
+    @Test("allows navigation when URL is nil")
+    func allowsNavigationWithNilUrl() {
+        let policy = EditorNavigationPolicy()
+
+        #expect(policy.shouldAllowNavigation(url: nil, navigationType: .other, isMainFrame: true))
+    }
+
+    @Test("allows navigation when isMainFrame is nil")
+    func allowsNavigationWithNilMainFrame() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://example.com/page")!
+
+        // When targetFrame is nil (unknown), we allow navigation except for linkActivated
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: nil))
+    }
+
+    @Test("blocks link clicks even when isMainFrame is nil")
+    func blocksLinkClicksWithNilMainFrame() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://example.com/page")!
+
+        #expect(!policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: nil))
+    }
+
+    @Test("allows dev server navigation regardless of navigation type")
+    func allowsDevServerRegardlessOfType() {
+        let devServerURL = URL(string: "http://localhost:5173")!
+        let policy = EditorNavigationPolicy(devServerURL: devServerURL)
+        let url = URL(string: "http://localhost:5173/hot-update.js")!
+
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true))
+        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true))
     }
 }

--- a/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
+++ b/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
@@ -156,11 +156,12 @@ struct EditorNavigationPolicyTests {
 
     // MARK: - Navigation Policy: Edge Cases
 
-    @Test("allows navigation when URL is nil")
-    func allowsNavigationWithNilUrl() {
+    @Test("blocks navigation when URL is nil")
+    func blocksNavigationWithNilUrl() {
         let policy = EditorNavigationPolicy()
 
-        #expect(policy.shouldAllowNavigation(url: nil, navigationType: .other, isMainFrame: true))
+        // The editor should only load known content
+        #expect(!policy.shouldAllowNavigation(url: nil, navigationType: .other, isMainFrame: true))
     }
 
     @Test("blocks external navigation when isMainFrame is nil")

--- a/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
+++ b/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+
+@testable import GutenbergKit
+
+@Suite
+struct EditorNavigationPolicyTests {
+
+    // MARK: - Allowed Schemes
+
+    @Test("allows file:// URLs for bundled editor resources")
+    func allowsFileScheme() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "file:///path/to/index.html")!
+
+        #expect(policy.shouldAllowNavigation(to: url))
+    }
+
+    @Test("allows gbk-cache-https:// URLs for cached remote assets")
+    func allowsCacheScheme() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "gbk-cache-https://public-api.wordpress.com/wpcom/v2/editor-assets")!
+
+        #expect(policy.shouldAllowNavigation(to: url))
+    }
+
+    @Test("allows gbk-media-file:// URLs for local media files")
+    func allowsMediaFileScheme() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "gbk-media-file:///Uploads/test-image.jpg")!
+
+        #expect(policy.shouldAllowNavigation(to: url))
+    }
+
+    // MARK: - External URLs
+
+    @Test("blocks https:// URLs and redirects to system browser")
+    func blocksHttpsUrls() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "https://wordpress.com/checkout/example.wordpress.com/premium")!
+
+        #expect(!policy.shouldAllowNavigation(to: url))
+    }
+
+    @Test("blocks http:// URLs and redirects to system browser")
+    func blocksHttpUrls() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "http://example.com/page")!
+
+        #expect(!policy.shouldAllowNavigation(to: url))
+    }
+
+    @Test("blocks WordPress.com upgrade URLs")
+    func blocksUpgradeUrls() {
+        let policy = EditorNavigationPolicy()
+        let upgradeUrls = [
+            "https://wordpress.com/checkout/example.wordpress.com/premium",
+            "https://wordpress.com/plans/example.wordpress.com",
+            "https://wordpress.com/checkout/example.wordpress.com/videopress"
+        ]
+
+        for urlString in upgradeUrls {
+            let url = URL(string: urlString)!
+            #expect(!policy.shouldAllowNavigation(to: url), "Should block: \(urlString)")
+        }
+    }
+
+    // MARK: - Dev Server
+
+    @Test("allows navigation to configured dev server URL")
+    func allowsDevServerUrl() {
+        let devServerURL = URL(string: "http://localhost:5173")!
+        let policy = EditorNavigationPolicy(devServerURL: devServerURL)
+
+        let url = URL(string: "http://localhost:5173/index.html")!
+        #expect(policy.shouldAllowNavigation(to: url))
+    }
+
+    @Test("allows navigation to dev server with different paths")
+    func allowsDevServerPaths() {
+        let devServerURL = URL(string: "http://localhost:5173")!
+        let policy = EditorNavigationPolicy(devServerURL: devServerURL)
+
+        let paths = ["/", "/index.html", "/assets/main.js", "/node_modules/@wordpress/block-editor"]
+        for path in paths {
+            let url = URL(string: "http://localhost:5173\(path)")!
+            #expect(policy.shouldAllowNavigation(to: url), "Should allow dev server path: \(path)")
+        }
+    }
+
+    @Test("blocks other localhost URLs when dev server is not configured")
+    func blocksLocalhostWithoutDevServer() {
+        let policy = EditorNavigationPolicy()
+        let url = URL(string: "http://localhost:5173/index.html")!
+
+        #expect(!policy.shouldAllowNavigation(to: url))
+    }
+
+    @Test("blocks other hosts even when dev server is configured")
+    func blocksOtherHostsWithDevServer() {
+        let devServerURL = URL(string: "http://localhost:5173")!
+        let policy = EditorNavigationPolicy(devServerURL: devServerURL)
+
+        let url = URL(string: "https://wordpress.com/checkout")!
+        #expect(!policy.shouldAllowNavigation(to: url))
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("handles URLs with nil scheme gracefully")
+    func handlesNilScheme() {
+        let policy = EditorNavigationPolicy()
+        // URL without scheme - should not be allowed
+        let url = URL(string: "//example.com/path")!
+
+        #expect(!policy.shouldAllowNavigation(to: url))
+    }
+
+    @Test("allowedSchemes contains expected values")
+    func allowedSchemesContainsExpectedValues() {
+        #expect(EditorNavigationPolicy.allowedSchemes.contains("file"))
+        #expect(EditorNavigationPolicy.allowedSchemes.contains("gbk-cache-https"))
+        #expect(EditorNavigationPolicy.allowedSchemes.contains("gbk-media-file"))
+        #expect(EditorNavigationPolicy.allowedSchemes.count == 3)
+    }
+}

--- a/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
+++ b/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
@@ -13,7 +13,7 @@ struct EditorNavigationPolicyTests {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "file:///path/to/index.html")!
 
-        #expect(policy.shouldAllowNavigation(to: url))
+        #expect(policy.isAllowedScheme(url))
     }
 
     @Test("allows gbk-cache-https:// URLs for cached remote assets")
@@ -21,7 +21,7 @@ struct EditorNavigationPolicyTests {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "gbk-cache-https://public-api.wordpress.com/wpcom/v2/editor-assets")!
 
-        #expect(policy.shouldAllowNavigation(to: url))
+        #expect(policy.isAllowedScheme(url))
     }
 
     @Test("allows gbk-media-file:// URLs for local media files")
@@ -29,29 +29,29 @@ struct EditorNavigationPolicyTests {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "gbk-media-file:///Uploads/test-image.jpg")!
 
-        #expect(policy.shouldAllowNavigation(to: url))
+        #expect(policy.isAllowedScheme(url))
     }
 
     // MARK: - External URLs
 
-    @Test("blocks https:// URLs and redirects to system browser")
-    func blocksHttpsUrls() {
+    @Test("does not allow https:// scheme")
+    func doesNotAllowHttpsScheme() {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "https://wordpress.com/checkout/example.wordpress.com/premium")!
 
-        #expect(!policy.shouldAllowNavigation(to: url))
+        #expect(!policy.isAllowedScheme(url))
     }
 
-    @Test("blocks http:// URLs and redirects to system browser")
-    func blocksHttpUrls() {
+    @Test("does not allow http:// scheme")
+    func doesNotAllowHttpScheme() {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "http://example.com/page")!
 
-        #expect(!policy.shouldAllowNavigation(to: url))
+        #expect(!policy.isAllowedScheme(url))
     }
 
-    @Test("blocks WordPress.com upgrade URLs")
-    func blocksUpgradeUrls() {
+    @Test("does not allow WordPress.com upgrade URLs by scheme")
+    func doesNotAllowUpgradeUrlSchemes() {
         let policy = EditorNavigationPolicy()
         let upgradeUrls = [
             "https://wordpress.com/checkout/example.wordpress.com/premium",
@@ -61,59 +61,59 @@ struct EditorNavigationPolicyTests {
 
         for urlString in upgradeUrls {
             let url = URL(string: urlString)!
-            #expect(!policy.shouldAllowNavigation(to: url), "Should block: \(urlString)")
+            #expect(!policy.isAllowedScheme(url), "Should not allow scheme for: \(urlString)")
         }
     }
 
     // MARK: - Dev Server
 
-    @Test("allows navigation to configured dev server URL")
-    func allowsDevServerUrl() {
+    @Test("recognizes configured dev server URL")
+    func recognizesDevServerUrl() {
         let devServerURL = URL(string: "http://localhost:5173")!
         let policy = EditorNavigationPolicy(devServerURL: devServerURL)
 
         let url = URL(string: "http://localhost:5173/index.html")!
-        #expect(policy.shouldAllowNavigation(to: url))
+        #expect(policy.isDevServerURL(url))
     }
 
-    @Test("allows navigation to dev server with different paths")
-    func allowsDevServerPaths() {
+    @Test("recognizes dev server with different paths")
+    func recognizesDevServerPaths() {
         let devServerURL = URL(string: "http://localhost:5173")!
         let policy = EditorNavigationPolicy(devServerURL: devServerURL)
 
         let paths = ["/", "/index.html", "/assets/main.js", "/node_modules/@wordpress/block-editor"]
         for path in paths {
             let url = URL(string: "http://localhost:5173\(path)")!
-            #expect(policy.shouldAllowNavigation(to: url), "Should allow dev server path: \(path)")
+            #expect(policy.isDevServerURL(url), "Should recognize dev server path: \(path)")
         }
     }
 
-    @Test("blocks other localhost URLs when dev server is not configured")
-    func blocksLocalhostWithoutDevServer() {
+    @Test("does not recognize localhost when dev server is not configured")
+    func doesNotRecognizeLocalhostWithoutDevServer() {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "http://localhost:5173/index.html")!
 
-        #expect(!policy.shouldAllowNavigation(to: url))
+        #expect(!policy.isDevServerURL(url))
     }
 
-    @Test("blocks other hosts even when dev server is configured")
-    func blocksOtherHostsWithDevServer() {
+    @Test("does not recognize other hosts as dev server")
+    func doesNotRecognizeOtherHostsAsDevServer() {
         let devServerURL = URL(string: "http://localhost:5173")!
         let policy = EditorNavigationPolicy(devServerURL: devServerURL)
 
         let url = URL(string: "https://wordpress.com/checkout")!
-        #expect(!policy.shouldAllowNavigation(to: url))
+        #expect(!policy.isDevServerURL(url))
     }
 
     // MARK: - Edge Cases
 
-    @Test("handles URLs with nil scheme gracefully")
-    func handlesNilScheme() {
+    @Test("does not allow URLs with nil scheme")
+    func doesNotAllowNilScheme() {
         let policy = EditorNavigationPolicy()
-        // URL without scheme - should not be allowed
+        // URL without scheme
         let url = URL(string: "//example.com/path")!
 
-        #expect(!policy.shouldAllowNavigation(to: url))
+        #expect(!policy.isAllowedScheme(url))
     }
 
     @Test("allowedSchemes contains expected values")
@@ -122,5 +122,24 @@ struct EditorNavigationPolicyTests {
         #expect(EditorNavigationPolicy.allowedSchemes.contains("gbk-cache-https"))
         #expect(EditorNavigationPolicy.allowedSchemes.contains("gbk-media-file"))
         #expect(EditorNavigationPolicy.allowedSchemes.count == 3)
+    }
+
+    // MARK: - Video/Media URL Schemes
+
+    @Test("does not treat video URLs as allowed scheme")
+    func doesNotAllowVideoUrlScheme() {
+        let policy = EditorNavigationPolicy()
+        let videoUrls = [
+            "https://videos.files.wordpress.com/abc123/video.mp4",
+            "https://v.wordpress.com/abc123",
+            "https://videopress.com/v/abc123"
+        ]
+
+        for urlString in videoUrls {
+            let url = URL(string: urlString)!
+            // Video URLs use https, which is not in allowedSchemes
+            // They should be allowed via subframe navigation, not scheme
+            #expect(!policy.isAllowedScheme(url), "Video URL should not match allowed scheme: \(urlString)")
+        }
     }
 }

--- a/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
+++ b/ios/Tests/GutenbergKitTests/EditorNavigationPolicyTests.swift
@@ -9,77 +9,40 @@ struct EditorNavigationPolicyTests {
 
     // MARK: - Allowed Schemes
 
-    @Test("allows file:// URLs for bundled editor resources")
-    func allowsFileScheme() {
+    @Test("allows internal URL schemes (file, gbk-cache-https, gbk-media-file)")
+    func allowsInternalSchemes() {
         let policy = EditorNavigationPolicy()
-        let url = URL(string: "file:///path/to/index.html")!
+        let allowedUrls = [
+            "file:///path/to/index.html",
+            "gbk-cache-https://public-api.wordpress.com/wpcom/v2/editor-assets",
+            "gbk-media-file:///Uploads/test-image.jpg"
+        ]
 
-        #expect(policy.isAllowedScheme(url))
+        for urlString in allowedUrls {
+            let url = URL(string: urlString)!
+            #expect(policy.isAllowedScheme(url), "Should allow scheme for: \(urlString)")
+        }
     }
 
-    @Test("allows gbk-cache-https:// URLs for cached remote assets")
-    func allowsCacheScheme() {
+    @Test("does not allow external URL schemes (https, http, nil)")
+    func doesNotAllowExternalSchemes() {
         let policy = EditorNavigationPolicy()
-        let url = URL(string: "gbk-cache-https://public-api.wordpress.com/wpcom/v2/editor-assets")!
+        let disallowedUrls = [
+            "https://wordpress.com/checkout/example.wordpress.com/premium",
+            "http://example.com/page",
+            "//example.com/path"
+        ]
 
-        #expect(policy.isAllowedScheme(url))
-    }
-
-    @Test("allows gbk-media-file:// URLs for local media files")
-    func allowsMediaFileScheme() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "gbk-media-file:///Uploads/test-image.jpg")!
-
-        #expect(policy.isAllowedScheme(url))
-    }
-
-    @Test("allowedSchemes contains expected values")
-    func allowedSchemesContainsExpectedValues() {
-        #expect(EditorNavigationPolicy.allowedSchemes.contains("file"))
-        #expect(EditorNavigationPolicy.allowedSchemes.contains("gbk-cache-https"))
-        #expect(EditorNavigationPolicy.allowedSchemes.contains("gbk-media-file"))
-        #expect(EditorNavigationPolicy.allowedSchemes.count == 3)
-    }
-
-    // MARK: - External URL Schemes
-
-    @Test("does not allow https:// scheme")
-    func doesNotAllowHttpsScheme() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "https://wordpress.com/checkout/example.wordpress.com/premium")!
-
-        #expect(!policy.isAllowedScheme(url))
-    }
-
-    @Test("does not allow http:// scheme")
-    func doesNotAllowHttpScheme() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "http://example.com/page")!
-
-        #expect(!policy.isAllowedScheme(url))
-    }
-
-    @Test("does not allow URLs with nil scheme")
-    func doesNotAllowNilScheme() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "//example.com/path")!
-
-        #expect(!policy.isAllowedScheme(url))
+        for urlString in disallowedUrls {
+            let url = URL(string: urlString)!
+            #expect(!policy.isAllowedScheme(url), "Should not allow scheme for: \(urlString)")
+        }
     }
 
     // MARK: - Dev Server
 
-    @Test("recognizes configured dev server URL")
+    @Test("recognizes configured dev server URL with various paths")
     func recognizesDevServerUrl() {
-        let devServerURL = URL(string: "http://localhost:5173")!
-        let policy = EditorNavigationPolicy(devServerURL: devServerURL)
-
-        let url = URL(string: "http://localhost:5173/index.html")!
-        #expect(policy.isDevServerURL(url))
-    }
-
-    @Test("recognizes dev server with different paths")
-    func recognizesDevServerPaths() {
         let devServerURL = URL(string: "http://localhost:5173")!
         let policy = EditorNavigationPolicy(devServerURL: devServerURL)
 
@@ -90,58 +53,57 @@ struct EditorNavigationPolicyTests {
         }
     }
 
-    @Test("does not recognize localhost when dev server is not configured")
-    func doesNotRecognizeLocalhostWithoutDevServer() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "http://localhost:5173/index.html")!
+    @Test("does not recognize dev server when not configured or for other hosts")
+    func doesNotRecognizeDevServerWhenNotConfiguredOrOtherHosts() {
+        // Not configured
+        let policyWithoutDevServer = EditorNavigationPolicy()
+        let localhostUrl = URL(string: "http://localhost:5173/index.html")!
+        #expect(!policyWithoutDevServer.isDevServerURL(localhostUrl))
 
-        #expect(!policy.isDevServerURL(url))
-    }
-
-    @Test("does not recognize other hosts as dev server")
-    func doesNotRecognizeOtherHostsAsDevServer() {
+        // Other hosts
         let devServerURL = URL(string: "http://localhost:5173")!
-        let policy = EditorNavigationPolicy(devServerURL: devServerURL)
-
-        let url = URL(string: "https://wordpress.com/checkout")!
-        #expect(!policy.isDevServerURL(url))
+        let policyWithDevServer = EditorNavigationPolicy(devServerURL: devServerURL)
+        let externalUrl = URL(string: "https://wordpress.com/checkout")!
+        #expect(!policyWithDevServer.isDevServerURL(externalUrl))
     }
 
     // MARK: - Navigation Policy: Allowed Schemes Always Pass
 
-    @Test("allows file:// URLs regardless of navigation type")
-    func allowsFileUrlsRegardlessOfNavigationType() {
+    @Test("allows internal scheme URLs regardless of navigation type")
+    func allowsInternalSchemeUrlsRegardlessOfNavigationType() {
         let policy = EditorNavigationPolicy()
-        let url = URL(string: "file:///path/to/editor.html")!
+        let urls = [
+            "file:///path/to/editor.html",
+            "gbk-cache-https://example.com/asset.js"
+        ]
 
-        // Should allow even for link clicks or JS navigation
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true))
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true))
-    }
-
-    @Test("allows gbk-cache-https:// URLs regardless of navigation type")
-    func allowsCacheUrlsRegardlessOfNavigationType() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "gbk-cache-https://example.com/asset.js")!
-
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true))
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true))
+        for urlString in urls {
+            let url = URL(string: urlString)!
+            #expect(
+                policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true),
+                "Should allow link click to: \(urlString)"
+            )
+            #expect(
+                policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true),
+                "Should allow JS navigation to: \(urlString)"
+            )
+        }
     }
 
     // MARK: - Navigation Policy: Subframe Navigation (Video/Embed Support)
 
-    @Test("allows subframe navigation to video URLs")
-    func allowsSubframeVideoNavigation() {
+    @Test("allows subframe navigation to external URLs (videos, embeds)")
+    func allowsSubframeNavigation() {
         let policy = EditorNavigationPolicy()
-        let videoUrls = [
+        let embedUrls = [
             "https://videos.files.wordpress.com/abc123/video.mp4",
-            "https://v.wordpress.com/abc123",
-            "https://videopress.com/v/abc123"
+            "https://www.youtube.com/embed/dQw4w9WgXcQ",
+            "https://platform.twitter.com/embed/Tweet.html",
+            "https://player.vimeo.com/video/123456"
         ]
 
-        for urlString in videoUrls {
+        for urlString in embedUrls {
             let url = URL(string: urlString)!
-            // Subframe navigation (isMainFrame = false) should be allowed
             #expect(
                 policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: false),
                 "Should allow subframe navigation to: \(urlString)"
@@ -149,59 +111,15 @@ struct EditorNavigationPolicyTests {
         }
     }
 
-    @Test("allows subframe navigation to YouTube embeds")
-    func allowsSubframeYouTubeNavigation() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "https://www.youtube.com/embed/dQw4w9WgXcQ")!
+    // MARK: - Navigation Policy: Main Frame External Navigation (Should Open in Browser)
 
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: false))
-    }
-
-    @Test("allows subframe navigation to Twitter embeds")
-    func allowsSubframeTwitterNavigation() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "https://platform.twitter.com/embed/Tweet.html")!
-
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: false))
-    }
-
-    @Test("allows subframe navigation to Vimeo embeds")
-    func allowsSubframeVimeoNavigation() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "https://player.vimeo.com/video/123456")!
-
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: false))
-    }
-
-    // MARK: - Navigation Policy: Link Clicks (Should Open in Browser)
-
-    @Test("blocks link clicks to external URLs")
+    @Test("blocks link clicks to external URLs in main frame")
     func blocksLinkClicksToExternalUrls() {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "https://example.com/page")!
 
         #expect(!policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true))
     }
-
-    @Test("blocks link clicks to WordPress.com checkout URLs")
-    func blocksLinkClicksToCheckout() {
-        let policy = EditorNavigationPolicy()
-        let checkoutUrls = [
-            "https://wordpress.com/checkout/example.wordpress.com/premium",
-            "https://wordpress.com/plans/example.wordpress.com",
-            "https://wordpress.com/checkout/example.wordpress.com/videopress"
-        ]
-
-        for urlString in checkoutUrls {
-            let url = URL(string: urlString)!
-            #expect(
-                !policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: true),
-                "Should block link click to: \(urlString)"
-            )
-        }
-    }
-
-    // MARK: - Navigation Policy: JavaScript Navigation (Upsell Buttons)
 
     @Test("blocks JavaScript main frame navigation to external URLs")
     func blocksJavaScriptMainFrameNavigation() {
@@ -212,56 +130,20 @@ struct EditorNavigationPolicyTests {
         #expect(!policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true))
     }
 
-    @Test("blocks JavaScript navigation to upgrade URLs in main frame")
-    func blocksJavaScriptUpgradeNavigation() {
-        let policy = EditorNavigationPolicy()
-        let upgradeUrls = [
-            "https://wordpress.com/checkout/example.wordpress.com/premium",
-            "https://wordpress.com/plans/example.wordpress.com",
-            "https://wordpress.com/checkout/example.wordpress.com/videopress"
-        ]
-
-        for urlString in upgradeUrls {
-            let url = URL(string: urlString)!
-            #expect(
-                !policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: true),
-                "Should block JS navigation to: \(urlString)"
-            )
-        }
-    }
-
     // MARK: - Navigation Policy: Other Navigation Types (Should Allow)
 
-    @Test("allows reload navigation")
-    func allowsReloadNavigation() {
+    @Test("allows reload, back/forward, and form navigation types")
+    func allowsOtherNavigationTypes() {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "https://example.com/editor")!
 
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .reload, isMainFrame: true))
-    }
-
-    @Test("allows back/forward navigation")
-    func allowsBackForwardNavigation() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "https://example.com/editor")!
-
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .backForward, isMainFrame: true))
-    }
-
-    @Test("allows form submitted navigation")
-    func allowsFormSubmittedNavigation() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "https://example.com/form-handler")!
-
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .formSubmitted, isMainFrame: true))
-    }
-
-    @Test("allows form resubmitted navigation")
-    func allowsFormResubmittedNavigation() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "https://example.com/form-handler")!
-
-        #expect(policy.shouldAllowNavigation(url: url, navigationType: .formResubmitted, isMainFrame: true))
+        let allowedTypes: [WKNavigationType] = [.reload, .backForward, .formSubmitted, .formResubmitted]
+        for navigationType in allowedTypes {
+            #expect(
+                policy.shouldAllowNavigation(url: url, navigationType: navigationType, isMainFrame: true),
+                "Should allow navigation type: \(navigationType)"
+            )
+        }
     }
 
     // MARK: - Navigation Policy: Edge Cases
@@ -273,20 +155,13 @@ struct EditorNavigationPolicyTests {
         #expect(policy.shouldAllowNavigation(url: nil, navigationType: .other, isMainFrame: true))
     }
 
-    @Test("allows navigation when isMainFrame is nil")
-    func allowsNavigationWithNilMainFrame() {
+    @Test("handles nil isMainFrame: allows .other, blocks .linkActivated")
+    func handlesNilMainFrame() {
         let policy = EditorNavigationPolicy()
         let url = URL(string: "https://example.com/page")!
 
-        // When targetFrame is nil (unknown), we allow navigation except for linkActivated
+        // When targetFrame is nil (unknown), allow .other but block link clicks
         #expect(policy.shouldAllowNavigation(url: url, navigationType: .other, isMainFrame: nil))
-    }
-
-    @Test("blocks link clicks even when isMainFrame is nil")
-    func blocksLinkClicksWithNilMainFrame() {
-        let policy = EditorNavigationPolicy()
-        let url = URL(string: "https://example.com/page")!
-
         #expect(!policy.shouldAllowNavigation(url: url, navigationType: .linkActivated, isMainFrame: nil))
     }
 


### PR DESCRIPTION
## What?

Updates the iOS WebView navigation policy to correctly open external URLs in the system browser while allowing embedded content (videos, iframes) to load within the editor.

## Why?

Fixes CMM-1172.

The WPCOM upsell button uses `window.top.location.href = url` (JavaScript navigation), which bypassed the original `.linkActivated`-only check. This caused the editor WebView to navigate to WordPress.com checkout pages instead of opening them in Safari.

## How?

Introduces `EditorNavigationPolicy` to evaluate navigation requests based on:

| Navigation Type | Target Frame | Result |
|-----------------|--------------|--------|
| Any | Allowed scheme (`file://`, `gbk-cache-https://`, `gbk-media-file://`) | ✅ Allow |
| Any | Dev server host | ✅ Allow |
| Any | Subframe (iframe) | ✅ Allow |
| `.reload` | Main frame | ✅ Allow |
| `.linkActivated`, `.other`, `.backForward`, `.formSubmitted`, `.formResubmitted` | Main frame | ❌ Open in Safari |

This ensures:
- Video embeds and iframes load correctly (subframe navigation allowed)
- User link clicks open in Safari
- JavaScript-initiated navigation (upsells) opens in Safari
- Editor resources and dev server work normally

## Testing Instructions

### Upsell Navigation (the bug fix)
> [!important]
> Requires testing with the WordPress app with the plugins feature enabled. 

1. Open a WPCOM Simple site with a Free plan
2. Insert a Video block
3. Tap the "Upgrade" button
4. **Expected:** Safari opens with the checkout page (not rendered inside the editor)

### Video Playback (regression test)
1. Create a post for a site allowing video uploads 
1. Insert a Video block  and attach media from the Media Library  
2. Tap the play button on the video  
3. **Expected:** Video plays inline in the editor

### Embed (regression test)
1. Create a post
2. Insert an Embed block 
3. Configure the embed with a valid URL
4. **Expected:** the embed preview renders within the editor[^1]

[^1]: YouTube embeds do not work on iOS due to https://github.com/WordPress/gutenberg/issues/73288.  

### Link Clicks (regression test)
1. Create a paragraph with a hyperlink to an external URL
6. Move the cursor into the link
7. Tap the edit link button in the toolbar 
8. Tap the existing link URL in the popover
9. **Expected:** Safari opens the URL

### Accessibility Testing Instructions

No UI changes - navigation behavior only.