### PR TITLE
build: reinstate nested qs dependency

### DIFF
--- a/ios/Demo-iOS/GutenbergUITests/EditorUITestHelpers.swift
+++ b/ios/Demo-iOS/GutenbergUITests/EditorUITestHelpers.swift
@@ -11,10 +11,10 @@ enum EditorUITestHelpers {
     /// the editor has loaded.
     @discardableResult
     static func navigateToEditor(app: XCUIApplication) throws -> XCUIElement {
-        // Tap the "Default Editor" row in the list.
-        let defaultEditor = app.staticTexts["Default Editor"]
-        XCTAssertTrue(defaultEditor.waitForExistence(timeout: 10), "Default Editor row not found")
-        defaultEditor.tap()
+        // Tap the "Standalone Editor" row in the list.
+        let standaloneEditor = app.staticTexts["Standalone Editor"]
+        XCTAssertTrue(standaloneEditor.waitForExistence(timeout: 10), "Standalone Editor row not found")
+        standaloneEditor.tap()
 
         // Tap the "Start" button on the configuration screen.
         let startButton = app.buttons["Start"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12953,6 +12953,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/body-parser/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/boolean": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -16093,6 +16109,22 @@
 			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/express/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/extract-zip": {
 			"version": "2.0.1",


### PR DESCRIPTION
## What?

1. Reinstates the nested `qs@6.14.2` dependency entries in `package-lock.json` for `body-parser` and `express`.
2. Fixes iOS UI tests that fail because the editor list row was renamed from "Default Editor" to "Standalone Editor".

## Why?

1. The `qs` dependency is required by `@wordpress/wp-env` and its transitive dependencies. It was introduced in e6cec57 but was erroneously discarded during a rebase in d12b489. Its absence causes CI failures due to an outdated lock file.
2. The row rename happened in e6cec57f but the UI test helper (`EditorUITestHelpers.swift`) was not updated, causing all tests that use `navigateToEditor` to fail (e.g. `testInsertImageBlock`).

## How?

1. Adds back the two nested `node_modules/body-parser/node_modules/qs` and `node_modules/express/node_modules/qs` entries to `package-lock.json`.
2. Updates the UI test helper to look for "Standalone Editor" instead of "Default Editor".

## Testing Instructions

1. Run `npm ci` and verify it completes without errors.
3. Verify CI passes.