### PR TITLE
fix: Resolve iOS retain cycle in EditorViewController async flow

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -239,8 +239,8 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
             }
         } else {
             // ASYNC FLOW: No dependencies - fetch them asynchronously
-            self.dependencyTaskHandle = Task(priority: .userInitiated) {
-                await self.prepareEditor()
+            self.dependencyTaskHandle = Task(priority: .userInitiated) { [weak self] in
+                await self?.prepareEditor()
             }
         }
     }
@@ -270,8 +270,8 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
 
         do {
             // EditorService.prepare() fetches dependencies concurrently with progress reporting
-            let dependencies = try await self.editorService.prepare { @MainActor progress in
-                self.progressView.setProgress(progress, animated: true)
+            let dependencies = try await self.editorService.prepare { @MainActor [weak self] progress in
+                self?.progressView.setProgress(progress, animated: true)
             }
 
             // Store dependencies for later use (e.g., HTMLPreviewManager)

--- a/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
@@ -118,6 +118,10 @@ public actor EditorService {
 
         self.progress = EditorProgress(completed: 1, total: 100)
         self.progressCallback = progress
+        defer {
+            self.progressCallback = nil
+            self.progress = nil
+        }
 
         async let settings = try prepareEditorSettings()
         async let assetBundle = try self.prepareAssetBundle()


### PR DESCRIPTION
## What?

Fixes a retain cycle that prevents `EditorViewController` from being deallocated when using the async dependency-loading flow.

## Why?

Fix CMM-1282.

When opening and closing the editor multiple times without pre-loaded dependencies, each `EditorViewController` instance leaks — `deinit` is never called and Safari's Web Inspector shows lingering web views.

The root cause is `EditorService.prepare()` storing the progress callback in a property that is never cleared. Since `EditorViewController` owns the `EditorService` and the callback captures the view controller, this creates a retain cycle:

```
EditorViewController → editorService → progressCallback → EditorViewController
```

This only affects the async flow (no pre-loaded dependencies) because:
- **Offline/default editor**: `prepare()` returns early before storing the callback
- **Pre-loaded dependencies**: The async flow is never entered

In WordPress-iOS, the issue is reproducible by using the pull-to-refresh gesture on My Site to invalidate the editor dependencies cache, then opening the editor.

## How?

1. **`EditorService.swift`**: Added `defer { self.progressCallback = nil; self.progress = nil }` in `prepare()` to clear the stored callback after completion, breaking the cycle from the service side.

2. **`EditorViewController.swift`**: Added `[weak self]` captures in the Task closure and progress callback as defense-in-depth, ensuring the cycle cannot form even if the service retains the callback.

Either fix alone resolves the issue; both together provide robustness.

## Testing Instructions

1. Open the iOS demo app
2. Configure a site editor (do **not** tap "Prepare Editor" to pre-load dependencies)
3. Open the editor — it will load dependencies asynchronously
4. Close the editor
5. Repeat steps 3–4 several times
6. Verify in Safari Web Inspector that old web views no longer linger
7. Optionally add a `deinit` to `EditorViewController` and confirm it fires on each dismissal