### PR TITLE
build: disable Dependabot major jQuery version upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
             update-types: ['version-update:semver-major']
           - dependency-name: 'react-dom' # react@>=19.x.x blocked by https://github.com/WordPress/gutenberg/issues/71336
             update-types: ['version-update:semver-major']
+          - dependency-name: 'jquery' # jquery@>=4.x.x blocked by https://core.trac.wordpress.org/ticket/60478
+            update-types: ['version-update:semver-major']


### PR DESCRIPTION
## What?

Ignore major jQuery version bumps in Dependabot.

## Why?

WordPress currently relies upon [jQuery 3.7.1](https://github.com/WordPress/wordpress-develop/blob/4e321a59694ef23d1bf68a2ba6e1dc04a2444b11/package.json#L95). The plan to [upgrade to jQuery 4.0](https://core.trac.wordpress.org/ticket/60478) has not yet landed in WordPress Core.

Follow-up to https://github.com/wordpress-mobile/GutenbergKit/pull/372#issuecomment-4075993694.

## How?

Add an `ignore` rule for `jquery` major version updates in `.github/dependabot.yml`, following the existing pattern for `eslint`, `react`, and `react-dom`.

## Testing Instructions

Verify the `dependabot.yml` syntax is valid.