### PR TITLE
Clean up old assets before downloading new ones

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
@@ -119,14 +119,21 @@ public actor EditorService {
         self.progress = EditorProgress(completed: 1, total: 100)
         self.progressCallback = progress
 
+        // Automatically clean up old asset bundles.
+        // Cleanup errors are intentionally ignored so that the download process
+        // continues uninterrupted. Failures are expected when running for the
+        // first time, since the storage directories may not yet exist.
+        await onceEvery(.seconds(86_400)) {
+            do {
+                try await self.cleanup()
+            } catch {
+                log(.warn, "Failed to cleanup old asset bundles: \(error)")
+            }
+        }
+
         async let settings = try prepareEditorSettings()
         async let assetBundle = try self.prepareAssetBundle()
         async let preloadList = try preparePreloadList()
-
-        // Automatically clean up old asset bundles
-        try await onceEvery(.seconds(86_400)) {
-            try await self.cleanup()
-        }
 
         return try await EditorDependencies(
             editorSettings: settings,


### PR DESCRIPTION
## What?

Perform the cleanup step before the download assets step.

## Why?

The cleanup step removes the assets that were just downloaded if the previous function call was one day ago.

To reproduce the issue locally:
1. change the interval from 1 day to 1 second.
2. Go to the Demo app.
3. Add a new site.
4. Tap the "Prepare Editor" button to preload.
5. Open the editor on the site. You'll see the editor open slowly because it's downloading assets.
