### PR TITLE
fix: mock oEmbed proxy in embed E2E test to prevent CI flakes

### DIFF
--- a/e2e/embed-content.spec.js
+++ b/e2e/embed-content.spec.js
@@ -50,8 +50,11 @@ async function mockOembedProxy( page ) {
 	await page.route( `${ apiBase }oembed/1.0/proxy**`, ( route ) => {
 		const url = new URL( route.request().url() );
 		const embedUrl = url.searchParams.get( 'url' ) || '';
+		const embedHostname = URL.canParse( embedUrl )
+			? new URL( embedUrl ).hostname
+			: '';
 
-		if ( embedUrl.includes( 'youtube.com' ) ) {
+		if ( /^(www\.)?youtube\.com$/.test( embedHostname ) ) {
 			return route.fulfill( {
 				status: 200,
 				contentType: 'application/json',

--- a/e2e/embed-content.spec.js
+++ b/e2e/embed-content.spec.js
@@ -7,12 +7,76 @@ import { test, expect } from '@playwright/test';
  * Internal dependencies
  */
 import EditorPage from './editor-page';
+import { credentials } from './wp-env-fixtures';
+
+/**
+ * Mock oEmbed proxy response for a YouTube video.
+ *
+ * This is a simplified version of the JSON that WordPress's oEmbed proxy
+ * (`/oembed/1.0/proxy`) returns after fetching from YouTube's oEmbed
+ * endpoint. Using a mock avoids external network calls to YouTube, which
+ * can flake in CI due to rate-limiting or connectivity issues.
+ *
+ * @type {Object}
+ */
+const YOUTUBE_OEMBED_RESPONSE = {
+	url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+	title: 'Rick Astley - Never Gonna Give You Up',
+	html: '<iframe width="200" height="113" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen title="Rick Astley - Never Gonna Give You Up"></iframe>',
+	author_name: 'Rick Astley',
+	author_url: 'https://www.youtube.com/@RickAstleyYT',
+	type: 'video',
+	height: 113,
+	width: 200,
+	version: '1.0',
+	provider_name: 'YouTube',
+	provider_url: 'https://www.youtube.com/',
+	thumbnail_url: 'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+	thumbnail_height: 360,
+	thumbnail_width: 480,
+};
+
+/**
+ * Intercept the WordPress oEmbed proxy endpoint and return mocked responses.
+ *
+ * Routes matching the wp-env REST API oEmbed proxy URL are intercepted.
+ * YouTube URLs receive a canned successful response; all other URLs
+ * receive a 404 (matching WordPress behavior for non-embeddable URLs).
+ *
+ * @param {import('@playwright/test').Page} page Playwright page.
+ */
+async function mockOembedProxy( page ) {
+	const apiBase = credentials.siteApiRoot;
+	await page.route( `${ apiBase }oembed/1.0/proxy**`, ( route ) => {
+		const url = new URL( route.request().url() );
+		const embedUrl = url.searchParams.get( 'url' ) || '';
+
+		if ( embedUrl.includes( 'youtube.com' ) ) {
+			return route.fulfill( {
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify( YOUTUBE_OEMBED_RESPONSE ),
+			} );
+		}
+
+		return route.fulfill( {
+			status: 404,
+			contentType: 'application/json',
+			body: JSON.stringify( {
+				code: 'oembed_invalid_url',
+				message: 'Not Found',
+				data: { status: 404 },
+			} ),
+		} );
+	} );
+}
 
 test.describe( 'Embedded Content', () => {
 	test( 'should insert an embed block with a YouTube URL', async ( {
 		page,
 	} ) => {
 		const editor = new EditorPage( page );
+		await mockOembedProxy( page );
 		await editor.setup();
 
 		await editor.insertBlock( 'core/embed' );
@@ -50,6 +114,7 @@ test.describe( 'Embedded Content', () => {
 		page,
 	} ) => {
 		const editor = new EditorPage( page );
+		await mockOembedProxy( page );
 		await editor.setup();
 
 		await editor.insertBlock( 'core/embed' );


### PR DESCRIPTION
## What?

Mocks the WordPress oEmbed proxy endpoint in the embed content E2E test using Playwright's `page.route()`.

## Why?

The embed test (`embed-content.spec.js`) hits YouTube's oEmbed endpoint via the WordPress proxy during CI. If YouTube rate-limits or is unreachable, the test flakes. This was flagged in https://github.com/wordpress-mobile/GutenbergKit/pull/329#issuecomment-3999409279.

## How?

- Adds a `mockOembedProxy()` helper that intercepts requests to the `/oembed/1.0/proxy` REST API endpoint using Playwright's route interception.
- YouTube URLs receive a canned successful oEmbed JSON response.
- Non-embeddable URLs receive a 404, matching WordPress's real behavior.
- Both tests call `mockOembedProxy(page)` before `editor.setup()`, so no external network calls are made.

## Testing Instructions

1. Run `make wp-env-start` to start the local WordPress environment.
2. Run `npx playwright test e2e/embed-content.spec.js`.
3. Verify both tests pass without any network calls to YouTube.

### Accessibility Testing Instructions

N/A — no UI changes.

## Screenshots or screencast

N/A — test infrastructure only.