### PR TITLE
fix(android): include restBase and restNamespace in GBKit post payload

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/GBKitGlobal.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/GBKitGlobal.kt
@@ -74,6 +74,10 @@ data class GBKitGlobal(
         val id: Int, // TODO: Instead of the `-1` trick, this should just be `null` for new posts
         /** The post type (e.g., `post`, `page`). */
         val type: String,
+        /** The REST API base path for this post type (e.g., `posts`, `pages`). */
+        val restBase: String,
+        /** The REST API namespace (e.g., `wp/v2`). */
+        val restNamespace: String,
         /** The post status (e.g., `draft`, `publish`, `pending`). */
         val status: String,
         /** The post title (URL-encoded). */
@@ -110,6 +114,8 @@ data class GBKitGlobal(
                 post = Post(
                     id = postId ?: -1,
                     type = configuration.postType,
+                    restBase = restBaseFor(configuration.postType),
+                    restNamespace = "wp/v2",
                     status = configuration.postStatus,
                     title = configuration.title.encodeForEditor(),
                     content = configuration.content.encodeForEditor()
@@ -125,6 +131,18 @@ data class GBKitGlobal(
                     }
                 }
             )
+        }
+
+        /**
+         * Maps a post type slug to its WordPress REST API base path.
+         *
+         * Defaults to pluralizing the slug for unknown types (e.g., `product` → `products`),
+         * which matches the WordPress convention for most post types.
+         */
+        private fun restBaseFor(postType: String): String = when (postType) {
+            "post" -> "posts"
+            "page" -> "pages"
+            else -> if (postType.endsWith("s")) postType else "${postType}s"
         }
     }
 

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/GBKitGlobalTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/GBKitGlobalTest.kt
@@ -118,6 +118,29 @@ class GBKitGlobalTest {
     }
 
     @Test
+    fun `populates restBase and restNamespace for post type`() {
+        val configuration = makeConfiguration(postType = "post")
+        val global = GBKitGlobal.fromConfiguration(configuration, makeDependencies())
+        assertEquals("posts", global.post.restBase)
+        assertEquals("wp/v2", global.post.restNamespace)
+    }
+
+    @Test
+    fun `populates restBase for page post type`() {
+        val configuration = makeConfiguration(postType = "page")
+        val global = GBKitGlobal.fromConfiguration(configuration, makeDependencies())
+        assertEquals("pages", global.post.restBase)
+        assertEquals("wp/v2", global.post.restNamespace)
+    }
+
+    @Test
+    fun `pluralizes custom post type slugs for restBase`() {
+        val configuration = makeConfiguration(postType = "product")
+        val global = GBKitGlobal.fromConfiguration(configuration, makeDependencies())
+        assertEquals("products", global.post.restBase)
+    }
+
+    @Test
     fun `maps zero postID to negative one`() {
         val configuration = makeConfiguration(postId = 0u)
         val global = GBKitGlobal.fromConfiguration(configuration, makeDependencies())

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -111,6 +111,18 @@ function tokenAuthMiddleware( options, next ) {
  * Middleware to filter out requests to specific endpoints.
  *
  * @type {APIFetchMiddleware}
+ *
+ * @todo Properly seed the post entity and remove this middleware.
+ *
+ * This was added to prevent re-fetching entity content provided by the native
+ * host app, which can lead to content loss. However, we can likely avoid the
+ * need for this middleware by ensuring we properly seed the entity content into
+ * the store on initialization.
+ *
+ * This requires hoisting the relevant logic from `useEditorSetup` to occur
+ * before we render the editor, and invoking `finishResolution`.
+ *
+ * See: https://github.com/wordpress-mobile/GutenbergKit/commit/c9b4fc9978a3760ba97f3f5d4359c2bc2155bb80
  */
 function filterEndpointsMiddleware( options, next ) {
 	const { post } = getGBKit();

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -7,7 +7,7 @@ import { getQueryArg } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { getGBKit } from './bridge';
+import { getGBKit, POST_FALLBACKS } from './bridge';
 
 /**
  * @typedef {import('@wordpress/api-fetch').APIFetchMiddleware} APIFetchMiddleware
@@ -114,13 +114,16 @@ function tokenAuthMiddleware( options, next ) {
  */
 function filterEndpointsMiddleware( options, next ) {
 	const { post } = getGBKit();
-	const { id, restNamespace, restBase } = post ?? {};
 
-	if ( id === undefined || ! restNamespace || ! restBase ) {
+	if ( ! post || post.id === undefined ) {
 		return next( options );
 	}
 
-	const disabledPath = `/${ restNamespace }/${ restBase }/${ id }`;
+	// Apply the same fallback contract as `getPost()` so the filter still
+	// engages on hosts whose payload omits restBase/restNamespace.
+	const restNamespace = post.restNamespace || POST_FALLBACKS.restNamespace;
+	const restBase = post.restBase || POST_FALLBACKS.restBase;
+	const disabledPath = `/${ restNamespace }/${ restBase }/${ post.id }`;
 
 	if (
 		options.path === disabledPath ||

--- a/src/utils/api-fetch.test.js
+++ b/src/utils/api-fetch.test.js
@@ -22,7 +22,13 @@ import apiFetch from '@wordpress/api-fetch';
 import { configureApiFetch } from './api-fetch';
 import * as bridge from './bridge';
 
-vi.mock( './bridge' );
+vi.mock( './bridge', async ( importOriginal ) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		getGBKit: vi.fn(),
+	};
+} );
 
 describe( 'api-fetch credentials handling', () => {
 	let originalFetch;
@@ -116,6 +122,76 @@ describe( 'api-fetch credentials handling', () => {
 
 		expect( options.credentials ).toBe( 'omit' );
 		expect( options.headers.Authorization ).toBe( 'Bearer override-token' );
+	} );
+
+	describe( 'filterEndpointsMiddleware', () => {
+		it( 'filters the post endpoint when restBase and restNamespace are provided', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [ 'wp/v2' ],
+				namespaceExcludedPaths: [],
+				post: {
+					id: 42,
+					restBase: 'posts',
+					restNamespace: 'wp/v2',
+				},
+			} );
+
+			const result = await apiFetch( { path: '/wp/v2/posts/42' } );
+
+			expect( global.fetch ).not.toHaveBeenCalled();
+			expect( result ).toEqual( [] );
+		} );
+
+		it( 'falls back to default restBase and restNamespace when omitted from the payload', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [ 'wp/v2' ],
+				namespaceExcludedPaths: [],
+				post: {
+					id: 7,
+					// restBase and restNamespace intentionally omitted
+				},
+			} );
+
+			const result = await apiFetch( { path: '/wp/v2/posts/7' } );
+
+			expect( global.fetch ).not.toHaveBeenCalled();
+			expect( result ).toEqual( [] );
+		} );
+
+		it( 'lets the request through when post id is undefined', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [ 'wp/v2' ],
+				namespaceExcludedPaths: [],
+				post: {},
+			} );
+
+			try {
+				await apiFetch( { path: '/wp/v2/posts/99' } );
+			} catch ( error ) {
+				// Ignore errors from the actual fetch
+			}
+
+			expect( global.fetch ).toHaveBeenCalled();
+		} );
+
+		it( 'lets the request through when no post payload is present', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [ 'wp/v2' ],
+				namespaceExcludedPaths: [],
+			} );
+
+			try {
+				await apiFetch( { path: '/wp/v2/posts/99' } );
+			} catch ( error ) {
+				// Ignore errors from the actual fetch
+			}
+
+			expect( global.fetch ).toHaveBeenCalled();
+		} );
 	} );
 
 	it( 'should preserve other headers when adding Authorization', async () => {

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -216,6 +216,19 @@ export function onNetworkRequest( requestData ) {
  */
 
 /**
+ * Default values used when the native host omits fields from the post payload.
+ * Centralized here so all consumers (getPost, filterEndpointsMiddleware) agree
+ * on the fallback contract.
+ */
+export const POST_FALLBACKS = {
+	id: -1,
+	type: 'post',
+	restBase: 'posts',
+	restNamespace: 'wp/v2',
+	status: 'draft',
+};
+
+/**
  * Retrieves the native-host-provided GBKit object from localStorage or returns
  * an empty object if not found.
  *
@@ -300,11 +313,11 @@ export async function getPost() {
 	if ( hostContent ) {
 		debug( 'Using content from native host' );
 		return {
-			id: post?.id || -1,
-			type: post?.type || 'post',
-			restBase: post?.restBase || 'posts',
-			restNamespace: post?.restNamespace || 'wp/v2',
-			status: post?.status || 'draft',
+			id: post?.id || POST_FALLBACKS.id,
+			type: post?.type || POST_FALLBACKS.type,
+			restBase: post?.restBase || POST_FALLBACKS.restBase,
+			restNamespace: post?.restNamespace || POST_FALLBACKS.restNamespace,
+			status: post?.status || POST_FALLBACKS.status,
 			title: { raw: hostContent.title },
 			content: { raw: hostContent.content },
 		};
@@ -313,11 +326,11 @@ export async function getPost() {
 	if ( post ) {
 		debug( 'Native bridge unavailable, using GBKit initial content' );
 		return {
-			id: post.id || -1,
-			type: post.type || 'post',
-			restBase: post.restBase || 'posts',
-			restNamespace: post.restNamespace || 'wp/v2',
-			status: post.status || 'draft',
+			id: post.id || POST_FALLBACKS.id,
+			type: post.type || POST_FALLBACKS.type,
+			restBase: post.restBase || POST_FALLBACKS.restBase,
+			restNamespace: post.restNamespace || POST_FALLBACKS.restNamespace,
+			status: post.status || POST_FALLBACKS.status,
 			title: { raw: decodeURIComponent( post.title ) },
 			content: { raw: decodeURIComponent( post.content ) },
 		};
@@ -325,11 +338,7 @@ export async function getPost() {
 
 	// Fallback to default empty post
 	return {
-		id: -1,
-		type: 'post',
-		restBase: 'posts',
-		restNamespace: 'wp/v2',
-		status: 'draft',
+		...POST_FALLBACKS,
 		title: { raw: '' },
 		content: { raw: '' },
 	};


### PR DESCRIPTION
## What?

- Adds `restBase` and `restNamespace` to the Android `GBKitGlobal.Post` payload, populated from the configured post type via a small heuristic (`post`→`posts`, `page`→`pages`, custom types pluralized).
- Hardens `filterEndpointsMiddleware` so it falls back to `wp/v2`/`posts` when those fields are missing from `window.GBKit.post`, matching the contract `getPost()` already provides.

## Why?

`filterEndpointsMiddleware` (in `src/utils/api-fetch.js`) failed blocking server fetches for the post being edited. This resulted in the WordPress core data fetched via `GET /wp/v2/posts/{id}` clearing the title and content set from the native host.

iOS already populates these fields from `EditorConfiguration.postType` (`PostTypeDetails`). This PR brings Android in line and adds a defensive fallback in the JS middleware so any host that omits the fields still gets the filter applied.

## How?

- `android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/GBKitGlobal.kt` — adds the two new fields to `Post`, populates them in `fromConfiguration`, and introduces a private `restBaseFor(postType)` helper with the pluralization heuristic.
- `src/utils/bridge.js` — extracts a new exported `POST_FALLBACKS` constant so `getPost()` and the middleware share one source of truth for default values.
- `src/utils/api-fetch.js` — `filterEndpointsMiddleware` now bails out only when there is no post or no post id, and falls back to `POST_FALLBACKS` for `restBase`/`restNamespace`.
- `src/utils/api-fetch.test.js` — switches the bridge mock to a partial mock so `POST_FALLBACKS` survives, and adds four new cases covering the filter with/without explicit fields and the bail-out paths.
- `android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/GBKitGlobalTest.kt` — asserts `restBase`/`restNamespace` for `post`, `page`, and a custom post type.

## Testing Instructions

Since the Android demo app cannot yet edit existing posts, a manual patch is required to verify the fix end-to-end.

1. Apply a manual patch with test title/content and valid post ID from a site. 
    ```diff
    diff --git a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
    index bb1a6c81..35a8dcf3 100644
    --- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
    +++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
    @@ -231,6 +231,7 @@ class SitePreparationViewModel(
                arrayOf()
            }
    
    +        val postId: UInt = 0000u;
            return EditorConfiguration.builder(
                siteURL = config.siteUrl,
                siteApiRoot = siteApiRoot,
    @@ -241,8 +242,9 @@ class SitePreparationViewModel(
                .setSiteApiNamespace(siteApiNamespace)
                .setNamespaceExcludedPaths(arrayOf())
                .setAuthHeader(config.authHeader)
    -            .setTitle("")
    -            .setContent("")
    +            .setPostId(postId)
    +            .setTitle("Test")
    +            .setContent("<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->")
                .setHideTitle(false)
                .setCookies(emptyMap())
                .setEnableNetworkLogging(true)

    ```
1. Replace `0000` with a valid post ID for your test site. 
1. Open the editor for your test site via the Start button. 
1. Wait a few seconds for initial fetches to complete.
1. Verify the editor title and content is not cleared. 

### Accessibility Testing Instructions

No UI changes; not applicable.

## Screenshots or screencast

N/A — bug fix with no visible UI changes.