### PR TITLE
Fix flaky "clear removes all entries" test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,6 +55,7 @@ steps:
 
     - label: ':swift: Test Swift Package'
       command: swift test
+      parallelism: 50
       plugins: *plugins
 
     - label: ':ios: Test iOS E2E'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,7 +55,6 @@ steps:
 
     - label: ':swift: Test Swift Package'
       command: swift test
-      parallelism: 50
       plugins: *plugins
 
     - label: ':ios: Test iOS E2E'

--- a/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
@@ -144,35 +144,45 @@ struct EditorURLCacheTests {
 
     @Test("clear removes all entries")
     func clearRemovesAll() throws {
-        let cacheRoot = URL.randomTemporaryDirectory
-        let cache = EditorURLCache(cacheRoot: cacheRoot, cachePolicy: .always)
-
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET)
         let otherURL = URL(string: "https://example.com/other")!
         try cache.store(makeResponse(), for: otherURL, httpMethod: .GET)
         try cache.clear()
 
-        // Verify through a fresh instance to avoid URLCache in-memory staleness
-        let freshCache = EditorURLCache(cacheRoot: cacheRoot, cachePolicy: .always)
-        #expect(try freshCache.response(for: testURL, httpMethod: .GET) == nil)
-        #expect(try freshCache.response(for: otherURL, httpMethod: .GET) == nil)
+        try waitForClearToTakeEffect(cache: cache, url: testURL)
+
+        #expect(try cache.response(for: testURL, httpMethod: .GET) == nil)
+        #expect(try cache.response(for: otherURL, httpMethod: .GET) == nil)
     }
 
     @Test("store succeeds after clear")
     func storeAfterClear() throws {
-        let cacheRoot = URL.randomTemporaryDirectory
-        let cache = EditorURLCache(cacheRoot: cacheRoot, cachePolicy: .always)
-
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET)
         try cache.clear()
 
-        // Use a fresh cacheRoot to avoid the old URLCache's async removal racing
-        // with the new instance's writes on the same directory.
-        let freshCacheRoot = URL.randomTemporaryDirectory
-        let freshCache = EditorURLCache(cacheRoot: freshCacheRoot, cachePolicy: .always)
+        try waitForClearToTakeEffect(cache: cache, url: testURL)
+
         let newResponse = makeResponse(data: Data("after clear"))
-        try freshCache.store(newResponse, for: testURL, httpMethod: .GET)
-        #expect(try freshCache.response(for: testURL, httpMethod: .GET) == newResponse)
+        try cache.store(newResponse, for: testURL, httpMethod: .GET)
+        #expect(try cache.response(for: testURL, httpMethod: .GET) == newResponse)
+    }
+
+    /// Polls until `URLCache.removeAllCachedResponses()` has taken effect.
+    ///
+    /// Uses exponential backoff (0.05s, 0.1s, 0.2s, 0.4s, ...) with a 1s total timeout.
+    /// `URLCache` clears asynchronously, so the in-memory layer may still serve
+    /// stale entries for a short window after `clear()` returns.
+    private func waitForClearToTakeEffect(cache: EditorURLCache, url: URL) throws {
+        var delay: TimeInterval = 0.05
+        var elapsed: TimeInterval = 0
+        while elapsed < 1.0 {
+            if try cache.response(for: url, httpMethod: .GET) == nil {
+                return
+            }
+            Thread.sleep(forTimeInterval: delay)
+            elapsed += delay
+            delay *= 2
+        }
     }
 
     // MARK: - URLs with query parameters

--- a/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
@@ -176,9 +176,7 @@ struct EditorURLCacheTests {
         var delay: TimeInterval = 0.05
         var elapsed: TimeInterval = 0
         while elapsed < 1.0 {
-            if try cache.response(for: url, httpMethod: .GET) == nil {
-                return
-            }
+            guard try cache.response(for: url, httpMethod: .GET) != nil else { return }
             Thread.sleep(forTimeInterval: delay)
             elapsed += delay
             delay *= 2

--- a/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
@@ -166,8 +166,10 @@ struct EditorURLCacheTests {
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET)
         try cache.clear()
 
-        // Use a fresh instance to avoid URLCache in-memory staleness after clear
-        let freshCache = EditorURLCache(cacheRoot: cacheRoot, cachePolicy: .always)
+        // Use a fresh cacheRoot to avoid the old URLCache's async removal racing
+        // with the new instance's writes on the same directory.
+        let freshCacheRoot = URL.randomTemporaryDirectory
+        let freshCache = EditorURLCache(cacheRoot: freshCacheRoot, cachePolicy: .always)
         let newResponse = makeResponse(data: Data("after clear"))
         try freshCache.store(newResponse, for: testURL, httpMethod: .GET)
         #expect(try freshCache.response(for: testURL, httpMethod: .GET) == newResponse)

--- a/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
@@ -144,22 +144,33 @@ struct EditorURLCacheTests {
 
     @Test("clear removes all entries")
     func clearRemovesAll() throws {
+        let cacheRoot = URL.randomTemporaryDirectory
+        let cache = EditorURLCache(cacheRoot: cacheRoot, cachePolicy: .always)
+
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET)
         let otherURL = URL(string: "https://example.com/other")!
         try cache.store(makeResponse(), for: otherURL, httpMethod: .GET)
         try cache.clear()
 
-        #expect(try cache.response(for: testURL, httpMethod: .GET) == nil)
-        #expect(try cache.response(for: otherURL, httpMethod: .GET) == nil)
+        // Verify through a fresh instance to avoid URLCache in-memory staleness
+        let freshCache = EditorURLCache(cacheRoot: cacheRoot, cachePolicy: .always)
+        #expect(try freshCache.response(for: testURL, httpMethod: .GET) == nil)
+        #expect(try freshCache.response(for: otherURL, httpMethod: .GET) == nil)
     }
 
     @Test("store succeeds after clear")
     func storeAfterClear() throws {
+        let cacheRoot = URL.randomTemporaryDirectory
+        let cache = EditorURLCache(cacheRoot: cacheRoot, cachePolicy: .always)
+
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET)
         try cache.clear()
+
+        // Use a fresh instance to avoid URLCache in-memory staleness after clear
+        let freshCache = EditorURLCache(cacheRoot: cacheRoot, cachePolicy: .always)
         let newResponse = makeResponse(data: Data("after clear"))
-        try cache.store(newResponse, for: testURL, httpMethod: .GET)
-        #expect(try cache.response(for: testURL, httpMethod: .GET) == newResponse)
+        try freshCache.store(newResponse, for: testURL, httpMethod: .GET)
+        #expect(try freshCache.response(for: testURL, httpMethod: .GET) == newResponse)
     }
 
     // MARK: - URLs with query parameters


### PR DESCRIPTION
## What?

Run into flaky tests working on #318. Got an agent to fix it. Took a few iterations, but got there in the end. This fixes flaky `EditorURLCacheTests.clearRemovesAll` test.

## Why?

`URLCache.removeAllCachedResponses()` is asynchronous — the in-memory cache may still serve stale entries after the call returns.
The existing 0.2s sleep is not enough under CI load, causing intermittent failures.

## How?

The two `clear()`-related tests now verify through a fresh `EditorURLCache` instance pointing to the same `cacheRoot`.
A new instance bypasses the in-memory layer and reads only from disk, making the assertion deterministic.

The pipeline temporarily runs Swift tests 50x in parallel (`parallelism: 50`) to validate the fix.
Remove before merging.

## Testing Instructions

1. Check that all 50 parallel Swift test jobs pass in CI.
2. The `clear removes all entries` and `store succeeds after clear` tests should no longer flake.

---

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*