### PR TITLE
fix: resolve iOS E2E test failures in block inserter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,10 +222,9 @@ test-ios-e2e: ## Run iOS E2E tests against the production build
 	else \
 		echo "--- :white_check_mark: Using existing build. Use 'make build REFRESH_JS_BUILD=1' to rebuild."; \
 	fi
-	@if [ ! -d "./ios/Sources/GutenbergKit/Gutenberg" ]; then \
-		echo "--- :open_file_folder: Copying build into iOS bundle"; \
-		cp -r ./dist/. ./ios/Sources/GutenbergKit/Gutenberg/; \
-	fi
+	@echo "--- :open_file_folder: Copying build into iOS bundle"
+	@rm -rf ./ios/Sources/GutenbergKit/Gutenberg/
+	@cp -r ./dist/. ./ios/Sources/GutenbergKit/Gutenberg/
 	@echo "--- :ios: Running iOS E2E Tests (production build)"
 	@set -o pipefail && \
 		xcodebuild test \

--- a/ios/Demo-iOS/GutenbergUITests/EditorUITestHelpers.swift
+++ b/ios/Demo-iOS/GutenbergUITests/EditorUITestHelpers.swift
@@ -43,7 +43,9 @@ enum EditorUITestHelpers {
         XCTAssertTrue(addBlockButton.waitForExistence(timeout: 10), "Add block button not found in WebView toolbar")
         addBlockButton.tap()
 
-        let blockOption = app.buttons[name]
+        // Use firstMatch because the same block can appear in multiple
+        // inserter sections (e.g. most-used and its category section).
+        let blockOption = app.buttons[name].firstMatch
         XCTAssertTrue(blockOption.waitForExistence(timeout: 10), "\(name) block not found in block inserter")
         blockOption.tap()
     }


### PR DESCRIPTION
## What?

Fix iOS E2E test failures (`testUndoRedoAfterTyping`, `testInsertImageBlock`) when interacting with the block inserter.

## Why?

Two separate issues caused the failures:

1. **CI: stale JS bundle** — The `test-ios-e2e` Makefile target only copied `dist/` into the iOS bundle directory (`ios/Sources/GutenbergKit/Gutenberg/`) when that directory didn't exist. Since it's checked into git, it always exists on CI checkout, so the freshly built `dist/` from the `build-react` pipeline step was never copied over the stale git-tracked bundle. This caused blocks to not appear in the inserter at all on CI.

2. **Duplicate button matches** — Blocks like "Paragraph" intentionally appear in multiple inserter sections (both `gbk-most-used` and their category section). When the test helper queries `app.buttons["Paragraph"]`, XCTest finds both instances and fails with "Multiple matching elements found".

## How?

- **Makefile**: Always replace the iOS bundle directory with the current `dist/` contents before running E2E tests, instead of conditionally skipping the copy when the directory already exists.
- **Test helper**: Use `.firstMatch` on the button query in `EditorUITestHelpers.insertBlock`, since both matching buttons insert the same block.

## Testing Instructions

1. Run `make test-ios-e2e`
2. Verify all E2E tests pass

### Accessibility Testing Instructions

No accessibility-facing UI changes.