### PR TITLE
fix: Resolve dev server CORS errors and falsy post id blocking editor render

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -607,7 +607,13 @@ class GutenbergView : FrameLayout {
     }
 
     private fun addCorsHeaders(headers: MutableMap<String, String>) {
-        headers["Access-Control-Allow-Origin"] = "https://appassets.androidplatform.net"
+        val origin = if (BuildConfig.GUTENBERG_EDITOR_URL.isNotEmpty()) {
+            val uri = Uri.parse(BuildConfig.GUTENBERG_EDITOR_URL)
+            "${uri.scheme}://${uri.host}${if (uri.port != -1) ":${uri.port}" else ""}"
+        } else {
+            "https://appassets.androidplatform.net"
+        }
+        headers["Access-Control-Allow-Origin"] = origin
         headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD"
         headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type, Accept, X-WP-Nonce"
         headers["Access-Control-Allow-Credentials"] = "true"

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -299,7 +299,7 @@ export async function getPost() {
 	if ( hostContent ) {
 		debug( 'Using content from native host' );
 		return {
-			id: post?.id ?? -1,
+			id: post?.id || -1,
 			type: post?.type || 'post',
 			status: post?.status || 'draft',
 			title: { raw: hostContent.title },
@@ -310,7 +310,7 @@ export async function getPost() {
 	if ( post ) {
 		debug( 'Native bridge unavailable, using GBKit initial content' );
 		return {
-			id: post.id,
+			id: post.id || -1,
 			type: post.type || 'post',
 			status: post.status || 'draft',
 			title: { raw: decodeURIComponent( post.title ) },


### PR DESCRIPTION
## What?

Two fixes that resolve the Android editor failing to render when using a local dev server via `GUTENBERG_EDITOR_URL`.

## Why?

After the native CORS proxy was added in cad54a1, using a local dev server (`GUTENBERG_EDITOR_URL`) caused two issues:

1. **CORS errors**: The `Access-Control-Allow-Origin` header was hardcoded to `https://appassets.androidplatform.net`, which doesn't match the dev server origin (e.g., `http://192.168.0.114:5173`). The browser rejected all proxied API responses.
2. **Editor never becoming ready**: `__unstableIsEditorReady()` returns `!!state.postId`, so a post id of `0` (falsy) keeps the editor permanently stuck returning `null`. The host app was providing `id: 0`, which passed through unchecked.

## How?

1. **CORS fix** (`GutenbergView.kt`): `addCorsHeaders` now derives the origin from `BuildConfig.GUTENBERG_EDITOR_URL` when set, falling back to the bundled asset origin otherwise.
2. **Post id fix** (`bridge.js`): Changed `??` to `||` for post id fallback in `getPost()`, so all falsy ids (including `0`) fall back to `-1`, consistent with the existing default path.

## Testing Instructions

1. Set `GUTENBERG_EDITOR_URL=http://<your-ip>:5173/` in `android/local.properties`
2. Run `make dev-server`
3. Build and run the Android app on a device/emulator
4. Verify the editor loads and renders without CORS errors in Logcat

### Accessibility Testing Instructions

No UI changes.