### PR TITLE
ci: ESLint ignores the build directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+android/
+build/
+dist/
+ios/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,7 +5,6 @@ module.exports = {
 		browser: true,
 		es2020: true,
 	},
-	ignorePatterns: [ 'android', 'dist', 'ios' ],
 	parserOptions: {
 		ecmaVersion: 'latest',
 		sourceType: 'module',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Configure ESLint to ignore the `./build` directory. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Local runs where a `./build` directory contained JavaScript files led to task timeouts. Debug logs showed the lint task traversing files in `./build`.

```
eslint:linter With ConfigArray: /GutenbergKit/build/DerivedData/Build/Intermediates.noindex/ArchiveIntermediates/GutenbergKitResources/BuildProductsPath/Release-iphonesimulator/GutenbergKit_GutenbergKitResources.bundle/Gutenberg/assets/ar-vbe2qB2J.js
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replace `ignorePatterns` configuration with a `.eslintignore` file that also ignores `build/`. Whenever the project is able to upgrade to the latest ESLint version, we could instead configure ESLint to rely upon the `.gitignore` file. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Verify the CI checks pass. 

### Accessibility Testing Instructions
<!-- How can you test the changes by using a keyboard/screen reader only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes. 