### PR TITLE
fix: improve offline indicator accuracy with HTTP probe

### DIFF
--- a/android/Gutenberg/src/main/AndroidManifest.xml
+++ b/android/Gutenberg/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
 </manifest>

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -4,6 +4,10 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
@@ -91,6 +95,10 @@ class GutenbergView : WebView {
     private lateinit var dependencies: EditorDependencies
 
     private val handler = Handler(Looper.getMainLooper())
+    private var connectivityManager: ConnectivityManager? = null
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    private var lastKnownConnectivity: Boolean? = null
+    private val availableNetworks = mutableSetOf<Network>()
     var filePathCallback: ValueCallback<Array<Uri?>?>? = null
     val pickImageRequestCode = 1
 
@@ -614,6 +622,9 @@ class GutenbergView : WebView {
         Log.i("GutenbergView", "EditorLoaded received in native code")
         isEditorLoaded = true
         handler.post {
+            lastKnownConnectivity?.let { isConnected ->
+                if (!isConnected) dispatchConnectivityEvent(false)
+            }
             if(!didFireEditorLoaded) {
                 loadingListener?.onEditorReady()
                 editorDidBecomeAvailableListener?.onEditorAvailable(this)
@@ -859,8 +870,14 @@ class GutenbergView : WebView {
         }
     }
 
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        startNetworkMonitoring()
+    }
+
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
+        stopNetworkMonitoring()
         clearConfig()
         this.stopLoading()
         FileCache.clearCache(context)
@@ -878,6 +895,51 @@ class GutenbergView : WebView {
         latestContentProvider = null
         handler.removeCallbacksAndMessages(null)
         this.destroy()
+    }
+
+    // Network Monitoring
+
+    private fun startNetworkMonitoring() {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager ?: return
+        connectivityManager = cm
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                availableNetworks.add(network)
+                handleConnectivityChange(true)
+            }
+            override fun onLost(network: Network) {
+                availableNetworks.remove(network)
+                handleConnectivityChange(availableNetworks.isNotEmpty())
+            }
+        }
+        networkCallback = callback
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+        cm.registerNetworkCallback(request, callback)
+    }
+
+    private fun stopNetworkMonitoring() {
+        try {
+            connectivityManager?.let { cm -> networkCallback?.let { cb -> cm.unregisterNetworkCallback(cb) } }
+        } catch (e: IllegalArgumentException) {
+            Log.w("GutenbergView", "NetworkCallback was not registered: ${e.message}")
+        }
+        connectivityManager = null
+        networkCallback = null
+        availableNetworks.clear()
+    }
+
+    private fun handleConnectivityChange(isConnected: Boolean) {
+        if (lastKnownConnectivity == isConnected) return
+        lastKnownConnectivity = isConnected
+        if (!isEditorLoaded) return
+        handler.post { dispatchConnectivityEvent(isConnected) }
+    }
+
+    private fun dispatchConnectivityEvent(isConnected: Boolean) {
+        val eventName = if (isConnected) "online" else "offline"
+        this.evaluateJavascript("window.dispatchEvent(new Event('$eventName'));", null)
     }
 
     companion object {

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -44,6 +44,7 @@ import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
 import org.wordpress.gutenberg.model.GBKitGlobal
 import org.wordpress.gutenberg.services.EditorService
+import java.util.Collections
 import java.util.Locale
 
 private const val ASSET_URL = "https://appassets.androidplatform.net/assets/index.html"
@@ -97,8 +98,8 @@ class GutenbergView : WebView {
     private val handler = Handler(Looper.getMainLooper())
     private var connectivityManager: ConnectivityManager? = null
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
-    private var lastKnownConnectivity: Boolean? = null
-    private val availableNetworks = mutableSetOf<Network>()
+    @Volatile private var lastKnownConnectivity: Boolean? = null
+    private val availableNetworks = Collections.synchronizedSet(mutableSetOf<Network>())
     var filePathCallback: ValueCallback<Array<Uri?>?>? = null
     val pickImageRequestCode = 1
 

--- a/src/components/offline-indicator/index.jsx
+++ b/src/components/offline-indicator/index.jsx
@@ -113,6 +113,7 @@ async function probeConnectivity() {
 	try {
 		await window.fetch( getConnectivityProbeUrl(), {
 			method: 'HEAD',
+			mode: 'no-cors',
 			cache: 'no-store',
 			signal: AbortSignal.timeout( 5000 ),
 		} );
@@ -125,10 +126,9 @@ async function probeConnectivity() {
 /**
  * Returns a URL suitable for probing real internet connectivity.
  *
- * Prefers the site API root (already used by the editor, same origin, no CORS
- * concerns) so that the probe reflects whether the WordPress API specifically
- * is reachable. Falls back to `/favicon.ico` for local dev environments where
- * no GBKit config is available.
+ * Prefers the site API root so the probe reflects whether the WordPress API
+ * specifically is reachable. Falls back to `/favicon.ico` for local dev
+ * environments where no GBKit config is available.
  *
  * @return {string} The probe URL.
  */

--- a/src/components/offline-indicator/index.jsx
+++ b/src/components/offline-indicator/index.jsx
@@ -10,6 +10,7 @@ import { offline } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { getGBKit } from '../../utils/bridge';
 import './style.scss';
 
 /**
@@ -48,25 +49,90 @@ export default function OfflineIndicator() {
 }
 
 /**
- * Tracks browser network connectivity via online/offline events.
+ * Tracks network connectivity using browser online/offline events verified by
+ * a real HTTP probe.
  *
- * @return {{ isConnected: boolean }} Whether the device is currently online.
+ * The `offline` event is treated as immediately authoritative. The `online`
+ * event triggers a probe to confirm actual connectivity before clearing the
+ * indicator, guarding against false positives from `navigator.onLine`.
+ *
+ * Initial state reads `navigator.onLine` but only trusts `false` — a definitive
+ * signal the browser has no network interface. A `true` value is not trusted on
+ * its own; Chrome is known to misreport it. If the browser reports online at
+ * mount, a probe runs immediately to verify before committing to that state.
+ *
+ * @return {{ isConnected: boolean }} Whether the device is currently connected.
  */
 function useNetworkConnectivity() {
 	const [ isConnected, setIsConnected ] = useState( navigator.onLine );
 
 	useEffect( () => {
-		const handleOnline = () => setIsConnected( true );
+		const abortController = new AbortController();
+
+		// If the browser reports online at mount, probe immediately to catch
+		// Chrome incorrectly reporting navigator.onLine as true.
+		if ( navigator.onLine ) {
+			probeConnectivity().then( ( connected ) => {
+				if ( ! abortController.signal.aborted ) {
+					setIsConnected( connected );
+				}
+			} );
+		}
+
+		const handleOnline = async () => {
+			const connected = await probeConnectivity();
+			if ( ! abortController.signal.aborted ) {
+				setIsConnected( connected );
+			}
+		};
 		const handleOffline = () => setIsConnected( false );
 
 		window.addEventListener( 'online', handleOnline );
 		window.addEventListener( 'offline', handleOffline );
 
 		return () => {
+			abortController.abort();
 			window.removeEventListener( 'online', handleOnline );
 			window.removeEventListener( 'offline', handleOffline );
 		};
 	}, [] );
 
 	return { isConnected };
+}
+
+/**
+ * Probes real internet connectivity by making a lightweight HEAD request.
+ *
+ * `navigator.onLine` and the browser `online` event are unreliable — they only
+ * confirm a network interface is active, not that the internet is reachable.
+ * This probe verifies actual connectivity before reporting online status.
+ *
+ * @return {Promise<boolean>} Whether the probe request succeeded.
+ */
+async function probeConnectivity() {
+	try {
+		await window.fetch( getConnectivityProbeUrl(), {
+			method: 'HEAD',
+			cache: 'no-store',
+			signal: AbortSignal.timeout( 5000 ),
+		} );
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Returns a URL suitable for probing real internet connectivity.
+ *
+ * Prefers the site API root (already used by the editor, same origin, no CORS
+ * concerns) so that the probe reflects whether the WordPress API specifically
+ * is reachable. Falls back to `/favicon.ico` for local dev environments where
+ * no GBKit config is available.
+ *
+ * @return {string} The probe URL.
+ */
+function getConnectivityProbeUrl() {
+	const { siteApiRoot } = getGBKit();
+	return siteApiRoot || '/favicon.ico';
 }

--- a/src/components/offline-indicator/index.test.jsx
+++ b/src/components/offline-indicator/index.test.jsx
@@ -10,33 +10,38 @@ import { render, screen, act } from '@testing-library/react';
 import OfflineIndicator from '.';
 
 vi.mock( '@wordpress/i18n' );
+vi.mock( '../../utils/bridge', () => ( {
+	getGBKit: vi.fn( () => ( {} ) ),
+} ) );
 
 describe( 'OfflineIndicator', () => {
-	let originalOnLine;
-
 	beforeEach( () => {
-		originalOnLine = navigator.onLine;
-	} );
-
-	afterEach( () => {
-		Object.defineProperty( navigator, 'onLine', {
-			value: originalOnLine,
-			writable: true,
-			configurable: true,
-		} );
-	} );
-
-	it( 'does not render when online', () => {
+		// Default: navigator.onLine is true, fetch probe succeeds.
 		Object.defineProperty( navigator, 'onLine', {
 			value: true,
 			configurable: true,
 		} );
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( () =>
+				Promise.resolve( new Response( null, { status: 200 } ) )
+			)
+		);
+	} );
 
-		const { container } = render( <OfflineIndicator /> );
+	afterEach( () => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	} );
+
+	it( 'does not render when navigator.onLine is true and probe succeeds', async () => {
+		const { container } = await act( async () =>
+			render( <OfflineIndicator /> )
+		);
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'renders "Working Offline" when navigator.onLine is false', () => {
+	it( 'renders immediately when navigator.onLine is false on mount', () => {
 		Object.defineProperty( navigator, 'onLine', {
 			value: false,
 			configurable: true,
@@ -46,16 +51,40 @@ describe( 'OfflineIndicator', () => {
 		expect( screen.getByText( 'Working Offline' ) ).toBeInTheDocument();
 	} );
 
-	it( 'auto-hides when online event fires', () => {
-		Object.defineProperty( navigator, 'onLine', {
-			value: false,
-			configurable: true,
+	it( 'renders when navigator.onLine is true on mount but probe fails', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( () => Promise.reject( new Error( 'Network error' ) ) )
+		);
+
+		await act( async () => render( <OfflineIndicator /> ) );
+
+		expect( screen.getByText( 'Working Offline' ) ).toBeInTheDocument();
+	} );
+
+	it( 're-appears when offline event fires', async () => {
+		await act( async () => render( <OfflineIndicator /> ) );
+		expect(
+			screen.queryByText( 'Working Offline' )
+		).not.toBeInTheDocument();
+
+		await act( async () => {
+			window.dispatchEvent( new Event( 'offline' ) );
 		} );
 
-		render( <OfflineIndicator /> );
+		expect( screen.getByText( 'Working Offline' ) ).toBeInTheDocument();
+	} );
+
+	it( 'auto-hides when online event fires and probe succeeds', async () => {
+		await act( async () => render( <OfflineIndicator /> ) );
+
+		await act( async () => {
+			window.dispatchEvent( new Event( 'offline' ) );
+		} );
+
 		expect( screen.getByText( 'Working Offline' ) ).toBeInTheDocument();
 
-		act( () => {
+		await act( async () => {
 			window.dispatchEvent( new Event( 'online' ) );
 		} );
 
@@ -64,21 +93,60 @@ describe( 'OfflineIndicator', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 're-appears when offline event fires', () => {
-		Object.defineProperty( navigator, 'onLine', {
-			value: true,
-			configurable: true,
-		} );
+	it( 'remains offline when online event fires but probe fails', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn( () => Promise.reject( new Error( 'Network error' ) ) )
+		);
 
-		render( <OfflineIndicator /> );
-		expect(
-			screen.queryByText( 'Working Offline' )
-		).not.toBeInTheDocument();
+		await act( async () => render( <OfflineIndicator /> ) );
 
-		act( () => {
+		await act( async () => {
 			window.dispatchEvent( new Event( 'offline' ) );
 		} );
 
+		await act( async () => {
+			window.dispatchEvent( new Event( 'online' ) );
+		} );
+
 		expect( screen.getByText( 'Working Offline' ) ).toBeInTheDocument();
+	} );
+
+	it( 'probes the siteApiRoot when available', async () => {
+		const { getGBKit } = await import( '../../utils/bridge' );
+		getGBKit.mockReturnValue( {
+			siteApiRoot: 'https://example.com/wp-json/',
+		} );
+
+		await act( async () => render( <OfflineIndicator /> ) );
+		await act( async () => {
+			window.dispatchEvent( new Event( 'online' ) );
+		} );
+
+		expect( fetch ).toHaveBeenCalledWith(
+			'https://example.com/wp-json/',
+			expect.objectContaining( {
+				method: 'HEAD',
+				cache: 'no-store',
+			} )
+		);
+	} );
+
+	it( 'falls back to /favicon.ico when siteApiRoot is not configured', async () => {
+		const { getGBKit } = await import( '../../utils/bridge' );
+		getGBKit.mockReturnValue( {} );
+
+		await act( async () => render( <OfflineIndicator /> ) );
+		await act( async () => {
+			window.dispatchEvent( new Event( 'online' ) );
+		} );
+
+		expect( fetch ).toHaveBeenCalledWith(
+			'/favicon.ico',
+			expect.objectContaining( {
+				method: 'HEAD',
+				cache: 'no-store',
+			} )
+		);
 	} );
 } );


### PR DESCRIPTION
## What?
Fixes the offline indicator not appearing in Android WebView, and improves its accuracy across all platforms.

## Why?
Two issues:

1. **Android WebView never fires `online`/`offline` events** — a known long-standing WebView limitation. Unlike Chrome (a full browser with its own network stack), Android WebView does not synthesize these events when OS network state changes, so the offline banner never appeared.
2. **`navigator.onLine` and browser `online`/`offline` events are unreliable** on other platforms — they only confirm a network interface is active, not that the internet is reachable. Chrome is also known to not fire the `offline` event in all network loss scenarios.

Fix CMM-1945. Follow up on https://github.com/wordpress-mobile/GutenbergKit/pull/366#discussion_r2915245274.

## How?

### Android native polyfill
Adds a `ConnectivityManager.NetworkCallback` inside `GutenbergView` that monitors OS network state and synthesizes `window.dispatchEvent(new Event('online'|'offline'))` into the WebView — a transparent polyfill requiring no host app changes. The callback is registered in `onAttachedToWindow` and unregistered in `onDetachedFromWindow`. Also adds the required `ACCESS_NETWORK_STATE` permission to the library manifest (a normal permission; no runtime grant needed).

### JS probe-based connectivity strategy
Replaces the simple event listener approach with an asymmetric strategy:

- **Initial state** reads `navigator.onLine`. A `false` value is trusted immediately (definitive signal the device has no interface). A `true` value triggers a mount-time probe to catch misreported online status before any event fires.
- **`offline` event**: trusted immediately — this signal is reliable.
- **`online` event**: verified by a lightweight `HEAD` probe before clearing the indicator, guarding against false positives.

The probe targets `siteApiRoot` from the GBKit config, testing actual WordPress API reachability. Falls back to `/favicon.ico` in local dev environments.

## Testing Instructions
1. If set, remove `GUTENBERG_EDITOR_URL` from `local.properties`. 
2. Run `make build` to build the latest JavaScript. 
1. Open the Android demo app editor on a device or emulator.
4. Toggle airplane mode on — verify the offline banner appears.
5. Toggle airplane mode off — verify the banner disappears.

### Accessibility Testing Instructions
The offline indicator uses `wp.a11y.speak()` to announce connectivity loss to screen readers. Verify the announcement is made when going offline.

## Screenshots or screencast <!-- if applicable -->

<details><summary>Screen recording</summary>
<p>

https://github.com/user-attachments/assets/06076541-e06f-4435-9e20-7d18fa77a54a

</p>
</details> 

<details><summary>Screenshot</summary>
<p>

![android-working-offline](https://github.com/user-attachments/assets/18d3ba99-794f-4dbc-b4d1-a5c3bb1a9c1d)

</p>
</details> 