### PR TITLE
fix: Register MediaFileSchemeHandler for native iOS media insertion

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -189,6 +189,9 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
 
         self.bundleProvider.bind(to: config)
 
+        // Register media file scheme handler for serving local media via gbk-media-file:// URLs
+        config.setURLSchemeHandler(MediaFileSchemeHandler(), forURLScheme: MediaFileSchemeHandler.scheme)
+
         config.applicationNameForUserAgent = "GutenbergKit/\(GutenbergKitVersion.version)"
 
         self.webView = GBWebView(frame: .zero, configuration: config)

--- a/ios/Tests/GutenbergKitTests/Media/MediaFileSchemeHandlerRegistrationTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaFileSchemeHandlerRegistrationTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+import WebKit
+
+@testable import GutenbergKit
+
+#if canImport(UIKit)
+
+@Suite("MediaFileSchemeHandler Registration")
+struct MediaFileSchemeHandlerRegistrationTests: MakesTestFixtures {
+    static let testSiteURL = URL(string: "https://test.example.com")!
+    static let testApiRoot = URL(string: "https://test.example.com/wp-json/wp/v2")!
+
+    @MainActor
+    @Test("EditorViewController registers MediaFileSchemeHandler for gbk-media-file scheme")
+    func editorViewControllerRegistersSchemeHandler() throws {
+        let configuration = makeConfiguration()
+        let editorVC = EditorViewController(configuration: configuration)
+
+        let handler = editorVC.webView.configuration.urlSchemeHandler(forURLScheme: MediaFileSchemeHandler.scheme)
+        #expect(handler != nil, "MediaFileSchemeHandler should be registered for \(MediaFileSchemeHandler.scheme) scheme")
+    }
+}
+
+#endif


### PR DESCRIPTION
## What?

Registers the `MediaFileSchemeHandler` with the WKWebView configuration so that media selected from the device's photo library can be displayed in the editor.

## Why?

When inserting media from the native iOS block inserter, selected photos and videos were not appearing in the editor. The `MediaFileSchemeHandler` for the `gbk-media-file://` URL scheme was defined but never registered with the WebView configuration.

This was a regression introduced in commit `6486090` ("Add iOS Preload List #250") when `EditorViewController` was refactored and the scheme handler registration was removed but not restored.

Fixes CMM-1207.

## How?

Added the missing scheme handler registration in `EditorViewController.init()`:

```swift
config.setURLSchemeHandler(MediaFileSchemeHandler(), forURLScheme: MediaFileSchemeHandler.scheme)
```

Also added test coverage to verify the scheme handler is properly registered.

## Testing Instructions

1. Open the editor on iOS
2. Tap the block inserter button
3. Select "Photos" to choose media from the device's photo library
4. Select a photo or video
5. Verify the media block is inserted and displays correctly

### Accessibility Testing Instructions

N/A - This fix restores existing functionality without UI changes.