### PR TITLE
fix: replace deprecated EditorSnackbars with SnackbarNotices

### DIFF
--- a/src/components/editor/style.scss
+++ b/src/components/editor/style.scss
@@ -37,12 +37,3 @@ button {
 	font-size: inherit;
 	font-weight: inherit;
 }
-
-.gutenberg-kit-editor .components-editor-notices__snackbar {
-	bottom: 58px;
-	left: 0;
-	padding-right: 8px;
-	padding-left: 8px;
-	position: fixed;
-	right: 0;
-}

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -1,11 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	EditorSnackbars,
-	ErrorBoundary,
-	AutosaveMonitor,
-} from '@wordpress/editor';
+import { ErrorBoundary, AutosaveMonitor } from '@wordpress/editor';
+import { SnackbarNotices } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -32,7 +29,7 @@ export default function Layout( props ) {
 			<OfflineIndicator />
 			<AutosaveMonitor autosave={ onEditorContentChanged } />
 			<Editor { ...editorProps }>
-				<EditorSnackbars />
+				<SnackbarNotices className="gutenberg-kit-layout__snackbar" />
 			</Editor>
 			<EditorLoadNotice
 				className="gutenberg-kit-layout__load-notice"

--- a/src/components/layout/style.scss
+++ b/src/components/layout/style.scss
@@ -1,3 +1,12 @@
+.gutenberg-kit-layout__snackbar {
+	bottom: 58px;
+	left: 0;
+	padding-right: 8px;
+	padding-left: 8px;
+	position: fixed;
+	right: 0;
+}
+
 .gutenberg-kit-layout__load-notice {
 	bottom: 62px;
 	left: 16px;


### PR DESCRIPTION
## What?
Replace the deprecated `wp.editor.EditorSnackbars` component with `wp.notices.SnackbarNotices`.

## Why?
`wp.editor.EditorSnackbars` was deprecated in `@wordpress/editor` v7.0 and will be removed in v7.2, generating a deprecation warning in the console on every editor load:

```
[Warning] wp.editor.EditorSnackbars is deprecated since version 7.0 and will be removed in version 7.2. Please use wp.notices.SnackbarNotices instead.
```

## How?
- Swap `EditorSnackbars` (from `@wordpress/editor`) for `SnackbarNotices` (from `@wordpress/notices`) in `layout/index.jsx`
- Replace the internal WordPress class `components-editor-notices__snackbar` with a project-owned `gutenberg-kit-layout__snackbar` class
- Move the snackbar positioning styles from `editor/style.scss` into `layout/style.scss`, co-locating them with the component that renders the snackbar

## Testing Instructions
1. Open the editor in your desktop web browser by running `make dev-server` and navigating to the local URL with the `?dev_mode` parameter appended (e.g. `http://localhost:5173/?dev_mode`).
2. Open the browser console (Web Inspector).
3. Verify the following deprecation warning is **no longer present**:
   > `wp.editor.EditorSnackbars is deprecated since version 7.0 and will be removed in version 7.2. Please use wp.notices.SnackbarNotices instead.`
4. Trigger a snackbar notice (e.g. copy all content via the editor menu) and verify it displays correctly.

### Accessibility Testing Instructions
N/A — no user-facing UI changes.

## Screenshots or screencast <!-- if applicable -->
N/A — no user-facing UI changes.