### PR TITLE
test: add E2E tests for third-party block types

### DIFF
--- a/e2e/editor-page.js
+++ b/e2e/editor-page.js
@@ -76,6 +76,7 @@ export default class EditorPage {
 				window.wp?.data
 					?.select( 'core/editor' )
 					?.__unstableIsEditorReady?.(),
+			null,
 			{ timeout: 30_000 }
 		);
 	}

--- a/e2e/embed-content.spec.js
+++ b/e2e/embed-content.spec.js
@@ -105,6 +105,7 @@ test.describe( 'Embedded Content', () => {
 					embed?.attributes?.providerNameSlug
 				);
 			},
+			null,
 			{ timeout: 30_000 }
 		);
 
@@ -138,6 +139,7 @@ test.describe( 'Embedded Content', () => {
 					.getBlocks();
 				return blocks[ 0 ]?.attributes?.url;
 			},
+			null,
 			{ timeout: 30_000 }
 		);
 

--- a/e2e/gallery-block.spec.js
+++ b/e2e/gallery-block.spec.js
@@ -47,6 +47,7 @@ test.describe( 'Gallery Block', () => {
 					)
 				);
 			},
+			null,
 			{ timeout: 30_000 }
 		);
 
@@ -86,6 +87,7 @@ test.describe( 'Gallery Block', () => {
 					gallery.innerBlocks[ 0 ].attributes.id > 0
 				);
 			},
+			null,
 			{ timeout: 30_000 }
 		);
 

--- a/e2e/third-party-blocks.spec.js
+++ b/e2e/third-party-blocks.spec.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import path from 'node:path';
+import { test, expect } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import EditorPage from './editor-page';
+
+const TEST_IMAGE_1 = path.resolve(
+	import.meta.dirname,
+	'assets/test-image.png'
+);
+const TEST_IMAGE_2 = path.resolve(
+	import.meta.dirname,
+	'assets/test-image-2.png'
+);
+
+test.describe( 'Third-Party Blocks', () => {
+	test( 'should load and insert a third-party block type', async ( {
+		page,
+	} ) => {
+		const editor = new EditorPage( page );
+		await editor.setup( { plugins: true } );
+
+		// Verify the Jetpack tiled-gallery block type is registered.
+		const isRegistered = await page.evaluate( () =>
+			Boolean( window.wp.blocks.getBlockType( 'jetpack/tiled-gallery' ) )
+		);
+		expect( isRegistered ).toBe( true );
+
+		await editor.insertBlock( 'jetpack/tiled-gallery' );
+
+		const blocks = await editor.getBlocks();
+		expect( blocks ).toHaveLength( 1 );
+		expect( blocks[ 0 ].name ).toBe( 'jetpack/tiled-gallery' );
+	} );
+
+	test( 'should upload images to the Tiled Gallery block', async ( {
+		page,
+	} ) => {
+		const editor = new EditorPage( page );
+		await editor.setup( { plugins: true } );
+
+		await editor.insertBlock( 'jetpack/tiled-gallery' );
+
+		// Use the "Upload" button to trigger the file input.
+		const fileChooserPromise = page.waitForEvent( 'filechooser' );
+		await page
+			.getByRole( 'button', { name: 'Upload', exact: true } )
+			.click();
+		const fileChooser = await fileChooserPromise;
+		await fileChooser.setFiles( [ TEST_IMAGE_1, TEST_IMAGE_2 ] );
+
+		// Wait for both images to upload by checking the gallery's `ids` attribute.
+		// The Tiled Gallery stores images as attributes (not inner blocks).
+		// `ids` contains null entries while uploads are in-flight and positive
+		// integers once the uploads complete.
+		await page.waitForFunction(
+			() => {
+				const blocks = window.wp.data
+					.select( 'core/block-editor' )
+					.getBlocks();
+				const gallery = blocks[ 0 ];
+				return (
+					gallery?.attributes?.ids?.length === 2 &&
+					gallery.attributes.ids.every( ( id ) => id > 0 )
+				);
+			},
+			null,
+			{ timeout: 30_000 }
+		);
+
+		const blocks = await editor.getBlocks();
+		const gallery = blocks[ 0 ];
+		expect( gallery.name ).toBe( 'jetpack/tiled-gallery' );
+		expect( gallery.attributes.ids ).toHaveLength( 2 );
+		expect( gallery.attributes.images ).toHaveLength( 2 );
+	} );
+} );


### PR DESCRIPTION
## What?

Adds E2E tests that verify third-party block types (loaded via the editor-assets endpoint) register and function correctly in the GutenbergKit editor. The Jetpack Tiled Gallery block is used as the test subject.

Also fixes a latent bug in existing `waitForFunction` calls across the E2E suite where `{ timeout: 30_000 }` was being passed as the `arg` parameter instead of the `options` parameter, causing the intended 30s timeout to be silently ignored.

## Why?

Third-party blocks (e.g. Jetpack blocks) are loaded dynamically via the `wpcom/v2/editor-assets` endpoint, a path distinct from core block registration. Without automated coverage, regressions in plugin asset loading or block registration could go undetected.

The `waitForFunction` timeout bug meant upload-heavy tests were running against the 10s `actionTimeout` rather than the intended 30s, making them more susceptible to flakiness in slow environments.

## How?

- `e2e/third-party-blocks.spec.js` — New test file with two tests:
  1. Verifies `jetpack/tiled-gallery` is registered after the editor loads with `plugins: true` in the GBKit config (which triggers the editor-assets fetch).
  2. Uploads two images to the Tiled Gallery block and waits for the `ids` attribute to be populated with WordPress media IDs (the Tiled Gallery stores images as block attributes rather than inner blocks, unlike `core/gallery`).
- `e2e/gallery-block.spec.js`, `e2e/embed-content.spec.js`, `e2e/editor-page.js` — Fixed `waitForFunction` calls to use the explicit 3-argument form `(fn, null, { timeout })` so the timeout option is correctly applied.

## Testing Instructions

1. Run `make wp-env-start` to start the local WordPress environment.
2. Run `npx playwright test e2e/third-party-blocks.spec.js` and confirm both tests pass.
3. Run `npx playwright test e2e/gallery-block.spec.js e2e/embed-content.spec.js` and confirm all tests still pass.

### Accessibility Testing Instructions

N/A — no UI changes.