### PR TITLE
build: disable minor eslint-plugin-react-refresh upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
             update-types: ['version-update:semver-major']
           - dependency-name: 'jquery' # jquery@>=4.x.x blocked by https://core.trac.wordpress.org/ticket/60478
             update-types: ['version-update:semver-major']
+          - dependency-name: 'eslint-plugin-react-refresh' # eslint-plugin-react-refresh@>=0.5.x requires eslint@>=9.x.x, blocked by https://github.com/WordPress/gutenberg/issues/64782
+            update-types: ['version-update:semver-minor']


### PR DESCRIPTION
## What?

Ignore minor `eslint-plugin-react-refresh` version bumps in Dependabot.

## Why?

`eslint-plugin-react-refresh` [v0.5.0](https://github.com/ArnaudBarre/eslint-plugin-react-refresh/releases/tag/v0.5.0) requires ESLint 9. We cannot upgrade `eslint-plugin-react-refresh` until we are [unblocked upgrading ESLint](https://github.com/WordPress/gutenberg/issues/64782).

Follow-up to https://github.com/wordpress-mobile/GutenbergKit/pull/381#issuecomment-4077987236.

## How?

Add an `ignore` rule for `eslint-plugin-react-refresh` minor version updates in `.github/dependabot.yml`, following the existing pattern for `eslint`, `react`, `react-dom`, and `jquery`.

## Testing Instructions

Verify the `dependabot.yml` syntax is valid.