### PR TITLE
build(deps-dev): upgrade to Vite 8 and @vitejs/plugin-react 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
 				"@testing-library/user-event": "^14.6.1",
 				"@types/react": "^19.2.7",
 				"@types/react-dom": "^19.2.3",
-				"@vitejs/plugin-react": "^5.1.4",
+				"@vitejs/plugin-react": "^6.0.1",
 				"@wordpress/dependency-extraction-webpack-plugin": "^6.41.0",
 				"@wordpress/env": "^11.2.0",
 				"@wordpress/eslint-plugin": "^24.3.0",
@@ -91,8 +91,7 @@
 				"react-devtools": "^7.0.1",
 				"react-devtools-core": "^7.0.1",
 				"sass-embedded": "^1.98.0",
-				"vite": "^7.3.1",
-				"vite-plugin-node-polyfills": "^0.25.0",
+				"vite": "^8.0.0",
 				"vitest": "^4.1.0"
 			}
 		},
@@ -259,6 +258,7 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -1659,38 +1659,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-transform-react-jsx-self": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-			"integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-react-jsx-source": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-			"integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"node_modules/@babel/plugin-transform-regenerator": {
 			"version": "7.29.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
@@ -2621,6 +2589,7 @@
 			"os": [
 				"aix"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2638,6 +2607,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2655,6 +2625,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2672,6 +2643,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2689,6 +2661,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2706,6 +2679,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2723,6 +2697,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2740,6 +2715,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2757,6 +2733,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2774,6 +2751,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2791,6 +2769,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2808,6 +2787,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2825,6 +2805,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2842,6 +2823,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2859,6 +2841,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2876,6 +2859,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2893,6 +2877,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2910,6 +2895,7 @@
 			"os": [
 				"netbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2927,6 +2913,7 @@
 			"os": [
 				"netbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2944,6 +2931,7 @@
 			"os": [
 				"openbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2961,6 +2949,7 @@
 			"os": [
 				"openbsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2978,6 +2967,7 @@
 			"os": [
 				"openharmony"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2995,6 +2985,7 @@
 			"os": [
 				"sunos"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -3012,6 +3003,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -3029,6 +3021,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -3046,6 +3039,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -3825,6 +3819,7 @@
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -4539,6 +4534,26 @@
 			"integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@oxc-project/runtime": {
+			"version": "0.115.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+			"integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.115.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+			"integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
 		},
 		"node_modules/@parcel/watcher": {
 			"version": "2.5.0",
@@ -6655,90 +6670,10 @@
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
-		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-			"integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@rollup/plugin-inject": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
-			"integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rollup/pluginutils": "^5.0.1",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.3"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"rollup": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@rollup/pluginutils": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
-			"integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0",
-				"estree-walker": "^2.0.2",
-				"picomatch": "^4.0.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"rollup": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@rollup/pluginutils/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-			"integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-			"integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+			"integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6747,12 +6682,15 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-			"integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+			"integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -6761,12 +6699,15 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-			"integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+			"integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
 			"cpu": [
 				"x64"
 			],
@@ -6775,26 +6716,15 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-			"integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-			"cpu": [
-				"arm64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-			"integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+			"integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
 			"cpu": [
 				"x64"
 			],
@@ -6803,12 +6733,15 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-			"integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+			"integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
 			"cpu": [
 				"arm"
 			],
@@ -6817,26 +6750,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-			"integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-			"cpu": [
-				"arm"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-			"integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+			"integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6845,12 +6767,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-			"integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+			"integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
 			"cpu": [
 				"arm64"
 			],
@@ -6859,40 +6784,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-			"integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-			"cpu": [
-				"loong64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-			"integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-			"integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+			"integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -6901,54 +6801,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-			"integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-			"cpu": [
-				"ppc64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-			"integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-			"integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-			"integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+			"integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
 			"cpu": [
 				"s390x"
 			],
@@ -6957,12 +6818,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-			"integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+			"integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
 			"cpu": [
 				"x64"
 			],
@@ -6971,12 +6835,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-			"integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+			"integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
 			"cpu": [
 				"x64"
 			],
@@ -6985,26 +6852,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-			"integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-			"cpu": [
-				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-			"integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+			"integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
 			"cpu": [
 				"arm64"
 			],
@@ -7013,12 +6869,49 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-			"integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+			"integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+			"integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1",
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+			"integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
 			"cpu": [
 				"arm64"
 			],
@@ -7027,26 +6920,15 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-			"integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-			"cpu": [
-				"ia32"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-			"integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+			"integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
 			"cpu": [
 				"x64"
 			],
@@ -7055,21 +6937,17 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-			"integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-			"cpu": [
-				"x64"
 			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.7",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+			"integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
 			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
+			"license": "MIT"
 		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
@@ -7359,51 +7237,6 @@
 			"integrity": "sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@types/babel__core": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7",
-				"@types/babel__generator": "*",
-				"@types/babel__template": "*",
-				"@types/babel__traverse": "*"
-			}
-		},
-		"node_modules/@types/babel__generator": {
-			"version": "7.6.8",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
-			"integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"node_modules/@types/babel__template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"node_modules/@types/babel__traverse": {
-			"version": "7.20.6",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
-			"integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.20.7"
-			}
 		},
 		"node_modules/@types/btoa-lite": {
 			"version": "1.0.2",
@@ -8169,24 +8002,29 @@
 			}
 		},
 		"node_modules/@vitejs/plugin-react": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
-			"integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+			"integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.29.0",
-				"@babel/plugin-transform-react-jsx-self": "^7.27.1",
-				"@babel/plugin-transform-react-jsx-source": "^7.27.1",
-				"@rolldown/pluginutils": "1.0.0-rc.3",
-				"@types/babel__core": "^7.20.5",
-				"react-refresh": "^0.18.0"
+				"@rolldown/pluginutils": "1.0.0-rc.7"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
 			},
 			"peerDependencies": {
-				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+				"@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+				"babel-plugin-react-compiler": "^1.0.0",
+				"vite": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@rolldown/plugin-babel": {
+					"optional": true
+				},
+				"babel-plugin-react-compiler": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@vitest/expect": {
@@ -12345,39 +12183,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/asn1.js": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"node_modules/asn1.js/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/assert": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"is-nan": "^1.3.2",
-				"object-is": "^1.1.5",
-				"object.assign": "^4.1.4",
-				"util": "^0.12.5"
-			}
-		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -12518,27 +12323,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -12568,13 +12352,6 @@
 			"dependencies": {
 				"require-from-string": "^2.0.2"
 			}
-		},
-		"node_modules/bn.js": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
-			"integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/body-parser": {
 			"version": "1.20.4",
@@ -12785,156 +12562,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/brorand": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/browser-resolve": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
-			"integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"resolve": "^1.17.0"
-			}
-		},
-		"node_modules/browserify-aes": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/browserify-cipher": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
-			}
-		},
-		"node_modules/browserify-des": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"node_modules/browserify-rsa": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
-			"integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bn.js": "^5.2.1",
-				"randombytes": "^2.1.0",
-				"safe-buffer": "^5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/browserify-sign": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
-			"integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"bn.js": "^5.2.2",
-				"browserify-rsa": "^4.1.1",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"elliptic": "^6.6.1",
-				"inherits": "^2.0.4",
-				"parse-asn1": "^5.1.9",
-				"readable-stream": "^2.3.8",
-				"safe-buffer": "^5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/browserify-sign/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/browserify-sign/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/browserify-sign/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/browserify-zlib": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pako": "~1.0.5"
-			}
-		},
 		"node_modules/browserslist": {
 			"version": "4.28.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -12976,31 +12603,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/buffer": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.1.13"
-			}
-		},
 		"node_modules/buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -13025,13 +12627,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/buffer-xor": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/builtin-modules": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
@@ -13044,13 +12639,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/builtin-status-codes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-			"integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
@@ -13348,21 +12936,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/cipher-base": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
-			"integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"safe-buffer": "^5.2.1",
-				"to-buffer": "^1.2.2"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/clean-git-ref": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
@@ -13627,12 +13200,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/console-browserify": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
-			"dev": true
-		},
 		"node_modules/constant-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -13643,13 +13210,6 @@
 				"tslib": "^2.0.3",
 				"upper-case": "^2.0.2"
 			}
-		},
-		"node_modules/constants-browserify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-			"integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/content-disposition": {
 			"version": "0.5.4",
@@ -13782,24 +13342,6 @@
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/create-ecdh": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
-			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.5.3"
-			}
-		},
-		"node_modules/create-ecdh/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/create-error-class": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -13812,42 +13354,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/create-hash": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
-			}
-		},
-		"node_modules/create-hmac": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
-			}
-		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -13862,33 +13368,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/crypto-browserify": {
-			"version": "3.12.1",
-			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
-			"integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"browserify-cipher": "^1.0.1",
-				"browserify-sign": "^4.2.3",
-				"create-ecdh": "^4.0.4",
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"diffie-hellman": "^5.0.3",
-				"hash-base": "~3.0.4",
-				"inherits": "^2.0.4",
-				"pbkdf2": "^3.1.2",
-				"public-encrypt": "^4.0.3",
-				"randombytes": "^2.1.0",
-				"randomfill": "^1.0.4"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/crypto-random-string": {
@@ -14215,17 +13694,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/des.js": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
-			"integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
-			}
-		},
 		"node_modules/destroy": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -14278,25 +13746,6 @@
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
 			"integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/diffie-hellman": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
-			}
-		},
-		"node_modules/diffie-hellman/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -14370,19 +13819,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/domain-browser": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
-			"integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://bevry.me/fund"
 			}
 		},
 		"node_modules/domelementtype": {
@@ -14525,29 +13961,6 @@
 			"version": "16.18.126",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
 			"integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/elliptic": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-			"integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bn.js": "^4.11.9",
-				"brorand": "^1.1.0",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.1",
-				"inherits": "^2.0.4",
-				"minimalistic-assert": "^1.0.1",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
-		"node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -14835,6 +14248,8 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -15636,13 +15051,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -15669,19 +15077,9 @@
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.x"
-			}
-		},
-		"node_modules/evp_bytestokey": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
 			}
 		},
 		"node_modules/execa": {
@@ -15908,9 +15306,9 @@
 			"peer": true
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+			"integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -15918,15 +15316,12 @@
 					"url": "https://github.com/sponsors/NaturalIntelligence"
 				}
 			],
-			"license": "MIT",
-			"dependencies": {
-				"path-expression-matcher": "^1.1.3"
-			}
+			"license": "MIT"
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.5.7",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
-			"integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+			"integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
 			"dev": true,
 			"funding": [
 				{
@@ -15936,9 +15331,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"fast-xml-builder": "^1.1.4",
-				"path-expression-matcher": "^1.1.3",
-				"strnum": "^2.2.0"
+				"fast-xml-builder": "^1.0.0",
+				"strnum": "^2.1.2"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -16099,9 +15493,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+			"integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -16692,31 +16086,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/hash-base": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
-			"integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"safe-buffer": "^5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/hash.js": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
-			}
-		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -16752,18 +16121,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.7.6"
-			}
-		},
-		"node_modules/hmac-drbg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"node_modules/hoist-non-react-statics": {
@@ -16892,13 +16249,6 @@
 				"node": ">=10.19.0"
 			}
 		},
-		"node_modules/https-browserify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-			"integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/human-signals": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -16920,27 +16270,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -17089,23 +16418,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
-			}
-		},
-		"node_modules/is-arguments": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-array-buffer": {
@@ -17450,23 +16762,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-nan": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-negative-zero": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -17772,16 +17067,6 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/isomorphic-timers-promises": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
-			"integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/isomorphic.js": {
 			"version": "0.2.5",
@@ -18224,6 +17509,277 @@
 				"url": "https://github.com/sponsors/dmonad"
 			}
 		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss/node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/line-height": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
@@ -18501,18 +18057,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/md5.js": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
 		"node_modules/mdn-data": {
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -18587,27 +18131,6 @@
 				"node": ">=8.6"
 			}
 		},
-		"node_modules/miller-rabin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
-			},
-			"bin": {
-				"miller-rabin": "bin/miller-rabin"
-			}
-		},
-		"node_modules/miller-rabin/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -18673,20 +18196,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/minimalistic-assert": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/minimalistic-crypto-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.5",
@@ -18933,52 +18442,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/node-stdlib-browser": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz",
-			"integrity": "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"assert": "^2.0.0",
-				"browser-resolve": "^2.0.0",
-				"browserify-zlib": "^0.2.0",
-				"buffer": "^5.7.1",
-				"console-browserify": "^1.1.0",
-				"constants-browserify": "^1.0.0",
-				"create-require": "^1.1.1",
-				"crypto-browserify": "^3.12.1",
-				"domain-browser": "4.22.0",
-				"events": "^3.0.0",
-				"https-browserify": "^1.0.0",
-				"isomorphic-timers-promises": "^1.0.1",
-				"os-browserify": "^0.3.0",
-				"path-browserify": "^1.0.1",
-				"pkg-dir": "^5.0.0",
-				"process": "^0.11.10",
-				"punycode": "^1.4.1",
-				"querystring-es3": "^0.2.1",
-				"readable-stream": "^3.6.0",
-				"stream-browserify": "^3.0.0",
-				"stream-http": "^3.2.0",
-				"string_decoder": "^1.0.0",
-				"timers-browserify": "^2.0.4",
-				"tty-browserify": "0.0.1",
-				"url": "^0.11.4",
-				"util": "^0.12.4",
-				"vm-browserify": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/node-stdlib-browser/node_modules/punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/normalize-url": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
@@ -19026,23 +18489,6 @@
 			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-is": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1"
-			},
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -19359,13 +18805,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/os-browserify": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-			"integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/own-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -19589,23 +19028,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/parse-asn1": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
-			"integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"asn1.js": "^4.10.1",
-				"browserify-aes": "^1.2.0",
-				"evp_bytestokey": "^1.0.3",
-				"pbkdf2": "^3.1.5",
-				"safe-buffer": "^5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -19716,13 +19138,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/path-browserify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/path-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
@@ -19741,22 +19156,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/path-expression-matcher": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-			"integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/path-is-absolute": {
@@ -19838,24 +19237,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/pbkdf2": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
-			"integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"create-hash": "^1.2.0",
-				"create-hmac": "^1.1.7",
-				"ripemd160": "^2.0.3",
-				"safe-buffer": "^5.2.1",
-				"sha.js": "^2.4.12",
-				"to-buffer": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -19890,19 +19271,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/pkg-dir": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"find-up": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/playwright": {
@@ -19963,9 +19331,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -20122,16 +19490,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6.0"
-			}
-		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -20194,28 +19552,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/public-encrypt": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1",
-				"safe-buffer": "^5.1.2"
-			}
-		},
-		"node_modules/public-encrypt/node_modules/bn.js": {
-			"version": "4.12.3",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-			"integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/pump": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -20253,15 +19589,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/querystring-es3": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-			"integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4.x"
-			}
-		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -20294,27 +19621,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
-		"node_modules/randomfill": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"randombytes": "^2.0.5",
-				"safe-buffer": "^5.1.0"
 			}
 		},
 		"node_modules/range-parser": {
@@ -20615,16 +19921,6 @@
 			"resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
 			"integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
 			"license": "MIT"
-		},
-		"node_modules/react-refresh": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-			"integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/react-remove-scroll-bar": {
 			"version": "2.3.8",
@@ -21006,83 +20302,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/ripemd160": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
-			"integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"hash-base": "^3.1.2",
-				"inherits": "^2.0.4"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/ripemd160/node_modules/hash-base": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
-			"integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"readable-stream": "^2.3.8",
-				"safe-buffer": "^5.2.1",
-				"to-buffer": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/ripemd160/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/ripemd160/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/ripemd160/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/roarr": {
 			"version": "2.15.4",
 			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -21102,50 +20321,46 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/rollup": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+		"node_modules/rolldown": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+			"integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "1.0.8"
+				"@oxc-project/types": "=0.115.0",
+				"@rolldown/pluginutils": "1.0.0-rc.9"
 			},
 			"bin": {
-				"rollup": "dist/bin/rollup"
+				"rolldown": "bin/cli.mjs"
 			},
 			"engines": {
-				"node": ">=18.0.0",
-				"npm": ">=8.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.59.0",
-				"@rollup/rollup-android-arm64": "4.59.0",
-				"@rollup/rollup-darwin-arm64": "4.59.0",
-				"@rollup/rollup-darwin-x64": "4.59.0",
-				"@rollup/rollup-freebsd-arm64": "4.59.0",
-				"@rollup/rollup-freebsd-x64": "4.59.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.59.0",
-				"@rollup/rollup-linux-arm64-musl": "4.59.0",
-				"@rollup/rollup-linux-loong64-gnu": "4.59.0",
-				"@rollup/rollup-linux-loong64-musl": "4.59.0",
-				"@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-				"@rollup/rollup-linux-ppc64-musl": "4.59.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-				"@rollup/rollup-linux-riscv64-musl": "4.59.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.59.0",
-				"@rollup/rollup-linux-x64-gnu": "4.59.0",
-				"@rollup/rollup-linux-x64-musl": "4.59.0",
-				"@rollup/rollup-openbsd-x64": "4.59.0",
-				"@rollup/rollup-openharmony-arm64": "4.59.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.59.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.59.0",
-				"@rollup/rollup-win32-x64-gnu": "4.59.0",
-				"@rollup/rollup-win32-x64-msvc": "4.59.0",
-				"fsevents": "~2.3.2"
+				"@rolldown/binding-android-arm64": "1.0.0-rc.9",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
 			}
+		},
+		"node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+			"integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/route-recognizer": {
 			"version": "0.3.4",
@@ -21970,13 +21185,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -22354,30 +21562,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/stream-browserify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-			"integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "~2.0.4",
-				"readable-stream": "^3.5.0"
-			}
-		},
-		"node_modules/stream-http": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
-			"integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"builtin-status-codes": "^3.0.0",
-				"inherits": "^2.0.4",
-				"readable-stream": "^3.6.0",
-				"xtend": "^4.0.2"
-			}
-		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -22663,9 +21847,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
-			"integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+			"integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -23036,19 +22220,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/timers-browserify": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
-			"integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"setimmediate": "^1.0.4"
-			},
-			"engines": {
-				"node": ">=0.6.0"
-			}
-		},
 		"node_modules/tiny-invariant": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -23307,13 +22478,6 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true,
 			"license": "0BSD"
-		},
-		"node_modules/tty-browserify": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
-			"integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -23760,20 +22924,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/url": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
-			"integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"punycode": "^1.4.1",
-				"qs": "^6.12.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/url-parse-lax": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -23786,13 +22936,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/url/node_modules/punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/use-callback-ref": {
 			"version": "1.3.3",
@@ -23855,20 +22998,6 @@
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/util": {
-			"version": "0.12.5",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"is-arguments": "^1.0.4",
-				"is-generator-function": "^1.0.7",
-				"is-typed-array": "^1.1.3",
-				"which-typed-array": "^1.1.2"
-			}
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -23917,17 +23046,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+			"integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.27.0",
-				"fdir": "^6.5.0",
+				"@oxc-project/runtime": "0.115.0",
+				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.3",
-				"postcss": "^8.5.6",
-				"rollup": "^4.43.0",
+				"postcss": "^8.5.8",
+				"rolldown": "1.0.0-rc.9",
 				"tinyglobby": "^0.2.15"
 			},
 			"bin": {
@@ -23944,9 +23073,10 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.0.0-alpha.31",
+				"esbuild": "^0.27.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
-				"lightningcss": "^1.21.0",
 				"sass": "^1.70.0",
 				"sass-embedded": "^1.70.0",
 				"stylus": ">=0.54.8",
@@ -23959,13 +23089,16 @@
 				"@types/node": {
 					"optional": true
 				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
 				"jiti": {
 					"optional": true
 				},
 				"less": {
-					"optional": true
-				},
-				"lightningcss": {
 					"optional": true
 				},
 				"sass": {
@@ -23987,41 +23120,6 @@
 					"optional": true
 				},
 				"yaml": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vite-plugin-node-polyfills": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.25.0.tgz",
-			"integrity": "sha512-rHZ324W3LhfGPxWwQb2N048TThB6nVvnipsqBUJEzh3R9xeK9KI3si+GMQxCuAcpPJBVf0LpDtJ+beYzB3/chg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@rollup/plugin-inject": "^5.0.5",
-				"node-stdlib-browser": "^1.3.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/davidmyersdev"
-			},
-			"peerDependencies": {
-				"vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-			}
-		},
-		"node_modules/vite/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
 					"optional": true
 				}
 			}
@@ -24140,13 +23238,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
-		},
-		"node_modules/vm-browserify": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/w3c-xmlserializer": {
 			"version": "5.0.0",
@@ -24745,16 +23836,6 @@
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4"
-			}
 		},
 		"node_modules/y-protocols": {
 			"version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"@testing-library/user-event": "^14.6.1",
 		"@types/react": "^19.2.7",
 		"@types/react-dom": "^19.2.3",
-		"@vitejs/plugin-react": "^5.1.4",
+		"@vitejs/plugin-react": "^6.0.1",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.41.0",
 		"@wordpress/env": "^11.2.0",
 		"@wordpress/eslint-plugin": "^24.3.0",
@@ -108,8 +108,7 @@
 		"react-devtools": "^7.0.1",
 		"react-devtools-core": "^7.0.1",
 		"sass-embedded": "^1.98.0",
-		"vite": "^7.3.1",
-		"vite-plugin-node-polyfills": "^0.25.0",
+		"vite": "^8.0.0",
 		"vitest": "^4.1.0"
 	}
 }

--- a/patches/README.md
+++ b/patches/README.md
@@ -31,6 +31,10 @@ Existing patches should be described and justified here.
 
 -   Add `./build-style/*` to the package's `exports` field to allow importing CSS files. The package added an `exports` field in [this commit](https://github.com/WordPress/gutenberg/commit/f13dcfaa60) that restricts importable paths, but omitted CSS assets. Note: Creating this patch required using `--exclude='^$'` due to a [patch-package limitation](https://github.com/ds300/patch-package/issues/250).
 
+### `mousetrap`
+
+-   Fix the `global-bind` plugin failing under Vite 8's Rolldown bundler due to import reordering. Rolldown may execute the `global-bind` side-effect import before the main `mousetrap` module ([rolldown#6436](https://github.com/rolldown/rolldown/issues/6436), [vite#5142](https://github.com/vitejs/vite/issues/5142)), so `window.Mousetrap` is not yet set when the plugin's IIFE checks `typeof Mousetrap`. The patch adds a `require("mousetrap")` fallback so the plugin resolves Mousetrap via the module system instead of relying on the global. We opted for a targeted patch over Rolldown's `output.strictExecutionOrder` option to avoid the bundle size increase that option incurs.
+
 ### `react-autosize-textarea`
 
 -   Fix CJS/ESM interop issue where Vite's esbuild pre-bundling wraps the `__esModule`-flagged default export as a module object instead of the actual React component, causing the `PlainText` component to crash. The patch removes the `__esModule` flag and switches from `exports["default"]` to `module.exports`, matching [Gutenberg's upstream fix](https://github.com/WordPress/gutenberg/pull/73822).

--- a/patches/mousetrap+1.6.5.patch
+++ b/patches/mousetrap+1.6.5.patch
@@ -1,0 +1,10 @@
+diff --git a/node_modules/mousetrap/plugins/global-bind/mousetrap-global-bind.js b/node_modules/mousetrap/plugins/global-bind/mousetrap-global-bind.js
+index 6b86a99..15f0c59 100644
+--- a/node_modules/mousetrap/plugins/global-bind/mousetrap-global-bind.js
++++ b/node_modules/mousetrap/plugins/global-bind/mousetrap-global-bind.js
+@@ -43,4 +43,4 @@
+     };
+ 
+     Mousetrap.init();
+-}) (typeof Mousetrap !== "undefined" ? Mousetrap : undefined);
++}) (typeof require !== "undefined" ? require("mousetrap") : typeof Mousetrap !== "undefined" ? Mousetrap : undefined);

--- a/src/stubs/node-modules.js
+++ b/src/stubs/node-modules.js
@@ -1,0 +1,12 @@
+/**
+ * Empty stub for Node.js modules imported by PostCSS.
+ *
+ * PostCSS marks `path`, `fs`, `url`, and `source-map-js` as `false` in its
+ * `browser` field, but `@wordpress/block-editor` imports PostCSS via direct
+ * file paths (e.g., `postcss/lib/processor`), bypassing that field. This stub
+ * is aliased to those modules so Vite resolves them without emitting
+ * "Module has been externalized for browser compatibility" warnings.
+ *
+ * @see https://github.com/postcss/postcss/blob/main/package.json
+ */
+export default {};

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,6 @@
  */
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import MagicString from 'magic-string';
 
 /**
@@ -11,18 +10,27 @@ import MagicString from 'magic-string';
  */
 import { defaultRequestToExternal } from '@wordpress/dependency-extraction-webpack-plugin/lib/util';
 
+// Stub for Node.js modules imported by PostCSS via @wordpress/block-editor.
+// PostCSS marks these as `false` in its `browser` field, but the direct file
+// path imports (e.g., `postcss/lib/processor`) bypass that field.
+const nodeModuleStub = new URL( './src/stubs/node-modules.js', import.meta.url )
+	.pathname;
+
 export default defineConfig( {
 	base: '',
 	build: {
 		outDir: '../dist',
 		target: 'esnext',
 	},
-	plugins: [
-		nodePolyfills(),
-		react(),
-		wordPressExternals(),
-		reactDevTools(),
-	],
+	resolve: {
+		alias: {
+			path: nodeModuleStub,
+			fs: nodeModuleStub,
+			url: nodeModuleStub,
+			'source-map-js': nodeModuleStub,
+		},
+	},
+	plugins: [ react(), wordPressExternals(), reactDevTools() ],
 	root: 'src',
 	css: {
 		preprocessorOptions: {


### PR DESCRIPTION
## What?

Upgrade Vite from v7 to v8 and `@vitejs/plugin-react` from v5 to v6.

Supersedes https://github.com/wordpress-mobile/GutenbergKit/pull/373 and #380.

## Why?

Vite 8 replaces esbuild and Rollup with [Rolldown and Oxc](https://vite.dev/blog/announcing-vite8), the new Rust-based build toolchain. This keeps us on the latest major version and unblocks upgrading `@vitejs/plugin-react` to v6, which was [required by the Dependabot PR](https://github.com/wordpress-mobile/GutenbergKit/pull/373#issuecomment-4076188720).

## How?

### Dependency changes (`package.json`)

- `vite`: `^7.3.1` → `^8.0.0`
- `@vitejs/plugin-react`: `^5.1.4` → `^6.0.1`
- Removed `vite-plugin-node-polyfills` (does not support Vite 8, and was replaced by a lighter approach)

### Replace `vite-plugin-node-polyfills` with resolve stubs (`vite.config.js`, `src/stubs/node-modules.js`)

PostCSS imports Node.js modules (`path`, `fs`, `url`, `source-map-js`) that don't exist in browsers. PostCSS marks these as `false` in its `browser` field, but `@wordpress/block-editor` imports PostCSS via direct file paths (e.g., `postcss/lib/processor`), bypassing that field and causing Vite to emit "Module has been externalized for browser compatibility" warnings.

The `vite-plugin-node-polyfills` plugin suppressed these by providing full browser polyfills (~600 KB in dependencies), but PostCSS never actually calls these modules at runtime—it guards usage behind `Boolean()` checks. A single empty stub module aliased via `resolve.alias` achieves the same result with zero bundle impact and no external dependencies.

### Patch mousetrap global-bind plugin (`patches/mousetrap+1.6.5.patch`)

Vite 8's Rolldown bundler may reorder side-effect imports relative to value imports ([rolldown/rolldown#6436](https://github.com/rolldown/rolldown/issues/6436), [vitejs/vite#5142](https://github.com/vitejs/vite/issues/5142)). This caused mousetrap's `global-bind` plugin to execute before the main mousetrap module, so `window.Mousetrap` was not yet set and `bindGlobal` was never added to the prototype—breaking `@wordpress/keyboard-shortcuts`.

The patch adds a `require("mousetrap")` fallback so the plugin resolves Mousetrap via the module system instead of relying on the global. This is preferred over Rolldown's [`output.strictExecutionOrder`](https://rolldown.rs/reference/OutputOptions.strictExecutionOrder) option, which would increase bundle size by injecting runtime helpers across the entire bundle.

## Testing Instructions

1. Run the dev server (`make dev-server`) and verify the editor loads without errors in the browser console.
2. Run `make build` and verify it completes successfully.
3. Run `make test-js` and verify all tests pass.
4. Test with plugins that register keyboard shortcuts (e.g., Jetpack AI Assistant[^1]) and verify no `mousetrap[bindGlobal]` errors appear.

[^1]: Requires adding a site to the demo app that has an active Jetpack connection—e.g., WoW/Atomic. 

### Accessibility Testing Instructions

N/A, no user-facing changes.