### PR TITLE
fix: Exclude WordPress globals files from externals plugin

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -53,6 +53,15 @@ function wordPressExternals() {
 				return null;
 			}
 
+			// Skip files that set up WordPress globals — they must import
+			// the actual modules from node_modules, not read from window.wp.
+			if (
+				id.includes( 'wordpress-globals' ) ||
+				id.includes( 'wordpress-i18n' )
+			) {
+				return null;
+			}
+
 			const magicString = new MagicString( code );
 			let hasReplacements = false;
 


### PR DESCRIPTION
## What?

Explicitly exclude `wordpress-globals.js` and `wordpress-i18n.js` from the `wordPressExternals()` Vite plugin transform.

## Why?

The `wordPressExternals()` plugin transforms `@wordpress/*` imports into `window.wp.*` global reads. The `wordpress-globals.js` and `wordpress-i18n.js` files are responsible for *populating* `window.wp` — they need to import the actual modules from `node_modules`, not read from the globals they haven't set up yet.

Currently these files are only spared by accident: the plugin's regex matches default imports (`import foo from '...'`) and named imports (`import { foo } from '...'`), but not the namespace imports (`import * as foo from '...'`) that these files use. If someone refactored those imports to named or default style, the production build would silently break — `window.wp` would never be populated, causing any code that depends on it to fail.

## How?

Added an early return in the `wordPressExternals()` `transform` function that skips files whose path includes `wordpress-globals` or `wordpress-i18n`, alongside the existing `node_modules` exclusion.

## Testing Instructions

1. Run `npm run build` — verify the build succeeds and `dist/assets/wordpress-globals-*.js` is still ~5.8 MB (confirming the WordPress modules are bundled, not externalized).
2. Run `npm run preview` and open `http://localhost:4173/?dev_mode=1` — verify `window.wp` is defined in the browser console.