### PR TITLE
fix: add default typography settings for sites without editor settings

### DIFF
--- a/src/utils/editor-settings.js
+++ b/src/utils/editor-settings.js
@@ -35,6 +35,39 @@ export function getDefaultEditorSettings() {
 			 */
 			blocks: {},
 			/**
+			 * Enable the typography controls that WordPress core enables by
+			 * default in its theme.json. This ensures blocks like Paragraph
+			 * have text alignment in the toolbar and typography options in
+			 * the block settings sidebar, even without editor settings from
+			 * the site.
+			 *
+			 * @see https://github.com/WordPress/gutenberg/blob/d97807b50f756126798a04a5ae94745aee19356d/lib/theme.json
+			 */
+			typography: {
+				customFontSize: true,
+				defaultFontSizes: true,
+				dropCap: true,
+				fontSizes: {
+					default: [
+						{ name: 'Small', slug: 'small', size: '13px' },
+						{ name: 'Medium', slug: 'medium', size: '20px' },
+						{ name: 'Large', slug: 'large', size: '36px' },
+						{
+							name: 'Extra Large',
+							slug: 'x-large',
+							size: '42px',
+						},
+					],
+				},
+				fontStyle: true,
+				fontWeight: true,
+				letterSpacing: true,
+				textAlign: true,
+				textDecoration: true,
+				textIndent: 'subsequent',
+				textTransform: true,
+			},
+			/**
 			 * Ensure themes lacking their own theme styles can customize blocks using
 			 * the default editor colors and gradients. Mirrors the approach taken by
 			 * the Gutenberg Mobile editor.


### PR DESCRIPTION
## What?

Add default typography settings to the fallback editor settings used when a site doesn't provide its own editor settings.

## Why?

Fix CMM-1933.

When a site lacks the Gutenberg plugin REST API endpoint, the editor is missing fundamental typography features: text alignment is absent from the block toolbar, the font size control is empty, and typography options (appearance, letter spacing, decoration, letter case, drop cap, line indent) are missing from the block settings sidebar.

## How?

Add a `typography` section to the `__experimentalFeatures` in `getDefaultEditorSettings()`, mirroring the defaults from WordPress core's `lib/theme.json`. This includes:

- Boolean flags for typography controls (`textAlign`, `fontStyle`, `fontWeight`, `letterSpacing`, `textDecoration`, `textTransform`, `dropCap`, `customFontSize`, `defaultFontSizes`)
- Default font size presets (Small, Medium, Large, Extra Large)
- Text indent mode (`'subsequent'`)

## Testing Instructions

1. Open the editor in a browser with dev mode enabled: `http://localhost:5173/?dev_mode`. Alternatively, use the local WordPress (wp-env) site in the demo app and manually disable the Gutenberg plugin.
2. Insert a Paragraph block.
3. Verify the text alignment button (left/center/right) appears in the block toolbar.
4. Open the block settings sidebar and verify the Typography section shows font size presets (S, M, L, XL), appearance, letter spacing, decoration, letter case, drop cap, and line indent controls (some settings are found within the sections more menu—the button with a plus icon).

### Accessibility Testing Instructions

N/A — no changes to accessibility behavior.

## Screenshots or screencast
<!-- Before/after screenshots showing the typography controls -->
Before | After
-- | --
<img width="380" height="755" alt="before" src="https://github.com/user-attachments/assets/0aadab76-7348-4cbc-bd95-5504f258f769" /> | <img width="380" height="755" alt="after" src="https://github.com/user-attachments/assets/e8216d09-917d-460a-9e95-e78a8cdc90e0" />