### PR TITLE
fix: normalize data store attributes to plain strings in JS bridge

### DIFF
--- a/__mocks__/@wordpress/block-editor.js
+++ b/__mocks__/@wordpress/block-editor.js
@@ -1,1 +1,3 @@
 // Intentionally empty — prevents the real module from loading.
+
+export const store = { name: 'core/block-editor' };

--- a/__mocks__/@wordpress/core-data.js
+++ b/__mocks__/@wordpress/core-data.js
@@ -1,1 +1,1 @@
-// Intentionally empty — prevents the real module from loading.
+export const store = { name: 'core/data' };

--- a/e2e/editor-page.js
+++ b/e2e/editor-page.js
@@ -188,6 +188,17 @@ export default class EditorPage {
 	}
 
 	/**
+	 * Call the bridge's `getTitleAndContent()` and return the result.
+	 *
+	 * @return {Promise<{title: string, content: string, changed: boolean}>} The editor state.
+	 */
+	async getTitleAndContent() {
+		return await this.#page.evaluate( () =>
+			window.editor.getTitleAndContent()
+		);
+	}
+
+	/**
 	 * Retrieve all blocks from the editor via the WP data store.
 	 *
 	 * @return {Promise<Array>} Array of block objects.

--- a/e2e/get-title-and-content.spec.js
+++ b/e2e/get-title-and-content.spec.js
@@ -101,4 +101,82 @@ test.describe( 'getTitleAndContent', () => {
 		expect( result.content ).toBe( '' );
 		expect( result.changed ).toBe( false );
 	} );
+
+	test( 'returns plain strings when data store title is a {raw, rendered} object', async ( {
+		page,
+	} ) => {
+		const editor = new EditorPage( page );
+		await editor.setup( {
+			post: {
+				id: 1,
+				type: 'post',
+				status: 'draft',
+				title: 'Initial Title',
+				content: '',
+			},
+		} );
+
+		// Inject an object-shaped title edit via editEntityRecord.
+		// This simulates the Gutenberg data store bug where
+		// getEditedPostAttribute bypasses getPostRawValue normalization
+		// for values in the edits layer.
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core' )
+				.editEntityRecord( 'postType', 'post', 1, {
+					title: {
+						raw: 'Object Title',
+						rendered: '<b>Object Title</b>',
+					},
+				} );
+		} );
+
+		const result = await editor.getTitleAndContent();
+
+		expect( typeof result.title ).toBe( 'string' );
+		expect( result.title ).toBe( 'Object Title' );
+		expect( result.changed ).toBe( true );
+
+		// Second call should report no further changes.
+		const second = await editor.getTitleAndContent();
+		expect( second.changed ).toBe( false );
+	} );
+
+	test( 'returns plain strings when data store content is a {raw, rendered} object', async ( {
+		page,
+	} ) => {
+		const editor = new EditorPage( page );
+		await editor.setup( {
+			post: {
+				id: 1,
+				type: 'post',
+				status: 'draft',
+				title: 'Title',
+				content: '',
+			},
+		} );
+
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core' )
+				.editEntityRecord( 'postType', 'post', 1, {
+					content: {
+						raw: '<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph -->',
+						rendered: '<p>Test</p>',
+					},
+				} );
+		} );
+
+		const result = await editor.getTitleAndContent();
+
+		expect( typeof result.content ).toBe( 'string' );
+		expect( result.content ).toContain(
+			'<!-- wp:paragraph --><p>Test</p><!-- /wp:paragraph -->'
+		);
+		expect( result.changed ).toBe( true );
+
+		// Second call should report no further changes.
+		const second = await editor.getTitleAndContent();
+		expect( second.changed ).toBe( false );
+	} );
 } );

--- a/e2e/get-title-and-content.spec.js
+++ b/e2e/get-title-and-content.spec.js
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import EditorPage from './editor-page';
+
+test.describe( 'getTitleAndContent', () => {
+	test( 'returns correct title and content before any edits', async ( {
+		page,
+	} ) => {
+		const editor = new EditorPage( page );
+		await editor.setup( {
+			post: {
+				id: 1,
+				type: 'post',
+				status: 'draft',
+				title: 'Initial Title',
+				content:
+					'<!-- wp:paragraph -->\n<p>Hello</p>\n<!-- /wp:paragraph -->',
+			},
+		} );
+
+		const result = await editor.getTitleAndContent();
+
+		expect( typeof result.title ).toBe( 'string' );
+		expect( typeof result.content ).toBe( 'string' );
+		expect( result.title ).toBe( 'Initial Title' );
+		expect( result.content ).toBe(
+			'<!-- wp:paragraph -->\n<p>Hello</p>\n<!-- /wp:paragraph -->'
+		);
+		expect( result.changed ).toBe( false );
+	} );
+
+	test( 'returns plain strings after editing the title', async ( {
+		page,
+	} ) => {
+		const editor = new EditorPage( page );
+		await editor.setup( {
+			post: {
+				id: 1,
+				type: 'post',
+				status: 'draft',
+				title: 'Original',
+				content: '',
+			},
+		} );
+
+		const titleInput = page.getByRole( 'textbox', {
+			name: 'Add title',
+		} );
+		await titleInput.click();
+		await page.keyboard.press( 'ControlOrMeta+a' );
+		await page.keyboard.type( 'Updated Title' );
+
+		const result = await editor.getTitleAndContent();
+
+		expect( typeof result.title ).toBe( 'string' );
+		expect( result.title ).toBe( 'Updated Title' );
+		expect( result.changed ).toBe( true );
+	} );
+
+	test( 'returns plain strings after editing content', async ( { page } ) => {
+		const editor = new EditorPage( page );
+		await editor.setup( {
+			post: {
+				id: 1,
+				type: 'post',
+				status: 'draft',
+				title: 'Title',
+				content: '',
+			},
+		} );
+
+		await editor.clickBlockAppender();
+		await page.keyboard.type( 'New paragraph' );
+
+		const result = await editor.getTitleAndContent();
+
+		expect( typeof result.title ).toBe( 'string' );
+		expect( typeof result.content ).toBe( 'string' );
+		expect( result.title ).toBe( 'Title' );
+		expect( result.content ).toContain( 'New paragraph' );
+		expect( result.changed ).toBe( true );
+	} );
+
+	test( 'returns plain strings with empty initial state', async ( {
+		page,
+	} ) => {
+		const editor = new EditorPage( page );
+		await editor.setup();
+
+		const result = await editor.getTitleAndContent();
+
+		expect( typeof result.title ).toBe( 'string' );
+		expect( typeof result.content ).toBe( 'string' );
+		expect( result.title ).toBe( '' );
+		expect( result.content ).toBe( '' );
+		expect( result.changed ).toBe( false );
+	} );
+} );

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -374,12 +374,6 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         evaluate("editor.setContent('\(escapedString)');", isCritical: true)
     }
 
-    /// Returns the current editor content.
-    public func getContent() async throws -> String {
-        guard isReady else { throw EditorNotReadyError() }
-        return try await webView.evaluateJavaScript("editor.getContent();") as! String
-    }
-
     public struct EditorTitleAndContent: Decodable {
         public let title: String
         public let content: String

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -380,6 +380,16 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         public let changed: Bool
     }
 
+    /// Returns just the current editor content, without the title.
+    ///
+    /// Use this when the editor is used without a title field (e.g. as a
+    /// comment editor). Delegates to `getTitleAndContent()` internally so
+    /// the same normalization is applied.
+    public func getContent() async throws -> String {
+        let result = try await getTitleAndContent()
+        return result.content
+    }
+
     /// Returns the current editor title and content.
     public func getTitleAndContent() async throws -> EditorTitleAndContent {
         guard isReady else { throw EditorNotReadyError() }

--- a/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewControllerDelegate.swift
@@ -18,7 +18,7 @@ public protocol EditorViewControllerDelegate: AnyObject {
 
     /// Notifies the client about the new edits.
     ///
-    /// - note: To get the latest content, call ``EditorViewController/getContent()``.
+    /// - note: To get the latest content, call ``EditorViewController/getTitleAndContent()``.
     /// Retrieving the content is a relatively expensive operation and should not
     /// be performed too frequently during editing.
     ///

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -8,9 +8,16 @@ import { renderHook } from '@testing-library/react';
  * Internal dependencies
  */
 import { useHostBridge } from '../use-host-bridge';
+import { getBlockType } from '@wordpress/blocks';
 
 const mockGetEditedPostAttribute = vi.fn();
 const mockGetEditedPostContent = vi.fn();
+const mockGetSelectedBlockClientId = vi.fn();
+const mockGetBlock = vi.fn();
+const mockGetSelectionStart = vi.fn();
+const mockGetSelectionEnd = vi.fn();
+const mockUpdateBlock = vi.fn();
+const mockSelectionChange = vi.fn();
 
 vi.mock( '@wordpress/data', () => ( {
 	useSelect: ( store ) => {
@@ -22,10 +29,10 @@ vi.mock( '@wordpress/data', () => ( {
 		}
 		// block-editor store selectors
 		return {
-			getSelectedBlockClientId: vi.fn(),
-			getBlock: vi.fn(),
-			getSelectionStart: vi.fn(),
-			getSelectionEnd: vi.fn(),
+			getSelectedBlockClientId: mockGetSelectedBlockClientId,
+			getBlock: mockGetBlock,
+			getSelectionStart: mockGetSelectionStart,
+			getSelectionEnd: mockGetSelectionEnd,
 		};
 	},
 	useDispatch: () => ( {
@@ -33,8 +40,8 @@ vi.mock( '@wordpress/data', () => ( {
 		undo: vi.fn(),
 		redo: vi.fn(),
 		switchEditorMode: vi.fn(),
-		updateBlock: vi.fn(),
-		selectionChange: vi.fn(),
+		updateBlock: mockUpdateBlock,
+		selectionChange: mockSelectionChange,
 	} ),
 } ) );
 vi.mock( '@wordpress/core-data', () => ( {
@@ -43,7 +50,28 @@ vi.mock( '@wordpress/core-data', () => ( {
 vi.mock( '@wordpress/editor', () => ( {
 	store: { name: 'core/editor' },
 } ) );
-vi.mock( '@wordpress/blocks' );
+vi.mock( '@wordpress/blocks', () => ( {
+	parse: vi.fn( () => [] ),
+	serialize: vi.fn( () => '' ),
+	getBlockType: vi.fn(),
+} ) );
+vi.mock( '@wordpress/rich-text', () => ( {
+	create: vi.fn( ( { html } ) => ( {
+		text: html,
+		formats: [],
+		replacements: [],
+		start: 0,
+		end: html.length,
+	} ) ),
+	insert: vi.fn( ( value, text ) => ( {
+		text: value.text + text,
+		formats: [],
+		replacements: [],
+		start: 0,
+		end: value.text.length + text.length,
+	} ) ),
+	toHTMLString: vi.fn( ( { value } ) => value.text ),
+} ) );
 vi.mock( '@wordpress/block-editor', () => ( {
 	store: { name: 'core/block-editor' },
 } ) );
@@ -120,6 +148,207 @@ describe( 'useHostBridge', () => {
 		const result = window.editor.getTitleAndContent();
 		expect( result.title ).toBe( 'Plain Title' );
 		expect( result.content ).toBe( 'Plain Content' );
+	} );
+
+	it( 'getTitleAndContent returns empty strings when data store returns null', () => {
+		mockGetEditedPostAttribute.mockReturnValue( null );
+		mockGetEditedPostContent.mockReturnValue( null );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.getTitleAndContent();
+		expect( result.title ).toBe( '' );
+		expect( result.content ).toBe( '' );
+	} );
+
+	it( 'getTitleAndContent returns empty strings when data store returns undefined', () => {
+		mockGetEditedPostAttribute.mockReturnValue( undefined );
+		mockGetEditedPostContent.mockReturnValue( undefined );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.getTitleAndContent();
+		expect( result.title ).toBe( '' );
+		expect( result.content ).toBe( '' );
+	} );
+
+	it( 'getTitleAndContent returns empty string for object with raw: null', () => {
+		mockGetEditedPostAttribute.mockReturnValue( { raw: null } );
+		mockGetEditedPostContent.mockReturnValue( {
+			raw: undefined,
+		} );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.getTitleAndContent();
+		expect( result.title ).toBe( '' );
+		expect( result.content ).toBe( '' );
+	} );
+
+	it( 'getTitleAndContent returns empty string for arrays', () => {
+		mockGetEditedPostAttribute.mockReturnValue( [ 'unexpected' ] );
+		mockGetEditedPostContent.mockReturnValue( [] );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.getTitleAndContent();
+		expect( result.title ).toBe( '' );
+		expect( result.content ).toBe( '' );
+	} );
+
+	it( 'getTitleAndContent coerces non-string primitives to strings', () => {
+		mockGetEditedPostAttribute.mockReturnValue( 42 );
+		mockGetEditedPostContent.mockReturnValue( false );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.getTitleAndContent();
+		expect( result.title ).toBe( '42' );
+		expect( result.content ).toBe( 'false' );
+	} );
+
+	it( 'getTitleAndContent reports changed correctly with object values', () => {
+		mockGetEditedPostAttribute.mockReturnValue( {
+			raw: 'Changed Title',
+			rendered: '<b>Changed Title</b>',
+		} );
+		mockGetEditedPostContent.mockReturnValue( '' );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const first = window.editor.getTitleAndContent();
+		expect( first.changed ).toBe( true );
+		expect( first.title ).toBe( 'Changed Title' );
+
+		const second = window.editor.getTitleAndContent();
+		expect( second.changed ).toBe( false );
+	} );
+
+	it( 'getTitleAndContent reports changed: false when values match initial state', () => {
+		mockGetEditedPostAttribute.mockReturnValue( '' );
+		mockGetEditedPostContent.mockReturnValue( '' );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.getTitleAndContent();
+		expect( result.changed ).toBe( false );
+	} );
+
+	it( 'appendTextAtCursor normalizes object-shaped block content', () => {
+		mockGetSelectedBlockClientId.mockReturnValue( 'block-1' );
+		mockGetBlock.mockReturnValue( {
+			name: 'core/paragraph',
+			clientId: 'block-1',
+			attributes: {
+				content: {
+					raw: '<p>Existing</p>',
+					rendered: '<p>Existing</p>',
+				},
+			},
+		} );
+		getBlockType.mockReturnValue( {
+			attributes: { content: { type: 'string' } },
+		} );
+		mockGetSelectionStart.mockReturnValue( {
+			clientId: 'block-1',
+			attributeKey: 'content',
+			offset: 8,
+		} );
+		mockGetSelectionEnd.mockReturnValue( {
+			clientId: 'block-1',
+			attributeKey: 'content',
+			offset: 8,
+		} );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.appendTextAtCursor( ' appended' );
+
+		expect( result ).toBe( true );
+		expect( mockUpdateBlock ).toHaveBeenCalledWith( 'block-1', {
+			attributes: expect.objectContaining( {
+				content: expect.any( String ),
+			} ),
+		} );
+	} );
+
+	it( 'appendTextAtCursor works with plain string block content', () => {
+		mockGetSelectedBlockClientId.mockReturnValue( 'block-1' );
+		mockGetBlock.mockReturnValue( {
+			name: 'core/paragraph',
+			clientId: 'block-1',
+			attributes: { content: 'Hello' },
+		} );
+		getBlockType.mockReturnValue( {
+			attributes: { content: { type: 'string' } },
+		} );
+		mockGetSelectionStart.mockReturnValue( {
+			clientId: 'block-1',
+			attributeKey: 'content',
+			offset: 5,
+		} );
+		mockGetSelectionEnd.mockReturnValue( {
+			clientId: 'block-1',
+			attributeKey: 'content',
+			offset: 5,
+		} );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.appendTextAtCursor( ' World' );
+
+		expect( result ).toBe( true );
+		expect( mockUpdateBlock ).toHaveBeenCalledWith( 'block-1', {
+			attributes: expect.objectContaining( {
+				content: expect.any( String ),
+			} ),
+		} );
+	} );
+
+	it( 'appendTextAtCursor returns false when no block is selected', () => {
+		mockGetSelectedBlockClientId.mockReturnValue( null );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		expect( window.editor.appendTextAtCursor( 'text' ) ).toBe( false );
+	} );
+
+	it( 'appendTextAtCursor returns false for blocks without content attribute', () => {
+		mockGetSelectedBlockClientId.mockReturnValue( 'block-1' );
+		mockGetBlock.mockReturnValue( {
+			name: 'core/image',
+			clientId: 'block-1',
+			attributes: { url: 'test.jpg' },
+		} );
+		getBlockType.mockReturnValue( {
+			attributes: { url: { type: 'string' } },
+		} );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		expect( window.editor.appendTextAtCursor( 'text' ) ).toBe( false );
 	} );
 
 	it( 'cleans up window.editor methods on unmount', () => {

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -44,17 +44,9 @@ vi.mock( '@wordpress/data', () => ( {
 		selectionChange: mockSelectionChange,
 	} ),
 } ) );
-vi.mock( '@wordpress/core-data', () => ( {
-	store: { name: 'core' },
-} ) );
-vi.mock( '@wordpress/editor', () => ( {
-	store: { name: 'core/editor' },
-} ) );
-vi.mock( '@wordpress/blocks', () => ( {
-	parse: vi.fn( () => [] ),
-	serialize: vi.fn( () => '' ),
-	getBlockType: vi.fn(),
-} ) );
+vi.mock( '@wordpress/core-data' );
+vi.mock( '@wordpress/editor' );
+vi.mock( '@wordpress/blocks' );
 vi.mock( '@wordpress/rich-text', () => ( {
 	create: vi.fn( ( { html } ) => ( {
 		text: html,
@@ -72,9 +64,7 @@ vi.mock( '@wordpress/rich-text', () => ( {
 	} ) ),
 	toHTMLString: vi.fn( ( { value } ) => value.text ),
 } ) );
-vi.mock( '@wordpress/block-editor', () => ( {
-	store: { name: 'core/block-editor' },
-} ) );
+vi.mock( '@wordpress/block-editor' );
 
 const defaultPost = {
 	id: 1,

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -9,11 +9,44 @@ import { renderHook } from '@testing-library/react';
  */
 import { useHostBridge } from '../use-host-bridge';
 
-vi.mock( '@wordpress/data' );
-vi.mock( '@wordpress/core-data' );
-vi.mock( '@wordpress/editor' );
+const mockGetEditedPostAttribute = vi.fn();
+const mockGetEditedPostContent = vi.fn();
+
+vi.mock( '@wordpress/data', () => ( {
+	useSelect: ( store ) => {
+		if ( store?.name === 'core/editor' ) {
+			return {
+				getEditedPostAttribute: mockGetEditedPostAttribute,
+				getEditedPostContent: mockGetEditedPostContent,
+			};
+		}
+		// block-editor store selectors
+		return {
+			getSelectedBlockClientId: vi.fn(),
+			getBlock: vi.fn(),
+			getSelectionStart: vi.fn(),
+			getSelectionEnd: vi.fn(),
+		};
+	},
+	useDispatch: () => ( {
+		editEntityRecord: vi.fn(),
+		undo: vi.fn(),
+		redo: vi.fn(),
+		switchEditorMode: vi.fn(),
+		updateBlock: vi.fn(),
+		selectionChange: vi.fn(),
+	} ),
+} ) );
+vi.mock( '@wordpress/core-data', () => ( {
+	store: { name: 'core' },
+} ) );
+vi.mock( '@wordpress/editor', () => ( {
+	store: { name: 'core/editor' },
+} ) );
 vi.mock( '@wordpress/blocks' );
-vi.mock( '@wordpress/block-editor' );
+vi.mock( '@wordpress/block-editor', () => ( {
+	store: { name: 'core/block-editor' },
+} ) );
 
 const defaultPost = {
 	id: 1,
@@ -43,7 +76,6 @@ describe( 'useHostBridge', () => {
 		// Verify all bridge methods exist
 		expect( window.editor.setContent ).toBeTypeOf( 'function' );
 		expect( window.editor.setTitle ).toBeTypeOf( 'function' );
-		expect( window.editor.getContent ).toBeTypeOf( 'function' );
 		expect( window.editor.getTitleAndContent ).toBeTypeOf( 'function' );
 		expect( window.editor.undo ).toBeTypeOf( 'function' );
 		expect( window.editor.redo ).toBeTypeOf( 'function' );
@@ -53,6 +85,41 @@ describe( 'useHostBridge', () => {
 		expect( window.editor.appendTextAtCursor ).toBeTypeOf( 'function' );
 
 		expect( markBridgeReady ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'getTitleAndContent returns plain strings when data store returns objects', () => {
+		mockGetEditedPostAttribute.mockReturnValue( {
+			raw: 'Hello World',
+			rendered: '<b>Hello World</b>',
+		} );
+		mockGetEditedPostContent.mockReturnValue( {
+			raw: '<!-- wp:paragraph -->\n<p>Hello</p>\n<!-- /wp:paragraph -->',
+			rendered: '<p>Hello</p>',
+			protected: false,
+		} );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.getTitleAndContent();
+		expect( result.title ).toBe( 'Hello World' );
+		expect( result.content ).toBe(
+			'<!-- wp:paragraph -->\n<p>Hello</p>\n<!-- /wp:paragraph -->'
+		);
+	} );
+
+	it( 'getTitleAndContent passes through plain strings unchanged', () => {
+		mockGetEditedPostAttribute.mockReturnValue( 'Plain Title' );
+		mockGetEditedPostContent.mockReturnValue( 'Plain Content' );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.getTitleAndContent();
+		expect( result.title ).toBe( 'Plain Title' );
+		expect( result.content ).toBe( 'Plain Content' );
 	} );
 
 	it( 'cleans up window.editor methods on unmount', () => {
@@ -66,7 +133,6 @@ describe( 'useHostBridge', () => {
 
 		expect( window.editor.setContent ).toBeUndefined();
 		expect( window.editor.setTitle ).toBeUndefined();
-		expect( window.editor.getContent ).toBeUndefined();
 		expect( window.editor.getTitleAndContent ).toBeUndefined();
 		expect( window.editor.undo ).toBeUndefined();
 		expect( window.editor.redo ).toBeUndefined();

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -104,6 +104,7 @@ describe( 'useHostBridge', () => {
 		// Verify all bridge methods exist
 		expect( window.editor.setContent ).toBeTypeOf( 'function' );
 		expect( window.editor.setTitle ).toBeTypeOf( 'function' );
+		expect( window.editor.getContent ).toBeTypeOf( 'function' );
 		expect( window.editor.getTitleAndContent ).toBeTypeOf( 'function' );
 		expect( window.editor.undo ).toBeTypeOf( 'function' );
 		expect( window.editor.redo ).toBeTypeOf( 'function' );
@@ -148,6 +149,24 @@ describe( 'useHostBridge', () => {
 		const result = window.editor.getTitleAndContent();
 		expect( result.title ).toBe( 'Plain Title' );
 		expect( result.content ).toBe( 'Plain Content' );
+	} );
+
+	it( 'getContent returns normalized content string', () => {
+		mockGetEditedPostAttribute.mockReturnValue( 'Title' );
+		mockGetEditedPostContent.mockReturnValue( {
+			raw: '<!-- wp:paragraph -->\n<p>Hello</p>\n<!-- /wp:paragraph -->',
+			rendered: '<p>Hello</p>',
+		} );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		const result = window.editor.getContent();
+		expect( typeof result ).toBe( 'string' );
+		expect( result ).toBe(
+			'<!-- wp:paragraph -->\n<p>Hello</p>\n<!-- /wp:paragraph -->'
+		);
 	} );
 
 	it( 'getTitleAndContent returns empty strings when data store returns null', () => {
@@ -362,6 +381,7 @@ describe( 'useHostBridge', () => {
 
 		expect( window.editor.setContent ).toBeUndefined();
 		expect( window.editor.setTitle ).toBeUndefined();
+		expect( window.editor.getContent ).toBeUndefined();
 		expect( window.editor.getTitleAndContent ).toBeUndefined();
 		expect( window.editor.undo ).toBeUndefined();
 		expect( window.editor.redo ).toBeUndefined();

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -36,10 +36,12 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 		[ editEntityRecord, post.id, post.type ]
 	);
 
-	const postTitleRef = useRef( post.title.raw );
+	const postTitleRef = useRef( normalizeAttribute( post.title ) );
 	const postContentRef = useRef( null );
 	if ( postContentRef.current === null ) {
-		postContentRef.current = serialize( parse( post.content.raw || '' ) );
+		postContentRef.current = serialize(
+			parse( normalizeAttribute( post.content ) )
+		);
 	}
 
 	useEffect( () => {
@@ -139,7 +141,9 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 				return false;
 			}
 
-			const blockContent = block.attributes?.content || '';
+			const blockContent = normalizeAttribute(
+				block.attributes?.content
+			);
 			const currentValue = create( { html: blockContent } );
 			const selectionStart = getSelectionStart();
 			const selectionEnd = getSelectionEnd();
@@ -212,14 +216,17 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
  * a field). This function always extracts the raw string so the host app
  * receives a consistent type.
  *
- * @param {string|Object} value The value from a data store selector.
+ * @param {string|Object|null|undefined} value The value from a data store selector.
  * @return {string} The raw string value.
  */
 function normalizeAttribute( value ) {
-	if ( typeof value === 'object' ) {
-		return value?.raw ?? '';
+	if ( value === null || value === undefined ) {
+		return '';
 	}
-	return value ?? '';
+	if ( typeof value === 'object' ) {
+		return value.raw ?? '';
+	}
+	return String( value );
 }
 
 /**

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -230,7 +230,7 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
  * @return {string} The raw string value.
  */
 function normalizeAttribute( value ) {
-	if ( value === null || value === undefined ) {
+	if ( value === null || value === undefined || Array.isArray( value ) ) {
 		return '';
 	}
 	if ( typeof value === 'object' ) {

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -53,6 +53,15 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 			editContent( { title: decodeURIComponent( title ) } );
 		};
 
+		// Convenience accessor for contexts where only the content is needed
+		// (e.g. a comment editor with no title field). Delegates to
+		// getTitleAndContent so normalization happens in one place.
+		window.editor.getContent = ( completeComposition = false ) => {
+			const { content } =
+				window.editor.getTitleAndContent( completeComposition );
+			return content;
+		};
+
 		window.editor.getTitleAndContent = ( completeComposition = false ) => {
 			if ( completeComposition ) {
 				endComposition( editorRef.current );
@@ -182,6 +191,7 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 		return () => {
 			delete window.editor.setContent;
 			delete window.editor.setTitle;
+			delete window.editor.getContent;
 			delete window.editor.getTitleAndContent;
 			delete window.editor.undo;
 			delete window.editor.redo;

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -51,21 +51,15 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 			editContent( { title: decodeURIComponent( title ) } );
 		};
 
-		window.editor.getContent = ( completeComposition = false ) => {
-			if ( completeComposition ) {
-				endComposition( editorRef.current );
-			}
-
-			return getEditedPostContent();
-		};
-
 		window.editor.getTitleAndContent = ( completeComposition = false ) => {
 			if ( completeComposition ) {
 				endComposition( editorRef.current );
 			}
 
-			const title = getEditedPostAttribute( 'title' );
-			const content = getEditedPostContent();
+			const title = normalizeAttribute(
+				getEditedPostAttribute( 'title' )
+			);
+			const content = normalizeAttribute( getEditedPostContent() );
 			const changed =
 				title !== postTitleRef.current ||
 				content !== postContentRef.current;
@@ -184,7 +178,6 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 		return () => {
 			delete window.editor.setContent;
 			delete window.editor.setTitle;
-			delete window.editor.getContent;
 			delete window.editor.getTitleAndContent;
 			delete window.editor.undo;
 			delete window.editor.redo;
@@ -209,6 +202,24 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 		updateBlock,
 		selectionChange,
 	] );
+}
+
+/**
+ * Normalizes a WordPress data store attribute to a plain string.
+ *
+ * The data store may return either a plain string or a `{ raw, rendered }`
+ * object depending on internal state (e.g. before vs. after the user edits
+ * a field). This function always extracts the raw string so the host app
+ * receives a consistent type.
+ *
+ * @param {string|Object} value The value from a data store selector.
+ * @return {string} The raw string value.
+ */
+function normalizeAttribute( value ) {
+	if ( typeof value === 'object' ) {
+		return value?.raw ?? '';
+	}
+	return value ?? '';
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a bug where `editor.getTitleAndContent()` could return JavaScript objects instead of plain strings to the native host app, corrupting the content in the host app.

## Root Cause

WordPress's Gutenberg data store has an architectural inconsistency in how `getEditedPostAttribute` handles values from the **edits layer** vs the **base entity record**.

When a post is loaded, title and content are stored as `{ raw: "..." }` objects in the entity record (this is the shape `getPost()` in `bridge.js` constructs). Two different normalization paths exist:

1. **Base record path** (no user edits): `getEditedPostAttribute('title')` → `getCurrentPostAttribute` → `getCurrentPost` → `getRawEntityRecord` (extracts `.raw`) → then `getPostRawValue` is applied — returns a **plain string**. ✅
2. **Edits path** (after any code calls `editEntityRecord`): `getEditedPostAttribute('title')` → `edits[attributeName]` — returns **whatever was stored in edits, with no normalization**. ❌

The edits reducer stores values verbatim:
```js
case 'EDIT_ENTITY_RECORD':
    const nextEdits = { ...state[action.recordId], ...action.edits };
```

So if anything dispatches `editEntityRecord('postType', type, id, { title: { raw: '...', rendered: '...' } })`, the `{raw, rendered}` object goes directly into `edits.title`, and `getEditedPostAttribute('title')` returns the object — bypassing `getPostRawValue` entirely.

Similarly, `getEditedPostContent()` has a code path that returns `record.content` from `getEditedEntityRecord` without normalization — if the content in the edits layer is an object, it passes through as-is.

### When does this happen in practice?

- **Undo/redo**: The undo manager stores `{ from: editedRecord[key], to: edits[key] }`. If at any point the edited record contained a `{raw, rendered}` object, undo replays it as an edit — re-introducing the object.
- **Any internal Gutenberg code** that calls `editEntityRecord` with REST API-shaped data rather than plain strings.

### Confirmed via E2E

We confirmed this by injecting `{raw, rendered}` objects via `editEntityRecord` in a Playwright test and then calling `getTitleAndContent()`, verifying the bridge returns plain strings (i.e., `normalizeAttribute()` catches the object before it reaches the host). The underlying `getEditedPostAttribute('title')` selector does return the object in this scenario — confirmed separately during reproduction testing.

We could **not** reproduce the bug through normal user interactions (typing, undo/redo, cache invalidation, REST API re-fetches) — the standard Gutenberg code paths happen to always produce string edits. The bug requires an internal code path that dispatches object-shaped edits, which is a Gutenberg data store implementation detail outside our control.

### The Android/iOS host apps are not the source

Both the Android (`GBKitGlobal.Post.title: String`) and iOS host apps pass plain strings to GutenbergKit. The WordPress Android app (WordPress-Android) also decomposes `{raw, rendered}` from the REST API into plain strings via FluxC `PostModel` before reaching GutenbergKit. The issue is entirely within the JS data store layer.

## What We Explored

### 1. Making native types match the `{raw, rendered}` shape
We initially updated iOS and Android to parse `{raw, rendered}` objects. This worked mechanically, but `rendered` is useless client-side — it's only available from the server's initial REST API response and becomes stale after any edit. The server-side rendering pipeline cannot be reproduced in the client.

### 2. Hoisting the `{raw, rendered}` wrapper into native input types
We considered having `EditorConfiguration` accept `{raw, rendered}` objects. But the data store replaces them with plain strings after edits, so output normalization would still be needed — making the input change pure overhead.

### 3. Using `getEditedPostAttribute('content')` instead of `getEditedPostContent()`
For `'content'` specifically, `getEditedPostAttribute` delegates to `getEditedPostContent()` — same code path, same bug.

## Fix

Add a `normalizeAttribute()` function at the JS bridge boundary that extracts `.raw` from objects or passes strings through unchanged. Applied to both title and content in `getTitleAndContent()`, to block content in `appendTextAtCursor()`, and defensively to the initial `postTitleRef` and `postContentRef` initialization.

```js
function normalizeAttribute( value ) {
    if ( value === null || value === undefined ) {
        return '';
    }
    if ( typeof value === 'object' ) {
        return value.raw ?? '';
    }
    return String( value );
}
```

The `getContent()` JS bridge method and iOS `EditorViewController.getContent()` are retained as convenience accessors for contexts where only content is needed (e.g. comment editors with no title field). Both delegate to `getTitleAndContent()` so normalization happens in one place.

## Changes

- **`src/components/editor/use-host-bridge.js`**: Add `normalizeAttribute()`, apply to `getTitleAndContent()`, `getContent()`, and `appendTextAtCursor()`, defensively normalize ref initialization
- **`src/components/editor/test/use-host-bridge.test.jsx`**: Unit tests for normalization edge cases (null, undefined, objects, arrays, primitives), `changed` flag correctness, `getContent()`, and `appendTextAtCursor` with object-shaped and string block content
- **`e2e/get-title-and-content.spec.js`**: E2E tests covering plain string return in all states, including regression tests that inject `{raw, rendered}` objects via `editEntityRecord` and verify normalization with correct `changed` flag behavior
- **`e2e/editor-page.js`**: Add `getTitleAndContent()` helper to page object
- **`ios/.../EditorViewController.swift`**: `getContent()` now delegates to `getTitleAndContent()` for consistent normalization

## Test Plan

- [x] JS unit tests pass (16 tests)
- [x] ESLint passes
- [x] E2E tests pass (6 tests) — including regression tests that reproduce the bug by injecting `{raw, rendered}` objects into the data store
- [x] iOS Swift package builds