### PR TITLE
feat: improve iOS offline editor experience

### DIFF
--- a/__mocks__/@wordpress/a11y.js
+++ b/__mocks__/@wordpress/a11y.js
@@ -1,0 +1,1 @@
+export const speak = () => {};

--- a/__mocks__/@wordpress/components/index.jsx
+++ b/__mocks__/@wordpress/components/index.jsx
@@ -1,3 +1,5 @@
+export const Icon = () => null;
+
 export const Notice = ( { children, onRemove } ) => (
 	<div data-testid="mock-notice">
 		<span>{ children }</span>

--- a/docs/code/preloading.md
+++ b/docs/code/preloading.md
@@ -264,6 +264,30 @@ site (for instance, the bundled editor in the demo app, or you just want an edit
 
 The JavaScript side falls back to `defaultPreloadData` which contains minimal type definitions to allow basic editor functionality.
 
+## Network Fallback Mode
+
+When `EditorConfiguration.networkFallbackMode` is set to `.automatic`, the editor gracefully handles network failures for sites that exist but are temporarily unreachable. Unlike offline mode (which skips networking entirely), network fallback mode attempts to fetch dependencies normally and only falls back to the bundled editor when a network error occurs.
+
+```swift
+let config = EditorConfigurationBuilder(
+    postType: .post,
+    siteURL: siteURL,
+    siteApiRoot: apiRoot
+)
+.setNetworkFallbackMode(.automatic)
+.build()
+```
+
+When a network error is caught (e.g., `notConnectedToInternet`, `timedOut`, `cannotConnectToHost`), `EditorService.prepare()` returns empty dependencies — the same as offline mode — so the bundled editor loads instead of showing an error. Non-network errors (e.g., decoding failures) still propagate normally.
+
+On the JavaScript side, an `OfflineIndicator` component displays a "Working Offline" status bar at the top of the editor when the device loses connectivity. The indicator automatically appears and disappears based on the browser's `online`/`offline` events.
+
+| Mode                              | Use case                                | Behavior                                                    |
+| --------------------------------- | --------------------------------------- | ----------------------------------------------------------- |
+| `isOfflineModeEnabled: true`      | No site (demo app, standalone editor)   | Skip all networking, use bundled defaults                   |
+| `networkFallbackMode: .automatic` | Site exists but may be offline          | Try network, fall back to bundled editor on network failure |
+| `networkFallbackMode: .disabled`  | Site exists, network required (default) | Network failures are fatal errors                           |
+
 ## Progress Reporting
 
 The preloading system reports its progress to give the user high-quality feedback about the loading process - if the user loads the

--- a/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
+++ b/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
@@ -292,8 +292,15 @@ class SitePreparationViewModel {
             siteURL: URL(string: config.siteUrl)!,
             siteApiRoot: URL(string: config.siteApiRoot)!
         )
-        .setShouldUseThemeStyles(false)
-        .setShouldUsePlugins(false)
+        // Optimistically enable theme styles and plugins so that
+        // previously-cached assets from an earlier online session can still be
+        // used. For sites that don't support these features, this is safe
+        // because EditorService won't be able to fetch the remote manifests
+        // while offline and the automatic network fallback will gracefully
+        // degrade to an empty asset bundle.
+        .setShouldUseThemeStyles(true)
+        .setShouldUsePlugins(true)
+        .setNetworkFallbackMode(.automatic)
         .setAuthHeader(config.authHeader)
         .setLogLevel(.debug)
         .build()

--- a/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
+++ b/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
@@ -57,6 +57,11 @@ struct SitePreparationView: View {
                 Toggle("Enable Native Inserter", isOn: $viewModel.enableNativeInserter)
                 Toggle("Enable Network Logging", isOn: $viewModel.enableNetworkLogging)
 
+                Picker("Network Fallback", selection: $viewModel.networkFallbackMode) {
+                    Text("Disabled").tag(NetworkFallbackMode.disabled)
+                    Text("Automatic").tag(NetworkFallbackMode.automatic)
+                }
+
                 if viewModel.postTypes.isEmpty {
                     HStack {
                         Text("Post Type")
@@ -155,6 +160,16 @@ class SitePreparationViewModel {
             guard let config = editorConfiguration else { return }
             editorConfiguration = config.toBuilder()
                 .setEnableNetworkLogging(newValue)
+                .build()
+        }
+    }
+
+    var networkFallbackMode: NetworkFallbackMode {
+        get { editorConfiguration?.networkFallbackMode ?? .disabled }
+        set {
+            guard let config = editorConfiguration else { return }
+            editorConfiguration = config.toBuilder()
+                .setNetworkFallbackMode(newValue)
                 .build()
         }
     }

--- a/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
+++ b/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
@@ -256,9 +256,15 @@ class SitePreparationViewModel {
                     )
                     self.client = client
 
-                    try await self.loadPostTypes()
-                    let newConfiguration = try await self.loadConfiguration(for: siteDetails)
-                    self.editorConfiguration = Self.applyDemoAppDefaults(to: newConfiguration)
+                    do {
+                        try await self.loadPostTypes()
+                        let newConfiguration = try await self.loadConfiguration(for: siteDetails)
+                        self.editorConfiguration = Self.applyDemoAppDefaults(to: newConfiguration)
+                    } catch let error where Self.isNetworkError(error) {
+                        self.postTypes = [.post, .page]
+                        let fallback = Self.buildOfflineConfiguration(for: siteDetails)
+                        self.editorConfiguration = Self.applyDemoAppDefaults(to: fallback)
+                    }
                 }
             } catch {
                 self.error = error
@@ -270,6 +276,27 @@ class SitePreparationViewModel {
         configuration.toBuilder()
             .setNativeInserterEnabled(true)
             .build()
+    }
+
+    private static func isNetworkError(_ error: Error) -> Bool {
+        if let wpError = error as? WpApiError,
+           case .RequestExecutionFailed(statusCode: _, redirects: _, reason: .deviceIsOfflineError) = wpError {
+            return true
+        }
+        return error is URLError
+    }
+
+    private static func buildOfflineConfiguration(for config: ConfiguredEditor) -> EditorConfiguration {
+        EditorConfigurationBuilder(
+            postType: .post,
+            siteURL: URL(string: config.siteUrl)!,
+            siteApiRoot: URL(string: config.siteApiRoot)!
+        )
+        .setShouldUseThemeStyles(false)
+        .setShouldUsePlugins(false)
+        .setAuthHeader(config.authHeader)
+        .setLogLevel(.debug)
+        .build()
     }
 
     /// Prepares the editor by caching all resources and preparing an `EditorDependencies` object to inject into the editor.

--- a/ios/Sources/GutenbergKit/Sources/Model/EditorConfiguration.swift
+++ b/ios/Sources/GutenbergKit/Sources/Model/EditorConfiguration.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+/// Controls whether the editor falls back to the bundled editor when network requests fail.
+///
+/// This is orthogonal to `isOfflineModeEnabled`:
+/// - `isOfflineModeEnabled`: No site exists; skip all networking entirely (demo/standalone use).
+/// - `networkFallbackMode`: A site exists, but if network fails, load the bundled editor
+///   instead of showing an error.
+public enum NetworkFallbackMode: Sendable, Hashable {
+    /// Network failures are fatal and propagate as errors (current default behavior).
+    case disabled
+    /// Automatically fall back to the bundled editor when network requests fail.
+    case automatic
+}
+
 /// Configuration settings for initializing the Gutenberg block editor.
 ///
 /// This struct contains all the parameters needed to configure the editor, including
@@ -48,6 +61,8 @@ public struct EditorConfiguration: Sendable, Hashable, Equatable {
   public let enableNetworkLogging: Bool
   /// Don't make HTTP requests
   public let isOfflineModeEnabled: Bool
+  /// Controls whether the editor falls back to the bundled editor on network failure
+  public let networkFallbackMode: NetworkFallbackMode
   /// A site ID derived from the URL that can be used in file system paths
   package let siteId: String
 
@@ -73,7 +88,8 @@ public struct EditorConfiguration: Sendable, Hashable, Equatable {
     editorAssetsEndpoint: URL?,
     logLevel: EditorLogLevel,
     enableNetworkLogging: Bool = false,
-    isOfflineModeEnabled: Bool = false
+    isOfflineModeEnabled: Bool = false,
+    networkFallbackMode: NetworkFallbackMode = .disabled
   ) {
     self.title = title
     self.content = content
@@ -96,6 +112,7 @@ public struct EditorConfiguration: Sendable, Hashable, Equatable {
     self.logLevel = logLevel
     self.enableNetworkLogging = enableNetworkLogging
     self.isOfflineModeEnabled = isOfflineModeEnabled
+    self.networkFallbackMode = networkFallbackMode
 
     // Derived Properties
     self.siteId = self.siteURL.host(percentEncoded: false) ?? UUID().uuidString
@@ -126,7 +143,8 @@ public struct EditorConfiguration: Sendable, Hashable, Equatable {
       editorAssetsEndpoint: editorAssetsEndpoint,
       logLevel: logLevel,
       enableNetworkLogging: enableNetworkLogging,
-      isOfflineModeEnabled: isOfflineModeEnabled
+      isOfflineModeEnabled: isOfflineModeEnabled,
+      networkFallbackMode: networkFallbackMode
     )
   }
 
@@ -172,6 +190,7 @@ public struct EditorConfigurationBuilder {
   private var logLevel: EditorLogLevel
   private var enableNetworkLogging: Bool
   private var isOfflineModeEnabled: Bool
+  private var networkFallbackMode: NetworkFallbackMode
 
   public init(
     title: String = "",
@@ -194,7 +213,8 @@ public struct EditorConfigurationBuilder {
     editorAssetsEndpoint: URL? = nil,
     logLevel: EditorLogLevel = .error,
     enableNetworkLogging: Bool = false,
-    isOfflineModeEnabled: Bool = false
+    isOfflineModeEnabled: Bool = false,
+    networkFallbackMode: NetworkFallbackMode = .disabled
   ) {
     self.title = title
     self.content = content
@@ -217,6 +237,7 @@ public struct EditorConfigurationBuilder {
     self.logLevel = logLevel
     self.enableNetworkLogging = enableNetworkLogging
     self.isOfflineModeEnabled = isOfflineModeEnabled
+    self.networkFallbackMode = networkFallbackMode
   }
 
   public func setTitle(_ title: String) -> EditorConfigurationBuilder {
@@ -348,6 +369,13 @@ public struct EditorConfigurationBuilder {
     return copy
   }
 
+  public func setNetworkFallbackMode(_ networkFallbackMode: NetworkFallbackMode)
+    -> EditorConfigurationBuilder {
+    var copy = self
+    copy.networkFallbackMode = networkFallbackMode
+    return copy
+  }
+
   /// Simplify conditionally applying a configuration change
   ///
   /// Sample Code:
@@ -395,7 +423,8 @@ public struct EditorConfigurationBuilder {
       editorAssetsEndpoint: editorAssetsEndpoint,
       logLevel: logLevel,
       enableNetworkLogging: enableNetworkLogging,
-      isOfflineModeEnabled: isOfflineModeEnabled
+      isOfflineModeEnabled: isOfflineModeEnabled,
+      networkFallbackMode: networkFallbackMode
     )
   }
 }

--- a/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
@@ -123,20 +123,20 @@ public actor EditorService {
             self.progress = nil
         }
 
-        async let settings = try prepareEditorSettings()
-        async let assetBundle = try self.prepareAssetBundle()
-        async let preloadList = try preparePreloadList()
-
-        // Automatically clean up old asset bundles
-        try await onceEvery(.seconds(86_400)) {
-            try await self.cleanup()
+        if self.configuration.networkFallbackMode == .automatic {
+            do {
+                return try await fetchDependencies()
+            } catch {
+                guard isNetworkError(error) else { throw error }
+                return EditorDependencies(
+                    editorSettings: .undefined,
+                    assetBundle: .empty,
+                    preloadList: nil
+                )
+            }
+        } else {
+            return try await fetchDependencies()
         }
-
-        return try await EditorDependencies(
-            editorSettings: settings,
-            assetBundle: assetBundle,
-            preloadList: preloadList
-        )
     }
 
     /// Clear unused on-disk resources associated with this service's configuration.
@@ -165,6 +165,35 @@ public actor EditorService {
             total: self.progress!.total)
         self.progress = progress
         await self.progressCallback?(progress)
+    }
+
+    private func fetchDependencies() async throws -> EditorDependencies {
+        async let settings = try prepareEditorSettings()
+        async let assetBundle = try self.prepareAssetBundle()
+        async let preloadList = try preparePreloadList()
+
+        // Automatically clean up old asset bundles
+        try await onceEvery(.seconds(86_400)) {
+            try await self.cleanup()
+        }
+
+        return try await EditorDependencies(
+            editorSettings: settings,
+            assetBundle: assetBundle,
+            preloadList: preloadList
+        )
+    }
+
+    private func isNetworkError(_ error: Error) -> Bool {
+        guard let urlError = error as? URLError else { return false }
+        return [
+            .notConnectedToInternet,
+            .networkConnectionLost,
+            .timedOut,
+            .cannotFindHost,
+            .cannotConnectToHost,
+            .dnsLookupFailed,
+        ].contains(urlError.code)
     }
 
     private func prepareEditorSettings() async throws -> EditorSettings {

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -13,6 +13,7 @@ import {
 import Editor from '../editor';
 import { onEditorContentChanged } from '../../utils/bridge';
 import EditorLoadNotice from '../editor-load-notice';
+import OfflineIndicator from '../offline-indicator';
 import './style.scss';
 
 /**
@@ -28,6 +29,7 @@ export default function Layout( props ) {
 
 	return (
 		<ErrorBoundary canCopyContent>
+			<OfflineIndicator />
 			<AutosaveMonitor autosave={ onEditorContentChanged } />
 			<Editor { ...editorProps }>
 				<EditorSnackbars />

--- a/src/components/offline-indicator/index.jsx
+++ b/src/components/offline-indicator/index.jsx
@@ -1,8 +1,10 @@
 /**
  * WordPress dependencies
  */
+import { Icon } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { offline } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -26,6 +28,7 @@ export default function OfflineIndicator() {
 
 	return (
 		<div className="offline-indicator">
+			<Icon icon={ offline } size={ 18 } />
 			{ __( 'Working Offline', 'gutenberg-kit' ) }
 		</div>
 	);

--- a/src/components/offline-indicator/index.jsx
+++ b/src/components/offline-indicator/index.jsx
@@ -27,7 +27,14 @@ export default function OfflineIndicator() {
 	}
 
 	return (
-		<div className="gutenberg-kit-offline-indicator">
+		<div
+			className="gutenberg-kit-offline-indicator"
+			role="status"
+			aria-label={ __(
+				'Network connection lost, working offline',
+				'gutenberg-kit'
+			) }
+		>
 			<Icon icon={ offline } size={ 18 } />
 			{ __( 'Working Offline', 'gutenberg-kit' ) }
 		</div>

--- a/src/components/offline-indicator/index.jsx
+++ b/src/components/offline-indicator/index.jsx
@@ -3,7 +3,7 @@
  */
 import { speak } from '@wordpress/a11y';
 import { Icon } from '@wordpress/components';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { offline } from '@wordpress/icons';
 
@@ -22,6 +22,18 @@ import './style.scss';
  */
 export default function OfflineIndicator() {
 	const { isConnected } = useNetworkConnectivity();
+
+	useEffect( () => {
+		if ( ! isConnected ) {
+			speak(
+				__(
+					'Network connection lost, working offline',
+					'gutenberg-kit'
+				),
+				'assertive'
+			);
+		}
+	}, [ isConnected ] );
 
 	if ( isConnected ) {
 		return null;
@@ -42,24 +54,10 @@ export default function OfflineIndicator() {
  */
 function useNetworkConnectivity() {
 	const [ isConnected, setIsConnected ] = useState( navigator.onLine );
-	const hasInitialized = useRef( false );
 
 	useEffect( () => {
 		const handleOnline = () => setIsConnected( true );
-		const handleOffline = () => {
-			setIsConnected( false );
-			speak(
-				__( 'Network connection lost', 'gutenberg-kit' ),
-				'assertive'
-			);
-		};
-
-		if ( ! hasInitialized.current ) {
-			hasInitialized.current = true;
-			if ( ! navigator.onLine ) {
-				handleOffline();
-			}
-		}
+		const handleOffline = () => setIsConnected( false );
 
 		window.addEventListener( 'online', handleOnline );
 		window.addEventListener( 'offline', handleOffline );

--- a/src/components/offline-indicator/index.jsx
+++ b/src/components/offline-indicator/index.jsx
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
+import { speak } from '@wordpress/a11y';
 import { Icon } from '@wordpress/components';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { offline } from '@wordpress/icons';
 
@@ -27,14 +28,7 @@ export default function OfflineIndicator() {
 	}
 
 	return (
-		<div
-			className="gutenberg-kit-offline-indicator"
-			role="status"
-			aria-label={ __(
-				'Network connection lost, working offline',
-				'gutenberg-kit'
-			) }
-		>
+		<div className="gutenberg-kit-offline-indicator">
 			<Icon icon={ offline } size={ 18 } />
 			{ __( 'Working Offline', 'gutenberg-kit' ) }
 		</div>
@@ -48,10 +42,24 @@ export default function OfflineIndicator() {
  */
 function useNetworkConnectivity() {
 	const [ isConnected, setIsConnected ] = useState( navigator.onLine );
+	const hasInitialized = useRef( false );
 
 	useEffect( () => {
 		const handleOnline = () => setIsConnected( true );
-		const handleOffline = () => setIsConnected( false );
+		const handleOffline = () => {
+			setIsConnected( false );
+			speak(
+				__( 'Network connection lost', 'gutenberg-kit' ),
+				'assertive'
+			);
+		};
+
+		if ( ! hasInitialized.current ) {
+			hasInitialized.current = true;
+			if ( ! navigator.onLine ) {
+				handleOffline();
+			}
+		}
 
 		window.addEventListener( 'online', handleOnline );
 		window.addEventListener( 'offline', handleOffline );

--- a/src/components/offline-indicator/index.jsx
+++ b/src/components/offline-indicator/index.jsx
@@ -27,7 +27,7 @@ export default function OfflineIndicator() {
 	}
 
 	return (
-		<div className="offline-indicator">
+		<div className="gutenberg-kit-offline-indicator">
 			<Icon icon={ offline } size={ 18 } />
 			{ __( 'Working Offline', 'gutenberg-kit' ) }
 		</div>

--- a/src/components/offline-indicator/index.jsx
+++ b/src/components/offline-indicator/index.jsx
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * Displays a thin status bar when the device is offline.
+ *
+ * The indicator automatically shows/hides based on the browser's online/offline
+ * events — no manual dismiss needed.
+ *
+ * @return {?Element} The rendered component or null when online.
+ */
+export default function OfflineIndicator() {
+	const { isConnected } = useNetworkConnectivity();
+
+	if ( isConnected ) {
+		return null;
+	}
+
+	return (
+		<div className="offline-indicator">
+			{ __( 'Working Offline', 'gutenberg-kit' ) }
+		</div>
+	);
+}
+
+/**
+ * Tracks browser network connectivity via online/offline events.
+ *
+ * @return {{ isConnected: boolean }} Whether the device is currently online.
+ */
+function useNetworkConnectivity() {
+	const [ isConnected, setIsConnected ] = useState( navigator.onLine );
+
+	useEffect( () => {
+		const handleOnline = () => setIsConnected( true );
+		const handleOffline = () => setIsConnected( false );
+
+		window.addEventListener( 'online', handleOnline );
+		window.addEventListener( 'offline', handleOffline );
+
+		return () => {
+			window.removeEventListener( 'online', handleOnline );
+			window.removeEventListener( 'offline', handleOffline );
+		};
+	}, [] );
+
+	return { isConnected };
+}

--- a/src/components/offline-indicator/index.test.jsx
+++ b/src/components/offline-indicator/index.test.jsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import OfflineIndicator from '.';
+
+vi.mock( '@wordpress/i18n' );
+
+describe( 'OfflineIndicator', () => {
+	let originalOnLine;
+
+	beforeEach( () => {
+		originalOnLine = navigator.onLine;
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( navigator, 'onLine', {
+			value: originalOnLine,
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	it( 'does not render when online', () => {
+		Object.defineProperty( navigator, 'onLine', {
+			value: true,
+			configurable: true,
+		} );
+
+		const { container } = render( <OfflineIndicator /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders "Working Offline" when navigator.onLine is false', () => {
+		Object.defineProperty( navigator, 'onLine', {
+			value: false,
+			configurable: true,
+		} );
+
+		render( <OfflineIndicator /> );
+		expect( screen.getByText( 'Working Offline' ) ).toBeInTheDocument();
+	} );
+
+	it( 'auto-hides when online event fires', () => {
+		Object.defineProperty( navigator, 'onLine', {
+			value: false,
+			configurable: true,
+		} );
+
+		render( <OfflineIndicator /> );
+		expect( screen.getByText( 'Working Offline' ) ).toBeInTheDocument();
+
+		act( () => {
+			window.dispatchEvent( new Event( 'online' ) );
+		} );
+
+		expect(
+			screen.queryByText( 'Working Offline' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 're-appears when offline event fires', () => {
+		Object.defineProperty( navigator, 'onLine', {
+			value: true,
+			configurable: true,
+		} );
+
+		render( <OfflineIndicator /> );
+		expect(
+			screen.queryByText( 'Working Offline' )
+		).not.toBeInTheDocument();
+
+		act( () => {
+			window.dispatchEvent( new Event( 'offline' ) );
+		} );
+
+		expect( screen.getByText( 'Working Offline' ) ).toBeInTheDocument();
+	} );
+} );

--- a/src/components/offline-indicator/style.scss
+++ b/src/components/offline-indicator/style.scss
@@ -1,8 +1,11 @@
 .offline-indicator {
+	align-items: center;
 	background-color: #dcdcde;
 	color: #1e1e1e;
+	display: flex;
 	font-size: 13px;
+	gap: 4px;
+	justify-content: center;
 	line-height: 1;
 	padding: 8px 16px;
-	text-align: center;
 }

--- a/src/components/offline-indicator/style.scss
+++ b/src/components/offline-indicator/style.scss
@@ -1,11 +1,17 @@
+@use "@wordpress/base-styles/colors" as wordpress;
+
 .gutenberg-kit-offline-indicator {
 	align-items: center;
-	background-color: #dcdcde;
-	color: #1e1e1e;
+	background-color: wordpress.$gray-200;
+	color: wordpress.$gray-800;
 	display: flex;
 	font-size: 13px;
 	gap: 4px;
 	justify-content: center;
 	line-height: 1;
 	padding: 8px 16px;
+
+	svg {
+		fill: wordpress.$gray-800;
+	}
 }

--- a/src/components/offline-indicator/style.scss
+++ b/src/components/offline-indicator/style.scss
@@ -1,0 +1,8 @@
+.offline-indicator {
+	background-color: #dcdcde;
+	color: #1e1e1e;
+	font-size: 13px;
+	line-height: 1;
+	padding: 8px 16px;
+	text-align: center;
+}

--- a/src/components/offline-indicator/style.scss
+++ b/src/components/offline-indicator/style.scss
@@ -10,6 +10,9 @@
 	justify-content: center;
 	line-height: 1;
 	padding: 8px 16px;
+	position: sticky;
+	top: 0;
+	z-index: 1;
 
 	svg {
 		fill: wordpress.$gray-800;

--- a/src/components/offline-indicator/style.scss
+++ b/src/components/offline-indicator/style.scss
@@ -1,4 +1,4 @@
-.offline-indicator {
+.gutenberg-kit-offline-indicator {
 	align-items: center;
 	background-color: #dcdcde;
 	color: #1e1e1e;


### PR DESCRIPTION
## What?

Improve the offline editor experience by adding network fallback mode support, an offline indicator, and graceful degradation when the device is offline.

## Why?

Fix CMM-1206.

When opening the iOS GutenbergKit editor while offline without a cached bundle, the editor fails to load entirely. The expected behavior is to fall back to the bundled editor and display a notice indicating that the user is offline.

## How?

- **Network fallback mode**: Add a `NetworkFallbackMode` enum and configuration property that enables automatic fallback to bundled resources when network requests fail (`EditorService`, `EditorConfiguration`).
- **Offline indicator**: Create an `OfflineIndicator` component that displays a "Working Offline" status bar with an offline icon when the device loses connectivity, using browser online/offline events. Uses `speak()` from `@wordpress/a11y` to announce "Network connection lost, working offline" for screen readers.
- **iOS demo app improvements**: Add a Network Fallback picker to the site configuration view. When the device is offline, fall back to offline defaults instead of showing an error, allowing the editor to still be opened.
- **Documentation**: Add a Network Fallback Mode section to the preloading docs.

## Testing Instructions

1. Open the iOS demo app.
2. Navigate to a configured site's Editor Configuration.
3. Enable "Automatic" for the Network Fallback picker.
4. Enable airplane mode.
5. Tap "Start" to open the editor.
6. Verify the editor loads with the bundled editor and displays a "Working Offline" indicator at the top with a wifi-off icon.
7. Disable airplane mode.
8. Verify the "Working Offline" indicator disappears.

### Accessibility Testing Instructions

1. Enable VoiceOver on the device.
2. With the editor open, enable airplane mode.
3. Verify VoiceOver announces "Network connection lost, working offline."
4. Navigate to the offline indicator and verify it reads "Working Offline."

## Screenshots or screencast

https://github.com/user-attachments/assets/935de5e6-1b38-434f-8b29-a46d7a053895