### PR TITLE
fix: Resolve Cover block inner UI inaccessible in GutenbergKit

### DIFF
--- a/e2e/cover-block.spec.js
+++ b/e2e/cover-block.spec.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import EditorPage from './editor-page';
+
+test.describe( 'Cover Block', () => {
+	test( 'should insert a cover block and select a background color', async ( {
+		page,
+	} ) => {
+		const editor = new EditorPage( page );
+		await editor.setup();
+
+		await editor.insertBlock( 'core/cover' );
+
+		// The Cover block placeholder should be visible.
+		const coverBlock = page.locator( '.wp-block-cover' );
+		await expect( coverBlock ).toBeVisible();
+
+		// Select a color from the overlay color palette in the placeholder.
+		const colorPalette = page.getByRole( 'group', {
+			name: 'Overlay color',
+		} );
+		await expect( colorPalette ).toBeVisible();
+		await colorPalette.getByRole( 'button', { name: 'Black' } ).click();
+
+		// After selecting a color, the Cover block transitions from its
+		// placeholder state to a full block with an inner paragraph.
+		const innerParagraph = page.getByRole( 'document', {
+			name: /start writing/,
+		} );
+		await expect( innerParagraph ).toBeVisible();
+
+		// Verify the block structure in the data store.
+		const blocks = await editor.getBlocks();
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].name ).toBe( 'core/cover' );
+		expect( blocks[ 0 ].attributes.overlayColor ).toBe( 'black' );
+
+		const innerBlocks = blocks[ 0 ].innerBlocks;
+		expect( innerBlocks ).toHaveLength( 1 );
+		expect( innerBlocks[ 0 ].name ).toBe( 'core/paragraph' );
+	} );
+} );

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,16 +3,21 @@
  */
 import { defineConfig, devices } from '@playwright/test';
 
+const isCI = process.env.CI === 'true';
+
+// CI uses production build, local development uses dev server
+const url = isCI ? 'http://localhost:4173' : 'http://localhost:5173';
+
 export default defineConfig( {
 	testDir: './e2e',
 	outputDir: './e2e/test-results',
 	fullyParallel: true,
-	workers: process.env.CI ? 1 : undefined,
-	retries: process.env.CI ? 2 : 0,
+	workers: isCI ? 1 : undefined,
+	retries: isCI ? 2 : 0,
 	timeout: 60_000,
-	reporter: process.env.CI ? 'list' : 'html',
+	reporter: isCI ? 'list' : 'html',
 	use: {
-		baseURL: 'http://localhost:4173',
+		baseURL: url,
 		actionTimeout: 10_000,
 		trace: 'on-first-retry',
 	},
@@ -23,9 +28,10 @@ export default defineConfig( {
 		},
 	],
 	webServer: {
-		command: 'npm run preview',
-		url: 'http://localhost:4173',
-		reuseExistingServer: true,
+		// CI uses production build, local development uses dev server
+		command: isCI ? 'npm run preview' : 'npm run dev',
+		url,
+		reuseExistingServer: ! isCI,
 		timeout: 30_000,
 	},
 } );

--- a/src/components/editor-toolbar/style.scss
+++ b/src/components/editor-toolbar/style.scss
@@ -105,7 +105,7 @@ $scroll-indicator-elevation: 32;
 }
 
 .gutenberg-kit-editor-toolbar.gutenberg-kit-editor-toolbar
-	.components-button.has-icon.has-icon {
+	.components-button.components-button {
 	min-width: $min-touch-target-size;
 	max-height: $min-touch-target-size;
 }

--- a/src/components/visual-editor/index.jsx
+++ b/src/components/visual-editor/index.jsx
@@ -20,7 +20,6 @@ import '@wordpress/format-library';
 import componentStyles from '@wordpress/components/build-style/style.css?inline';
 import blockEditorContentStyles from '@wordpress/block-editor/build-style/content.css?inline';
 import blocksStyles from '@wordpress/block-library/build-style/style.css?inline';
-import blocksEditorStyles from '@wordpress/block-library/build-style/editor.css?inline';
 
 /**
  * Internal dependencies
@@ -94,8 +93,7 @@ function VisualEditor( { hideTitle } ) {
 		hasThemeStyles ? '' : defaultThemeStyles,
 		componentStyles,
 		blockEditorContentStyles,
-		blocksStyles,
-		blocksEditorStyles
+		blocksStyles
 	);
 
 	const editorClasses = clsx( 'gutenberg-kit-visual-editor', {

--- a/src/utils/editor-styles.js
+++ b/src/utils/editor-styles.js
@@ -4,5 +4,6 @@
 // Default styles that are needed for the editor.
 import '@wordpress/components/build-style/style.css';
 import '@wordpress/block-editor/build-style/style.css';
+import '@wordpress/block-library/build-style/editor.css';
 import '@wordpress/format-library/build-style/style.css';
 import '@wordpress/editor/build-style/style.css';


### PR DESCRIPTION
## What?

Fixes the Cover block's inner UI being inaccessible after insertion, and applies a consistent maximum height to toolbar buttons.

## Why?

After inserting a Cover block, it was not possible to interact with the block's inner UI (color selection, media attachment, resizing). The drag handle was also erroneously positioned at the top of the block instead of the bottom.

The root cause was that block editor styles (`@wordpress/block-library/build-style/editor.css`) were being injected as scoped inline styles inside the editor iframe rather than as global styles. This caused certain CSS rules — particularly those for the Cover block — to be incorrectly scoped, breaking the block's interactive UI.

Additionally, toolbar buttons with text (non-icon-only) were not constrained to the same maximum height as icon buttons.

Fixes: CMM-1281

## How?

1. **Move block editor styles to global scope** (`src/utils/editor-styles.js`): Import `@wordpress/block-library/build-style/editor.css` as a global style instead of an inline scoped style within the visual editor iframe. This ensures editor styles apply correctly without scoping issues.

2. **Remove scoped inline import** (`src/components/visual-editor/index.jsx`): Remove the `blocksEditorStyles` inline import and its usage in `useEditorStyles`, since it is now loaded globally.

3. **Broaden toolbar button max-height selector** (`src/components/editor-toolbar/style.scss`): Change the selector from `.components-button.has-icon.has-icon` to `.components-button.components-button` so that all toolbar buttons (not just icon buttons) get the consistent `max-height` constraint.

4. **Add Cover block E2E test** (`e2e/cover-block.spec.js`): Add an end-to-end test that inserts a Cover block, selects a background color from the overlay color palette, and verifies the block transitions to its full state with the correct inner block structure. This test exercises the CSS scoping fix — the color button click fails if the resizable popover intercepts pointer events due to incorrectly scoped styles.

5. **Simplify local E2E testing** (`playwright.config.js`): On CI, E2E tests run against the production build (`npm run preview`). Locally, tests use the Vite dev server (`npm run dev`) so changes can be tested without a full rebuild.

## Testing Instructions

1. Open a post or page.
2. Insert a Cover block.
3. Verify you can interact with the block's inner UI — select colors, attach media, and resize the block.
4. Verify the drag handle appears at the bottom of the block (not the top).
5. Check that toolbar buttons (both icon-only and text) have a consistent height.

### Accessibility Testing Instructions

N/A, no navigation changes. 

## Screenshots or screencast <!-- if applicable -->

Cover Before | Cover After
-- | --
<img width="380" height="755" alt="cover-before" src="https://github.com/user-attachments/assets/0a658542-39b3-484a-b4b6-413496361d79" /> | <img width="380" height="755" alt="cover-after" src="https://github.com/user-attachments/assets/88349d33-a32d-4778-870b-b9bf784d2f44" />

<details><summary>Toolbar Before</summary>
<p>


https://github.com/user-attachments/assets/a0af9c73-58ba-46ac-a6ea-250c67325332



</p>
</details> 

<details><summary>Toolbar After</summary>
<p>


https://github.com/user-attachments/assets/eca9a8af-076a-433a-8e5b-afbd13162fcb



</p>
</details> 