### PR TITLE
fix: filter cross-origin "Script error." from Sentry reports

### DIFF
--- a/src/utils/global-error-handler.js
+++ b/src/utils/global-error-handler.js
@@ -10,6 +10,12 @@ import { logException } from './bridge';
 export function setUpGlobalErrorHandlers() {
 	// Catch unhandled errors
 	window.addEventListener( 'error', ( event ) => {
+		// "Script error." with no filename is the browser's sanitized form of a
+		// cross-origin script error. There is no actionable information, so skip it.
+		if ( event.message === 'Script error.' && ! event.filename ) {
+			return;
+		}
+
 		if ( isExternalError( event.filename, event.error ) ) {
 			return;
 		}


### PR DESCRIPTION
## What?

Filters cross-origin `"Script error."` events from being forwarded to Sentry.

## Why?

Browsers sanitize errors thrown by cross-origin scripts into the opaque `"Script error."` message with no filename, line/column number, or stack trace — this is a browser security feature (Same-Origin Policy). These events were passing through `isExternalError()` undetected (an empty filename doesn't start with `http`) and being forwarded to Sentry as noise with no actionable information.

Relates to Sentry issue JETPACK-ANDROID-1FBM.

## How?

Added an early-exit guard in the `window.error` handler: if `event.message === 'Script error.'` and `event.filename` is empty, the event is dropped before reaching `logException`.

## Testing Instructions

1. Start the dev server: `make dev-server`
2. Open the editor in your browser: `http://localhost:5173/?dev_mode`.
5. Add a breakpoint to the `logException` function via the dev tools or add a `debugger` or `console.log()` to the source itself. 
3. Serve a throwing script from a different port without CORS headers:
   ```bash
   echo 'throw new Error("real");' > /tmp/throwing.js && python3 -m http.server 5174 --directory /tmp
   ```
4. In the editor browser console, inject the cross-origin script:
   ```js
   var s = document.createElement('script'); s.src = 'http://localhost:5174/throwing.js'; document.head.appendChild(s);
   ```
5. Confirm no `logException` call is triggered for the resulting `"Script error."` event.
6. Confirm real same-origin errors still reach `logException` by running the following in the console. Note: `setTimeout` is required — a synchronous `throw` is caught by the console itself and never reaches the global `error` handler.
   ```js
   setTimeout(() => { throw new Error("same-origin test error"); }, 0);
   ```
7. Confirm `logException` is called for the same-origin error above.

### Accessibility Testing Instructions

N/A — no UI changes.

## Screenshots or screencast <!-- if applicable -->
N/A — no user-facing changes. 