### PR TITLE
docs: remove manual undo/redo test case

### DIFF
--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -4,28 +4,21 @@
 
 **Purpose:** Verify the editor's core functionality: writing/formatting text, uploading media, saving/publishing, and basic block manipulation.
 
-### S.1. Undo/Redo Actions
-
--   **Steps:**
-    -   Add, remove, and edit blocks and text.
-    -   Use Undo and Redo buttons.
--   **Expected Outcome:** Editor correctly undoes and redoes actions, restoring previous states.
-
-### S.2. Upload an image
+### S.1. Upload an image
 
 -   **Steps:**
     -   Add an Image block.
     -   Tap "Choose from device" and select an image.
 -   **Expected Outcome:** Image uploads and displays in the block. An activity indicator is shown while the image is uploading.
 
-### S.3. Upload an video
+### S.2. Upload an video
 
 -   **Steps:**
     -   Add a Video block.
     -   Tap "Choose from device" and select a video.
 -   **Expected Outcome:** Video uploads and displays in the block. An activity indicator is shown while the video is uploading.
 
-### S.4. Save and publish a post
+### S.3. Save and publish a post
 
 -   **Steps:**
     -   Create a new post with text and media.


### PR DESCRIPTION
## What?

Removes the manual undo/redo test case from the smoke test cases documentation and renumbers the remaining test cases.

## Why?

The undo/redo functionality is now covered by automated E2E tests, making the manual test case redundant. Removing it keeps the manual test cases focused on scenarios that require human verification.

- #319 
- #340 

## How?

- Removed the "S.1. Undo/Redo Actions" section from `docs/test-cases.md`
- Renumbered the remaining smoke test cases (S.2 → S.1, S.3 → S.2, S.4 → S.3)

## Testing Instructions

1. Review the changes in `docs/test-cases.md` to verify the removed test case and correct renumbering.