### PR TITLE
ci: automate release notes and PR labeling

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -17,3 +17,10 @@ changelog:
         - title: Other Changes
           labels:
               - '*'
+          exclude:
+              labels:
+                  - '[Type] Automated Testing'
+                  - '[Type] Build Tooling'
+                  - '[Type] Task'
+                  - '[Type] Developer Documentation'
+                  - dependencies # Added by Dependabot

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+    exclude:
+        authors:
+            - dependabot
+    categories:
+        - title: Features & Enhancements
+          labels:
+              - '[Type] Enhancement'
+        - title: Bug Fixes
+          labels:
+              - '[Type] Bug'
+              - '[Type] Regression'
+        - title: Other Changes
+          labels:
+              - '*'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ changelog:
     exclude:
         authors:
             - dependabot
+            - dependabot[bot]
     categories:
         - title: Features & Enhancements
           labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,9 @@ changelog:
             - dependabot
             - dependabot[bot]
     categories:
+        - title: Breaking Changes
+          labels:
+              - '[Type] Breaking Change'
         - title: Features & Enhancements
           labels:
               - '[Type] Enhancement'

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -15,10 +15,11 @@ jobs:
               with:
                   script: |
                       const title = context.payload.pull_request.title;
-                      const prefixMatch = title.match(/^(\w+)[\(!:]/);
+                      const prefixMatch = title.match(/^(\w+)(?:\([^)]*\))?(!)?:/);
                       if (!prefixMatch) return;
 
                       const prefix = prefixMatch[1].toLowerCase();
+                      const isBreaking = prefixMatch[2] === '!';
                       const labelMap = {
                           feat: '[Type] Enhancement',
                           fix: '[Type] Bug',
@@ -33,8 +34,8 @@ jobs:
                           style: '[Type] Task',
                       };
 
-                      const label = labelMap[prefix];
-                      if (!label) return;
+                      const typeLabel = isBreaking ? '[Type] Breaking Change' : labelMap[prefix];
+                      if (!typeLabel) return;
 
                       const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
                           owner: context.repo.owner,
@@ -42,16 +43,19 @@ jobs:
                           issue_number: context.payload.pull_request.number,
                       });
 
-                      const typeLabels = Object.values(labelMap);
+                      const allTypeLabels = [...Object.values(labelMap), '[Type] Breaking Change'];
                       const hasConflictingLabel = currentLabels.some(
-                          (l) => typeLabels.includes(l.name) && l.name !== label
+                          (l) => allTypeLabels.includes(l.name) && l.name !== typeLabel
                       );
 
                       if (hasConflictingLabel) return;
+
+                      const alreadyLabeled = currentLabels.some((l) => l.name === typeLabel);
+                      if (alreadyLabeled) return;
 
                       await github.rest.issues.addLabels({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           issue_number: context.payload.pull_request.number,
-                          labels: [label],
+                          labels: [typeLabel],
                       });

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,57 @@
+name: Label PR
+
+on:
+    pull_request_target:
+        types: [opened, edited]
+
+jobs:
+    label:
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - name: Apply label based on Conventional Commits prefix
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const title = context.payload.pull_request.title;
+                      const prefixMatch = title.match(/^(\w+)[\(!:]/);
+                      if (!prefixMatch) return;
+
+                      const prefix = prefixMatch[1].toLowerCase();
+                      const labelMap = {
+                          feat: '[Type] Enhancement',
+                          fix: '[Type] Bug',
+                          perf: '[Type] Performance',
+                          test: '[Type] Automated Testing',
+                          docs: '[Type] Developer Documentation',
+                          build: '[Type] Build Tooling',
+                          ci: '[Type] Build Tooling',
+                          refactor: '[Type] Task',
+                          task: '[Type] Task',
+                          chore: '[Type] Task',
+                          style: '[Type] Task',
+                      };
+
+                      const label = labelMap[prefix];
+                      if (!label) return;
+
+                      const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.payload.pull_request.number,
+                      });
+
+                      const typeLabels = Object.values(labelMap);
+                      const hasConflictingLabel = currentLabels.some(
+                          (l) => typeLabels.includes(l.name) && l.name !== label
+                      );
+
+                      if (hasConflictingLabel) return;
+
+                      await github.rest.issues.addLabels({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.payload.pull_request.number,
+                          labels: [label],
+                      });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,11 +78,7 @@ These commands ensure code quality and prevent lint errors from blocking commits
 
 ### Commit and Pull Request Guidelines
 
-When creating pull requests:
-
-1. **Use the PR template**: Read `.github/PULL_REQUEST_TEMPLATE.md` to get the current template structure and follow it when writing the PR body.
-2. **Assign a label**: Use `gh label list` to retrieve available labels and select the most relevant one for the PR.
-3. **Use Conventional Commits**: Follow the Conventional Commits specification for commit messages (e.g. `feat: add new block type`, `fix: resolve toolbar bug`).
+Follow the conventions documented in [Developer Workflows](./docs/code/developer-workflows.md), including Conventional Commits prefixes, PR template usage, and label assignment.
 
 ### E2E Test Interaction Guidelines
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -258,8 +258,8 @@ commit_changes() {
     fi
 
     git add .
-    git commit -m "$version"
-    print_success "Changes committed with message: $version"
+    git commit -m "chore(release): $version"
+    print_success "Changes committed with message: chore(release): $version"
 }
 
 # Function to create git tag

--- a/docs/code/README.md
+++ b/docs/code/README.md
@@ -6,6 +6,7 @@ This guide is for developers who want to contribute code to GutenbergKit.
 
 -   [Getting Started](./getting-started.md) - Prerequisites, setup, and running the demo apps
 -   [Development Tools](./development-tools.md) - Development mode, React DevTools, and logging
+-   [Developer Workflows](./developer-workflows.md) - Commit conventions, pull requests, and labeling
 -   [Testing](./testing.md) - Running tests and ensuring code quality
 -   [Troubleshooting](./troubleshooting.md) - Common issues and solutions
 

--- a/docs/code/developer-workflows.md
+++ b/docs/code/developer-workflows.md
@@ -1,0 +1,49 @@
+# Developer Workflows
+
+This guide covers commit conventions, pull request guidelines, and labeling workflows in GutenbergKit.
+
+## Commit Messages
+
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification for commit messages and pull request titles.
+
+Format: `<type>: <description>`
+
+Common types:
+
+| Type       | When to use                                |
+| ---------- | ------------------------------------------ |
+| `feat`     | New feature or capability                  |
+| `fix`      | Bug fix                                    |
+| `perf`     | Performance improvement                    |
+| `test`     | Adding or updating tests                   |
+| `docs`     | Documentation changes                      |
+| `build`    | Build system or dependency changes         |
+| `ci`       | CI/CD configuration changes                |
+| `refactor` | Code restructuring without behavior change |
+| `chore`    | Routine maintenance tasks                  |
+
+Examples: `feat: add offline indicator`, `fix: resolve iOS retain cycle in async flow`
+
+## Pull Requests
+
+When creating a pull request:
+
+1. **Use the PR template**: The template in `.github/PULL_REQUEST_TEMPLATE.md` provides the required structure.
+2. **Assign a label**: Use `gh label list` to see available labels and select the most relevant one.
+3. **Follow Conventional Commits**: The PR title should use the same format as commit messages above.
+
+### Automatic Labeling
+
+PRs are automatically labeled based on the Conventional Commits prefix in the title:
+
+| Prefix                               | Label applied                    |
+| ------------------------------------ | -------------------------------- |
+| `feat`                               | `[Type] Enhancement`             |
+| `fix`                                | `[Type] Bug`                     |
+| `perf`                               | `[Type] Performance`             |
+| `test`                               | `[Type] Automated Testing`       |
+| `docs`                               | `[Type] Developer Documentation` |
+| `build`, `ci`                        | `[Type] Build Tooling`           |
+| `refactor`, `task`, `chore`, `style` | `[Type] Task`                    |
+
+If you manually apply a type label before the automation runs, your choice is respected — the workflow skips re-labeling when a conflicting type label is already present.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -39,5 +39,17 @@ The script:
 
 After the release is created, it is ready for integration into the WordPress app.
 
+## Release Notes
+
+GitHub automatically generates release notes when a release is created. Notes are organized into the following categories based on PR labels:
+
+-   **Features & Enhancements** — `[Type] Enhancement`
+-   **Bug Fixes** — `[Type] Bug`, `[Type] Regression`
+-   **Other Changes** — everything else
+
+Dependabot dependency bump PRs are excluded automatically.
+
+PRs are labeled automatically based on their Conventional Commits title prefix. See the [Developer Workflows](./code/developer-workflows.md) guide for details on the labeling rules.
+
 [^1]: We increment the version before building and without tagging so that (1) the correct version number is included in the build's [error reporting metadata](https://github.com/wordpress-mobile/GutenbergKit/blob/8195901ec8883125dcfa102abf2b6a2a3962af3e/src/utils/exception-parser.js#L99) and (2) the Git tag includes the latest build output.
 [^2]: CI tasks create new Android builds for each commit. However, such infrastructure is not yet in place for iOS. Therefore, we must manually create and commit the iOS build.


### PR DESCRIPTION
## What?
Adds GitHub configuration and documentation to automate release notes generation and PR labeling based on Conventional Commits.

## Why?
Release notes were noisy — Dependabot dependency bump PRs dominated the changelog, making it hard to see meaningful changes. There was also no consistent labeling of PRs by type, and the commit/PR conventions lived only in AGENTS.md (AI agent guidance) rather than human-facing docs.

## How?
- **`.github/release.yml`**: Configures GitHub's automatic release notes to exclude Dependabot PRs and group changes into four categories — \"Breaking Changes\", \"Features & Enhancements\", \"Bug Fixes\", and \"Other Changes\" — using existing repository type labels. Noise labels (`[Type] Automated Testing`, `[Type] Build Tooling`, `[Type] Task`, `[Type] Developer Documentation`, `dependencies`) are excluded from \"Other Changes\" to keep the changelog focused on user-visible changes.
- **`.github/workflows/label-pr.yml`**: On PR open or edit, parses the Conventional Commits prefix and breaking change indicator (`!`) from the PR title and applies the matching repository label. When `!` is present (e.g. `feat!:`, `fix(scope)!:`), only `[Type] Breaking Change` is applied. Skips if a conflicting type label is already present, so developers can override the auto-assigned label.
- **`bin/release.sh`**: Release commits now follow the Conventional Commits format (`chore(release): x.y.z`).
- **`docs/code/developer-workflows.md`** (new): Human-facing documentation covering Conventional Commits usage, PR guidelines, and the automatic labeling rules.
- **`docs/releases.md`**: Added a \"Release Notes\" section explaining category groupings, Dependabot exclusions, and linking to the labeling rules.
- **`docs/code/README.md`**: Linked to the new `developer-workflows.md`.
- **`AGENTS.md`**: Replaced inline commit/PR guidelines with a pointer to the new doc.

Conventional Commits → label mapping:
| Prefix | Label |
|---|---|
| `feat` | `[Type] Enhancement` |
| `fix` | `[Type] Bug` |
| `perf` | `[Type] Performance` |
| `test` | `[Type] Automated Testing` |
| `docs` | `[Type] Developer Documentation` |
| `build`, `ci` | `[Type] Build Tooling` |
| `refactor`, `task`, `chore`, `style` | `[Type] Task` |
| any type with `!` | `[Type] Breaking Change` |

## Testing Instructions
We can forgo testing for now, as the changes will not take effect until they are merged. 

### Accessibility Testing Instructions
N/A — no UI changes.