### PR TITLE
fix: include block library editor styles for correct placeholder UI

### DIFF
--- a/src/components/visual-editor/index.jsx
+++ b/src/components/visual-editor/index.jsx
@@ -20,6 +20,7 @@ import '@wordpress/format-library';
 import componentStyles from '@wordpress/components/build-style/style.css?inline';
 import blockEditorContentStyles from '@wordpress/block-editor/build-style/content.css?inline';
 import blocksStyles from '@wordpress/block-library/build-style/style.css?inline';
+import blocksEditorStyles from '@wordpress/block-library/build-style/editor.css?inline';
 
 /**
  * Internal dependencies
@@ -93,7 +94,8 @@ function VisualEditor( { hideTitle } ) {
 		hasThemeStyles ? '' : defaultThemeStyles,
 		componentStyles,
 		blockEditorContentStyles,
-		blocksStyles
+		blocksStyles,
+		blocksEditorStyles
 	);
 
 	const editorClasses = clsx( 'gutenberg-kit-visual-editor', {


### PR DESCRIPTION
## What?

Include `@wordpress/block-library` editor styles (`editor.css`) in the visual editor's style bundle.

## Why?

Fix CMM-1939.

The editor-specific styles from `@wordpress/block-library` were not being loaded after being erroneously removed in #332. This caused styling issues in blocks that rely on editor-only CSS — notably the Featured Image block, whose placeholder button rendered at 100% width instead of the intended max 48px.

## How?

Import `editor.css` from `@wordpress/block-library/build-style/` and pass it to `useEditorStyles` alongside the existing block library styles.

Note: This means the stylesheet is loaded into the DOM twice, but this matches the web editor's current implementation, albeit odd.

## Testing Instructions

1. Open the demo editor.
2. Add a Featured Image block.
3. Verify the placeholder buttons (e.g., "Upload") are compact (~48px) rather than stretching to full width.

### Accessibility Testing Instructions

No accessibility changes — this is a CSS-only fix restoring intended button dimensions.

## Screenshots or screencast <!-- if applicable -->

Before | After
-- | --
<img width="380" height="755" alt="before" src="https://github.com/user-attachments/assets/df7805e8-80d2-4066-9067-9509d03c90ae" /> | <img width="380" height="755" alt="after" src="https://github.com/user-attachments/assets/6ec8be39-d3d8-4f84-a1d8-b582d22d0e63" />