### PR TITLE
task: Add Claude Code auto-format hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "Edit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "jq -r '.tool_input.file_path' | xargs ./node_modules/.bin/prettier --write"
+					}
+				]
+			}
+		]
+	}
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,9 +201,6 @@ Note: Console logs should be used sparingly. For verbose or development-specific
 **IMPORTANT**: Always run these commands after making code changes and before presenting work for review/commit:
 
 ```bash
-# Format JavaScript code
-make format
-
 # Auto-fix linting errors
 make lint-js-fix
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,11 +201,8 @@ Note: Console logs should be used sparingly. For verbose or development-specific
 **IMPORTANT**: Always run these commands after making code changes and before presenting work for review/commit:
 
 ```bash
-# Auto-fix linting errors
+# Auto-fix linting errors & verify linting passes
 make lint-js-fix
-
-# Verify linting passes
-make lint-js
 ```
 
 These commands ensure code quality and prevent lint errors from blocking commits.


### PR DESCRIPTION
## What?

Adds a `.claude/settings.json` file with a PostToolUse hook that automatically runs Prettier on files after Claude Code edits them. Also simplifies the CLAUDE.md pre-commit checklist since formatting is now handled automatically. 

## Why?

The project's CLAUDE.md pre-commit checklist requires running `make format` (Prettier) and `make lint-js-fix` (ESLint) before every commit. Without automation, formatting drift can accumulate during a Claude Code session, leading to noisy diffs and extra manual steps. This hook ensures every file Claude edits is immediately formatted, keeping code consistent without manual intervention.

## How?

- **`.claude/settings.json`**: Adds a `PostToolUse` hook that triggers after every `Edit` or `Write` tool call. The hook extracts the edited file path from the tool input via `jq` and runs `./node_modules/.bin/prettier --write` on that single file. Based on [Claude examples](https://code.claude.com/docs/en/hooks-guide#auto-format-code-after-edits). 
- **`CLAUDE.md`**: Removes `make format` and `make lint-js` from the pre-commit checklist since formatting is now automatic. Only `make lint-js-fix` remains (ESLint is too slow for per-edit hooks and can make semantic changes).

### Design decisions

- **Local binary (`./node_modules/.bin/prettier`)** instead of `npx` — avoids any risk of downloading packages from the internet.
- **Prettier only, not ESLint** — Prettier on a single file is near-instant (<100 ms). ESLint with the WordPress plugin takes 1–3 s per file and can make semantic changes (e.g., removing imports).
- **Graceful degradation** — PostToolUse hooks are non-blocking. If `jq` is missing or `node_modules` isn't installed, Prettier fails silently and Claude continues. Prettier also respects `.prettierignore`.

## Testing Instructions

Not important that we test these scripting changes, but here are some ideas: 

1. Start a new Claude Code session in the project.
2. Ask Claude to edit a JS/JSX file — confirm the file is auto-formatted after the edit.
3. Edit a file in an ignored directory (e.g., `ios/`) — confirm Prettier skips it gracefully.
4. Run `make lint-js` to confirm no formatting regressions.