### PR TITLE
fix: gracefully handle missing translation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,7 +194,8 @@ local.properties
 # /ios/Sources/GutenbergKit/Gutenberg/index.html
 
 # Translation files
-src/translations/
+src/translations/*
+!src/translations/.gitkeep
 
 # Playwright
 e2e/test-results/

--- a/src/utils/localization.js
+++ b/src/utils/localization.js
@@ -7,7 +7,7 @@ import { setLocaleData } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getGBKit } from './bridge';
-import { error, debug } from './logger';
+import { warn, debug } from './logger';
 
 const DEFAULT_LOCALE = 'en';
 
@@ -40,7 +40,9 @@ async function loadTranslations( locale ) {
 		);
 		setLocaleData( translations );
 	} catch ( err ) {
-		// Continue with default locale
-		error( 'Error loading translations', err );
+		warn(
+			`Translations unavailable for locale "${ locale }". Falling back to English.`
+		);
+		debug( 'Translation loading error details:', err );
 	}
 }


### PR DESCRIPTION
## What?

Ensure the editor does not fail to load when translation files are missing.

## Why?

If the `src/translations/` directory does not exist — for example, after setting up a new git worktree without running `make prep-translations` — the Vite dev server fails its dependency scan because the dynamic import in `localization.js` cannot resolve any translation files. This blocks the editor from loading entirely.

## How?

- Add a `.gitkeep` to `src/translations/` so the directory is always present in a fresh clone, giving Vite's dependency scanner something to resolve against.
- Update `.gitignore` to ignore translation file contents but preserve the `.gitkeep`.
- Downgrade the translation load failure from `error` to `warn` with a user-friendly message, since this is a recoverable situation that gracefully falls back to English.

## Testing Instructions

1. Clone the repository fresh (or set up a new worktree).
2. Run `make dev-server-force` (ensures Vite does not reuse caches).
3. Verify the following error is **not** present in the terminal output:

<details>
<summary>Previously observed error</summary>

```
  VITE v7.3.1  ready in 575 ms

  ➜  Local:   http://localhost:5174/
  ➜  Network: http://192.168.0.167:5174/
  ➜  press h + enter to show help
(!) Failed to run dependency scan. Skipping dependency pre-bundling. Error:   Failed to scan for dependencies from entries:
  /Users/[REDACTED]/Sites/a8c/GutenbergKit--test/src/index.html

  ✘ [ERROR] Could not resolve import("../translations/**/*.json")

    src/utils/localization.js:39:3:
      39 │       `../translations/${ locale }.json`
         ╵       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


    at failureErrorWithLog (/Users/[REDACTED]/Sites/a8c/GutenbergKit--test/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/[REDACTED]/Sites/a8c/GutenbergKit--test/node_modules/esbuild/lib/main.js:926:25
    at runOnEndCallbacks (/Users/[REDACTED]/Sites/a8c/GutenbergKit--test/node_modules/esbuild/lib/main.js:1307:45)
    at buildResponseToResult (/Users/[REDACTED]/Sites/a8c/GutenbergKit--test/node_modules/esbuild/lib/main.js:924:7)
    at /Users/[REDACTED]/Sites/a8c/GutenbergKit--test/node_modules/esbuild/lib/main.js:936:9
    at new Promise (<anonymous>)
    at requestCallbacks.on-end (/Users/[REDACTED]/Sites/a8c/GutenbergKit--test/node_modules/esbuild/lib/main.js:935:54)
    at handleRequest (/Users/[REDACTED]/Sites/a8c/GutenbergKit--test/node_modules/esbuild/lib/main.js:628:17)
    at handleIncomingPacket (/Users/[REDACTED]/Sites/a8c/GutenbergKit--test/node_modules/esbuild/lib/main.js:653:7)
    at Socket.readFromStdout (/Users/[REDACTED]/Sites/a8c/GutenbergKit--test/node_modules/esbuild/lib/main.js:581:7)
```

</details>

### Accessibility Testing Instructions

Not applicable — no UI changes.