### PR TITLE
fix: coerce post ID 0 to nil on both platforms and JS bridge

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/EditorConfiguration.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/EditorConfiguration.kt
@@ -76,7 +76,7 @@ data class EditorConfiguration(
 
         fun setTitle(title: String) = apply { this.title = title }
         fun setContent(content: String) = apply { this.content = content }
-        fun setPostId(postId: UInt?) = apply { this.postId = postId }
+        fun setPostId(postId: UInt?) = apply { this.postId = postId?.takeIf { it != 0u } }
         fun setPostType(postType: String) = apply { this.postType = postType }
         fun setPostStatus(postStatus: String) = apply { this.postStatus = postStatus }
         fun setThemeStyles(themeStyles: Boolean) = apply { this.themeStyles = themeStyles }
@@ -99,7 +99,7 @@ data class EditorConfiguration(
         fun build(): EditorConfiguration = EditorConfiguration(
             title = title,
             content = content,
-            postId = postId,
+            postId = postId?.takeIf { it != 0u },
             postType = postType,
             postStatus = postStatus,
             themeStyles = themeStyles,

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/EditorConfigurationTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/EditorConfigurationTest.kt
@@ -79,6 +79,15 @@ class EditorConfigurationBuilderTest {
     }
 
     @Test
+    fun `setPostId with zero results in null`() {
+        val config = builder()
+            .setPostId(0u)
+            .build()
+
+        assertNull(config.postId)
+    }
+
+    @Test
     fun `setPostId with null clears postId`() {
         val config = builder()
             .setPostId(123u)

--- a/ios/Sources/GutenbergKit/Sources/Model/EditorConfiguration.swift
+++ b/ios/Sources/GutenbergKit/Sources/Model/EditorConfiguration.swift
@@ -93,7 +93,7 @@ public struct EditorConfiguration: Sendable, Hashable, Equatable {
   ) {
     self.title = title
     self.content = content
-    self.postID = postID
+    self.postID = postID == 0 ? nil : postID
     self.postType = postType
     self.postStatus = postStatus
     self.shouldUseThemeStyles = shouldUseThemeStyles

--- a/ios/Tests/GutenbergKitTests/Model/EditorConfigurationTests.swift
+++ b/ios/Tests/GutenbergKitTests/Model/EditorConfigurationTests.swift
@@ -65,6 +65,15 @@ struct EditorConfigurationBuilderTests: MakesTestFixtures {
     #expect(config.postID == 123)
   }
 
+  @Test("setPostID with zero results in nil")
+  func setPostIDWithZeroResultsInNil() {
+    let config = makeConfigurationBuilder()
+      .setPostID(0)
+      .build()
+
+    #expect(config.postID == nil)
+  }
+
   @Test("setPostID with nil clears postID")
   func setPostIDWithNilClearsPostID() {
     let config = makeConfigurationBuilder()

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -300,7 +300,7 @@ export async function getPost() {
 	if ( hostContent ) {
 		debug( 'Using content from native host' );
 		return {
-			id: post?.id ?? -1,
+			id: post?.id || -1,
 			type: post?.type || 'post',
 			restBase: post?.restBase || 'posts',
 			restNamespace: post?.restNamespace || 'wp/v2',
@@ -313,7 +313,7 @@ export async function getPost() {
 	if ( post ) {
 		debug( 'Native bridge unavailable, using GBKit initial content' );
 		return {
-			id: post.id,
+			id: post.id || -1,
 			type: post.type || 'post',
 			restBase: post.restBase || 'posts',
 			restNamespace: post.restNamespace || 'wp/v2',

--- a/src/utils/bridge.test.js
+++ b/src/utils/bridge.test.js
@@ -282,6 +282,33 @@ describe( 'getPost', () => {
 			expect( result.title.raw ).toBe( 'Updated Title' );
 			expect( result.content.raw ).toBe( 'Updated Content' );
 		} );
+
+		it( 'should coerce post ID 0 to -1 with host content', async () => {
+			const hostContent = {
+				title: 'Title',
+				content: 'Content',
+			};
+			window.webkit = {
+				messageHandlers: {
+					requestLatestContent: {
+						postMessage: vi.fn().mockResolvedValue( hostContent ),
+					},
+				},
+			};
+			window.GBKit = {
+				post: {
+					id: 0,
+					type: 'post',
+					status: 'draft',
+					title: 'Title',
+					content: 'Content',
+				},
+			};
+
+			const result = await getPost();
+
+			expect( result.id ).toBe( -1 );
+		} );
 	} );
 
 	describe( 'fallback to GBKit', () => {
@@ -339,6 +366,22 @@ describe( 'getPost', () => {
 				restBase: 'posts',
 				restNamespace: 'wp/v2',
 			} );
+		} );
+
+		it( 'should coerce post ID 0 to -1 in GBKit fallback', async () => {
+			window.GBKit = {
+				post: {
+					id: 0,
+					type: 'post',
+					status: 'draft',
+					title: 'Title',
+					content: 'Content',
+				},
+			};
+
+			const result = await getPost();
+
+			expect( result.id ).toBe( -1 );
 		} );
 	} );
 


### PR DESCRIPTION
## Summary
- Treats post ID `0` as `nil`/absent across Android, iOS, and the JS bridge layer
- WordPress uses `0` as a sentinel for "no post" in several contexts; passing it through causes incorrect API requests and editor state
- Adds unit tests on both platforms to verify the coercion

Extracted from #316.

## Test plan
- [x] Verify Android unit tests pass (`EditorConfigurationTest`)
- [x] Verify iOS unit tests pass (`EditorConfigurationTests`)
- [x] Verify JS bridge correctly maps `0` to `-1` (the "no post" sentinel used by Gutenberg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>