### PR TITLE
fix: skip editor settings fetch when theme styles are disabled

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/RESTAPIRepository.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/RESTAPIRepository.kt
@@ -86,7 +86,7 @@ class RESTAPIRepository(
      * @return The parsed editor settings.
      */
     suspend fun fetchEditorSettings(): EditorSettings {
-        if (!configuration.plugins && !configuration.themeStyles) {
+        if (!configuration.themeStyles) {
             return EditorSettings.undefined
         }
 

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/RESTAPIRepositoryTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/RESTAPIRepositoryTest.kt
@@ -77,8 +77,20 @@ class RESTAPIRepositoryTest {
     // MARK: - fetchEditorSettings Tests
 
     @Test
-    fun `fetchEditorSettings returns empty when plugins and theme styles disabled`() = runBlocking {
+    fun `fetchEditorSettings returns undefined when theme styles disabled`() = runBlocking {
         val configuration = makeConfiguration(shouldUsePlugins = false, shouldUseThemeStyles = false)
+        val mockClient = MockHTTPClient()
+        val repository = makeRepository(configuration = configuration, httpClient = mockClient)
+
+        val settings = repository.fetchEditorSettings()
+
+        assertEquals(EditorSettings.undefined, settings)
+        assertEquals(0, mockClient.getCallCount)
+    }
+
+    @Test
+    fun `fetchEditorSettings returns undefined when plugins enabled but theme styles disabled`() = runBlocking {
+        val configuration = makeConfiguration(shouldUsePlugins = true, shouldUseThemeStyles = false)
         val mockClient = MockHTTPClient()
         val repository = makeRepository(configuration = configuration, httpClient = mockClient)
 

--- a/ios/Sources/GutenbergKit/Sources/RESTAPIRepository.swift
+++ b/ios/Sources/GutenbergKit/Sources/RESTAPIRepository.swift
@@ -120,7 +120,7 @@ public struct RESTAPIRepository: Sendable {
     // MARK: Editor Settings
     @discardableResult
     public func fetchEditorSettings() async throws -> EditorSettings {
-        if !self.configuration.shouldUsePlugins && !self.configuration.shouldUseThemeStyles {
+        if !self.configuration.shouldUseThemeStyles {
             return .undefined
         }
 

--- a/ios/Tests/GutenbergKitTests/Services/RESTAPIRepositoryTests.swift
+++ b/ios/Tests/GutenbergKitTests/Services/RESTAPIRepositoryTests.swift
@@ -25,9 +25,21 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
 
     // MARK: - fetchEditorSettings Tests
 
-    @Test("fetchEditorSettings returns empty when plugins and theme styles disabled")
-    func fetchEditorSettingsReturnsEmptyWhenDisabled() async throws {
+    @Test("fetchEditorSettings returns undefined when theme styles disabled")
+    func fetchEditorSettingsReturnsUndefinedWhenThemeStylesDisabled() async throws {
         let configuration = makeConfiguration(shouldUsePlugins: false, shouldUseThemeStyles: false)
+        let mockClient = EditorAssetLibraryMockHTTPClient()
+        let repository = makeRepository(configuration: configuration, httpClient: mockClient)
+
+        let settings = try await repository.fetchEditorSettings()
+
+        #expect(settings == .undefined)
+        #expect(mockClient.getCallCount == 0)
+    }
+
+    @Test("fetchEditorSettings returns undefined when plugins enabled but theme styles disabled")
+    func fetchEditorSettingsReturnsUndefinedWhenOnlyPluginsEnabled() async throws {
+        let configuration = makeConfiguration(shouldUsePlugins: true, shouldUseThemeStyles: false)
         let mockClient = EditorAssetLibraryMockHTTPClient()
         let repository = makeRepository(configuration: configuration, httpClient: mockClient)
 


### PR DESCRIPTION
## What?

Skip the `/wp-block-editor/v1/settings` fetch when `shouldUseThemeStyles` is disabled, regardless of the `shouldUsePlugins` flag.

## Why?

Fix CMM-1921. Fix CMM-1163. 

The guard in `fetchEditorSettings()` previously required **both** `shouldUsePlugins` and `shouldUseThemeStyles` to be `false` before skipping the fetch. This meant a site with plugins enabled but no support for the block editor settings endpoint would still attempt the fetch, resulting in a 404 error that could cause the editor to fail to load.

The editor settings endpoint is only relevant for theme styles — plugins have their own separate asset endpoint (`/wpcom/v2/editor-assets`).

## How?

Changed the guard condition in `fetchEditorSettings()` from:
```
if !shouldUsePlugins && !shouldUseThemeStyles → skip
```
to:
```
if !shouldUseThemeStyles → skip
```

Applied to both iOS (`RESTAPIRepository.swift`) and Android (`RESTAPIRepository.kt`), with updated and additional test coverage on both platforms.

## Testing Instructions

1. Configure a site that supports plugins (`/wpcom/v2/editor-assets` route exists) but does **not** support the block editor settings endpoint (`/wp-block-editor/v1/settings` route is absent).
2. Open the editor for that site.
3. Verify the editor loads without a 404 error for the settings endpoint.
4. Verify that a site with both plugins and theme styles enabled still fetches and applies editor settings correctly.

### Accessibility Testing Instructions

N/A — no UI changes.

## Screenshots or screencast

N/A — no UI changes.