### PR TITLE
feat: trigger editor savePost() lifecycle from native hosts

### DIFF
--- a/__mocks__/@wordpress/data.js
+++ b/__mocks__/@wordpress/data.js
@@ -1,19 +1,11 @@
 import { vi } from 'vitest';
 
-// Stable map of mock dispatched actions for stores referenced by editor
-// code (e.g. core/editor's `savePost`, `undo`, `redo`, `switchEditorMode`,
-// and core/notices' `removeNotice`).
-//
+// Returns mock dispatched actions for stores referenced by editor code
+// (e.g. core/editor's `savePost`, `undo`, `redo`, `switchEditorMode`).
 // Returning `vi.fn()` rather than `undefined` lets `useHostBridge` assign
 // destructured actions directly (e.g. `window.editor.savePost = savePost`)
 // without silently producing `undefined` values.
-//
-// Returning the *same* object on every call is important for tests that
-// need to read the captured mock after the hook runs — e.g. `const
-// { savePost } = useDispatch()` in a test must yield the very same
-// `vi.fn` the hook destructured, so `mockResolvedValueOnce` and
-// `toHaveBeenCalled` work end-to-end.
-const dispatchedActions = {
+export const useDispatch = vi.fn( () => ( {
 	undo: vi.fn(),
 	redo: vi.fn(),
 	savePost: vi.fn(),
@@ -21,10 +13,7 @@ const dispatchedActions = {
 	editEntityRecord: vi.fn(),
 	updateBlock: vi.fn(),
 	selectionChange: vi.fn(),
-	removeNotice: vi.fn(),
-};
-
-export const useDispatch = vi.fn( () => dispatchedActions );
+} ) );
 export const useSelect = vi.fn( ( selector ) => {
 	if ( typeof selector === 'function' ) {
 		return selector( () => ( {} ) );

--- a/__mocks__/@wordpress/data.js
+++ b/__mocks__/@wordpress/data.js
@@ -1,11 +1,19 @@
 import { vi } from 'vitest';
 
-// Returns mock dispatched actions for stores referenced by editor code
-// (e.g. core/editor's `savePost`, `undo`, `redo`, `switchEditorMode`).
+// Stable map of mock dispatched actions for stores referenced by editor
+// code (e.g. core/editor's `savePost`, `undo`, `redo`, `switchEditorMode`,
+// and core/notices' `removeNotice`).
+//
 // Returning `vi.fn()` rather than `undefined` lets `useHostBridge` assign
 // destructured actions directly (e.g. `window.editor.savePost = savePost`)
 // without silently producing `undefined` values.
-export const useDispatch = vi.fn( () => ( {
+//
+// Returning the *same* object on every call is important for tests that
+// need to read the captured mock after the hook runs — e.g. `const
+// { savePost } = useDispatch()` in a test must yield the very same
+// `vi.fn` the hook destructured, so `mockResolvedValueOnce` and
+// `toHaveBeenCalled` work end-to-end.
+const dispatchedActions = {
 	undo: vi.fn(),
 	redo: vi.fn(),
 	savePost: vi.fn(),
@@ -13,7 +21,10 @@ export const useDispatch = vi.fn( () => ( {
 	editEntityRecord: vi.fn(),
 	updateBlock: vi.fn(),
 	selectionChange: vi.fn(),
-} ) );
+	removeNotice: vi.fn(),
+};
+
+export const useDispatch = vi.fn( () => dispatchedActions );
 export const useSelect = vi.fn( ( selector ) => {
 	if ( typeof selector === 'function' ) {
 		return selector( () => ( {} ) );

--- a/__mocks__/@wordpress/data.js
+++ b/__mocks__/@wordpress/data.js
@@ -1,19 +1,6 @@
 import { vi } from 'vitest';
 
-// Returns mock dispatched actions for stores referenced by editor code
-// (e.g. core/editor's `savePost`, `undo`, `redo`, `switchEditorMode`).
-// Returning `vi.fn()` rather than `undefined` lets `useHostBridge` assign
-// destructured actions directly (e.g. `window.editor.savePost = savePost`)
-// without silently producing `undefined` values.
-export const useDispatch = vi.fn( () => ( {
-	undo: vi.fn(),
-	redo: vi.fn(),
-	savePost: vi.fn(),
-	switchEditorMode: vi.fn(),
-	editEntityRecord: vi.fn(),
-	updateBlock: vi.fn(),
-	selectionChange: vi.fn(),
-} ) );
+export const useDispatch = vi.fn( () => ( {} ) );
 export const useSelect = vi.fn( ( selector ) => {
 	if ( typeof selector === 'function' ) {
 		return selector( () => ( {} ) );

--- a/__mocks__/@wordpress/data.js
+++ b/__mocks__/@wordpress/data.js
@@ -1,6 +1,19 @@
 import { vi } from 'vitest';
 
-export const useDispatch = vi.fn( () => ( {} ) );
+// Returns mock dispatched actions for stores referenced by editor code
+// (e.g. core/editor's `savePost`, `undo`, `redo`, `switchEditorMode`).
+// Returning `vi.fn()` rather than `undefined` lets `useHostBridge` assign
+// destructured actions directly (e.g. `window.editor.savePost = savePost`)
+// without silently producing `undefined` values.
+export const useDispatch = vi.fn( () => ( {
+	undo: vi.fn(),
+	redo: vi.fn(),
+	savePost: vi.fn(),
+	switchEditorMode: vi.fn(),
+	editEntityRecord: vi.fn(),
+	updateBlock: vi.fn(),
+	selectionChange: vi.fn(),
+} ) );
 export const useSelect = vi.fn( ( selector ) => {
 	if ( typeof selector === 'function' ) {
 		return selector( () => ( {} ) );

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -773,7 +773,9 @@ class GutenbergView : FrameLayout {
     fun savePost(callback: SavePostCallback) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't save until the editor has loaded")
-            callback.onComplete(false, "Editor not loaded")
+            handler.post {
+                callback.onComplete(false, "Editor not loaded")
+            }
             return
         }
         val requestId = java.util.UUID.randomUUID().toString()

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -760,6 +760,11 @@ class GutenbergView : FrameLayout {
      * its own REST API calls. The callback fires only after the editor store's save
      * lifecycle completes, so it is safe to read and persist content at that point.
      *
+     * **Important:** if the callback reports `success = false` (for example because a
+     * third-party plugin subscribed to the lifecycle errored out), hosts should still
+     * proceed to read and persist content. A misbehaving plugin must not block the
+     * user from saving their work — log the lifecycle failure and continue.
+     *
      * Note: `window.editor.savePost()` is an async JS function that returns a Promise.
      * Android's `WebView.evaluateJavascript` cannot await Promises (unlike iOS's
      * `WKWebView.callAsyncJavaScript`), so we dispatch the call and route completion
@@ -773,11 +778,15 @@ class GutenbergView : FrameLayout {
         }
         val requestId = java.util.UUID.randomUUID().toString()
         pendingSaveCallbacks[requestId] = callback
+        // Quote the requestId for safe JS string interpolation. UUIDs are safe
+        // today, but routing all values through `JSONObject.quote()` ensures we
+        // never accidentally inject untrusted strings into the JS context.
+        val quotedRequestId = JSONObject.quote(requestId)
         handler.post {
             webView.evaluateJavascript(
                 "editor.savePost()" +
-                    ".then(() => editorDelegate.onSavePostComplete('$requestId', true, null))" +
-                    ".catch((e) => editorDelegate.onSavePostComplete('$requestId', false, String(e)));",
+                    ".then(() => editorDelegate.onSavePostComplete($quotedRequestId, true, null))" +
+                    ".catch((e) => editorDelegate.onSavePostComplete($quotedRequestId, false, String(e)));",
                 null
             )
         }
@@ -1091,8 +1100,21 @@ class GutenbergView : FrameLayout {
         latestContentProvider = null
         blockInserterDialog?.dismiss()
         blockInserterDialog = null
+        // Fail any save callbacks still waiting on a JS Promise — without this,
+        // coroutines awaiting `savePost()` would hang forever (and leak whatever
+        // they captured) when the view is torn down mid-save.
+        drainPendingSaveCallbacks("View detached")
         handler.removeCallbacksAndMessages(null)
         webView.destroy()
+    }
+
+    private fun drainPendingSaveCallbacks(reason: String) {
+        val pending = synchronized(pendingSaveCallbacks) {
+            val snapshot = pendingSaveCallbacks.toMap()
+            pendingSaveCallbacks.clear()
+            snapshot
+        }
+        pending.values.forEach { it.onComplete(false, reason) }
     }
 
     // Network Monitoring

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -788,7 +788,7 @@ class GutenbergView : FrameLayout {
             webView.evaluateJavascript(
                 "editor.savePost()" +
                     ".then(() => editorDelegate.onSavePostComplete($quotedRequestId, true, null))" +
-                    ".catch((e) => editorDelegate.onSavePostComplete($quotedRequestId, false, String(e)));",
+                    ".catch((e) => editorDelegate.onSavePostComplete($quotedRequestId, false, (e && e.message) || String(e)));",
                 null
             )
         }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -745,7 +745,7 @@ class GutenbergView : FrameLayout {
         }
     }
 
-    private val pendingSaveCallbacks = Collections.synchronizedMap(mutableMapOf<String, SavePostCallback>())
+    private val pendingLifecycleCallbacks = Collections.synchronizedMap(mutableMapOf<String, SaveLifecycleCallback>())
 
     /**
      * Triggers the editor store's save lifecycle and invokes [callback] when it completes.
@@ -765,44 +765,44 @@ class GutenbergView : FrameLayout {
      * proceed to read and persist content. A misbehaving plugin must not block the
      * user from saving their work — log the lifecycle failure and continue.
      *
-     * Note: `window.editor.savePost()` is an async JS function that returns a Promise.
-     * Android's `WebView.evaluateJavascript` cannot await Promises (unlike iOS's
-     * `WKWebView.callAsyncJavaScript`), so we dispatch the call and route completion
-     * back via the `editorDelegate` JavaScript interface.
+     * Note: `window.editor.triggerSaveLifecycle()` is an async JS function that returns
+     * a Promise. Android's `WebView.evaluateJavascript` cannot await Promises (unlike
+     * iOS's `WKWebView.callAsyncJavaScript`), so we dispatch the call and route
+     * completion back via the `editorDelegate` JavaScript interface.
      */
-    fun savePost(callback: SavePostCallback) {
+    fun triggerSaveLifecycle(callback: SaveLifecycleCallback) {
         if (!isEditorLoaded) {
-            Log.e("GutenbergView", "You can't save until the editor has loaded")
+            Log.e("GutenbergView", "You can't trigger the save lifecycle until the editor has loaded")
             handler.post {
                 callback.onComplete(false, "Editor not loaded")
             }
             return
         }
         val requestId = java.util.UUID.randomUUID().toString()
-        pendingSaveCallbacks[requestId] = callback
+        pendingLifecycleCallbacks[requestId] = callback
         // Quote the requestId for safe JS string interpolation. UUIDs are safe
         // today, but routing all values through `JSONObject.quote()` ensures we
         // never accidentally inject untrusted strings into the JS context.
         val quotedRequestId = JSONObject.quote(requestId)
         handler.post {
             webView.evaluateJavascript(
-                "editor.savePost()" +
-                    ".then(() => editorDelegate.onSavePostComplete($quotedRequestId, true, null))" +
-                    ".catch((e) => editorDelegate.onSavePostComplete($quotedRequestId, false, (e && e.message) || String(e)));",
+                "editor.triggerSaveLifecycle()" +
+                    ".then(() => editorDelegate.onSaveLifecycleComplete($quotedRequestId, true, null))" +
+                    ".catch((e) => editorDelegate.onSaveLifecycleComplete($quotedRequestId, false, (e && e.message) || String(e)));",
                 null
             )
         }
     }
 
     @JavascriptInterface
-    fun onSavePostComplete(requestId: String, success: Boolean, error: String?) {
-        val callback = pendingSaveCallbacks.remove(requestId) ?: return
+    fun onSaveLifecycleComplete(requestId: String, success: Boolean, error: String?) {
+        val callback = pendingLifecycleCallbacks.remove(requestId) ?: return
         handler.post {
             callback.onComplete(success, error)
         }
     }
 
-    fun interface SavePostCallback {
+    fun interface SaveLifecycleCallback {
         fun onComplete(success: Boolean, error: String?)
     }
 
@@ -1102,18 +1102,18 @@ class GutenbergView : FrameLayout {
         latestContentProvider = null
         blockInserterDialog?.dismiss()
         blockInserterDialog = null
-        // Fail any save callbacks still waiting on a JS Promise — without this,
-        // coroutines awaiting `savePost()` would hang forever (and leak whatever
-        // they captured) when the view is torn down mid-save.
-        drainPendingSaveCallbacks("View detached")
+        // Fail any lifecycle callbacks still waiting on a JS Promise — without
+        // this, coroutines awaiting `triggerSaveLifecycle()` would hang forever
+        // (and leak whatever they captured) when the view is torn down mid-save.
+        drainPendingLifecycleCallbacks("View detached")
         handler.removeCallbacksAndMessages(null)
         webView.destroy()
     }
 
-    private fun drainPendingSaveCallbacks(reason: String) {
-        val pending = synchronized(pendingSaveCallbacks) {
-            val snapshot = pendingSaveCallbacks.toMap()
-            pendingSaveCallbacks.clear()
+    private fun drainPendingLifecycleCallbacks(reason: String) {
+        val pending = synchronized(pendingLifecycleCallbacks) {
+            val snapshot = pendingLifecycleCallbacks.toMap()
+            pendingLifecycleCallbacks.clear()
             snapshot
         }
         pending.values.forEach { it.onComplete(false, reason) }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -745,6 +745,56 @@ class GutenbergView : FrameLayout {
         }
     }
 
+    private val pendingSaveCallbacks = Collections.synchronizedMap(mutableMapOf<String, SavePostCallback>())
+
+    /**
+     * Triggers the editor store's save lifecycle and invokes [callback] when it completes.
+     *
+     * This drives the WordPress `core/editor` store through its full save flow, causing
+     * `isSavingPost()` to transition `true` → `false`. Plugins that subscribe to this
+     * lifecycle (e.g., VideoPress syncing metadata via `/wpcom/v2/videopress/meta`) fire
+     * their side-effect API calls during this transition.
+     *
+     * The actual post content is **not** persisted by this method — the host app is
+     * responsible for reading content via [getTitleAndContent] and saving it through
+     * its own REST API calls. The callback fires only after the editor store's save
+     * lifecycle completes, so it is safe to read and persist content at that point.
+     *
+     * Note: `window.editor.savePost()` is an async JS function that returns a Promise.
+     * Android's `WebView.evaluateJavascript` cannot await Promises (unlike iOS's
+     * `WKWebView.callAsyncJavaScript`), so we dispatch the call and route completion
+     * back via the `editorDelegate` JavaScript interface.
+     */
+    fun savePost(callback: SavePostCallback) {
+        if (!isEditorLoaded) {
+            Log.e("GutenbergView", "You can't save until the editor has loaded")
+            callback.onComplete(false, "Editor not loaded")
+            return
+        }
+        val requestId = java.util.UUID.randomUUID().toString()
+        pendingSaveCallbacks[requestId] = callback
+        handler.post {
+            webView.evaluateJavascript(
+                "editor.savePost()" +
+                    ".then(() => editorDelegate.onSavePostComplete('$requestId', true, null))" +
+                    ".catch((e) => editorDelegate.onSavePostComplete('$requestId', false, String(e)));",
+                null
+            )
+        }
+    }
+
+    @JavascriptInterface
+    fun onSavePostComplete(requestId: String, success: Boolean, error: String?) {
+        val callback = pendingSaveCallbacks.remove(requestId) ?: return
+        handler.post {
+            callback.onComplete(success, error)
+        }
+    }
+
+    fun interface SavePostCallback {
+        fun onComplete(success: Boolean, error: String?)
+    }
+
     fun appendTextAtCursor(text: String) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't append text until the editor has loaded")

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -345,12 +345,12 @@ fun EditorScreen(
 /**
  * Suspends until the editor store's save lifecycle completes.
  *
- * Bridges the [GutenbergView.savePost] callback to a coroutine so the caller
- * can sequence post-save work (like persisting content via the REST API).
+ * Bridges the [GutenbergView.triggerSaveLifecycle] callback to a coroutine so
+ * the caller can sequence post-save work (like persisting content via the REST API).
  */
-private suspend fun GutenbergView.savePostAwait(): Boolean =
+private suspend fun GutenbergView.triggerSaveLifecycleAwait(): Boolean =
     suspendCancellableCoroutine { continuation ->
-        savePost { success, _ ->
+        triggerSaveLifecycle { success, _ ->
             if (continuation.isActive) continuation.resume(success)
         }
     }
@@ -358,10 +358,10 @@ private suspend fun GutenbergView.savePostAwait(): Boolean =
 /**
  * Reads the latest title/content from the editor and PUTs it to the WordPress REST API.
  *
- * Triggers [GutenbergView.savePost] first so plugin side-effects (e.g., VideoPress
- * syncing metadata) settle before the content is read and persisted. A lifecycle
- * failure must NOT block the user from saving their work — the warning is logged
- * and persistence proceeds anyway.
+ * Triggers [GutenbergView.triggerSaveLifecycle] first so plugin side-effects
+ * (e.g., VideoPress syncing metadata) settle before the content is read and
+ * persisted. A lifecycle failure must NOT block the user from saving their
+ * work — the warning is logged and persistence proceeds anyway.
  */
 private suspend fun persistPost(
     context: Context,
@@ -371,11 +371,11 @@ private suspend fun persistPost(
     postId: UInt
 ): String? {
     // 1. Trigger the editor store save lifecycle so plugins fire side-effects.
-    val saveSucceeded = view.savePostAwait()
-    if (saveSucceeded) {
-        Log.i("EditorActivity", "editor.savePost() completed — editor store save lifecycle fired")
+    val lifecycleSucceeded = view.triggerSaveLifecycleAwait()
+    if (lifecycleSucceeded) {
+        Log.i("EditorActivity", "editor.triggerSaveLifecycle() completed — editor store save lifecycle fired")
     } else {
-        Log.w("EditorActivity", "editor.savePost() lifecycle failed; persisting anyway")
+        Log.w("EditorActivity", "editor.triggerSaveLifecycle() failed; persisting anyway")
     }
 
     // 2. Persist post content via REST API.

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -343,7 +343,25 @@ fun EditorScreen(
 }
 
 /**
+ * Suspends until the editor store's save lifecycle completes.
+ *
+ * Bridges the [GutenbergView.savePost] callback to a coroutine so the caller
+ * can sequence post-save work (like persisting content via the REST API).
+ */
+private suspend fun GutenbergView.savePostAwait(): Boolean =
+    suspendCancellableCoroutine { continuation ->
+        savePost { success, _ ->
+            if (continuation.isActive) continuation.resume(success)
+        }
+    }
+
+/**
  * Reads the latest title/content from the editor and PUTs it to the WordPress REST API.
+ *
+ * Triggers [GutenbergView.savePost] first so plugin side-effects (e.g., VideoPress
+ * syncing metadata) settle before the content is read and persisted. A lifecycle
+ * failure must NOT block the user from saving their work — the warning is logged
+ * and persistence proceeds anyway.
  */
 private suspend fun persistPost(
     context: Context,
@@ -352,6 +370,15 @@ private suspend fun persistPost(
     accountId: ULong,
     postId: UInt
 ): String? {
+    // 1. Trigger the editor store save lifecycle so plugins fire side-effects.
+    val saveSucceeded = view.savePostAwait()
+    if (saveSucceeded) {
+        Log.i("EditorActivity", "editor.savePost() completed — editor store save lifecycle fired")
+    } else {
+        Log.w("EditorActivity", "editor.savePost() lifecycle failed; persisting anyway")
+    }
+
+    // 2. Persist post content via REST API.
     return try {
         val titleAndContent = suspendCancellableCoroutine<Pair<CharSequence, CharSequence>> { cont ->
             view.getTitleAndContent(

--- a/ios/Demo-iOS/Sources/Views/EditorView.swift
+++ b/ios/Demo-iOS/Sources/Views/EditorView.swift
@@ -30,6 +30,18 @@ struct EditorView: View {
             viewModel: viewModel
         )
             .toolbar { toolbar }
+            .alert(
+                "Save failed",
+                isPresented: Binding(
+                    get: { viewModel.errorMessage != nil },
+                    set: { if !$0 { viewModel.errorMessage = nil } }
+                ),
+                presenting: viewModel.errorMessage
+            ) { _ in
+                Button("OK", role: .cancel) {}
+            } message: { message in
+                Text(message)
+            }
     }
 
     @ToolbarContentBuilder
@@ -145,8 +157,21 @@ private struct _EditorView: UIViewControllerRepresentable {
         viewController.isCodeEditorEnabled = viewModel.isCodeEditorEnabled
     }
 
-    /// Persists the post via the REST API.
+    /// Triggers the editor store save lifecycle, then persists the post via the REST API.
+    ///
+    /// A lifecycle failure must **not** block the user from saving their work — the
+    /// warning is logged and persistence proceeds anyway. Persist failures surface
+    /// through `viewModel.errorMessage`, which the parent view binds to an `Alert`.
     private func persistPost(viewController: EditorViewController, viewModel: EditorViewModel) async {
+        // 1. Trigger the editor store save lifecycle so plugins fire side-effects.
+        do {
+            try await viewController.savePost()
+            print("editor.savePost() completed — editor store save lifecycle fired")
+        } catch {
+            print("editor.savePost() lifecycle failed; persisting anyway: \(error)")
+        }
+
+        // 2. Persist post content via REST API.
         guard let apiClient, let postID = configuration.postID else { return }
         do {
             let titleAndContent = try await viewController.getTitleAndContent()
@@ -169,6 +194,7 @@ private struct _EditorView: UIViewControllerRepresentable {
             print("Post \(postID) persisted via REST API")
         } catch {
             print("Failed to persist post \(postID): \(error)")
+            viewModel.errorMessage = "Failed to save post: \(error.localizedDescription)"
         }
     }
 
@@ -289,6 +315,7 @@ private final class EditorViewModel {
     var isCodeEditorEnabled = false
     var isSaving = false
     var isEditorReady = false
+    var errorMessage: String?
 
     var hasPostID = false
 

--- a/ios/Demo-iOS/Sources/Views/EditorView.swift
+++ b/ios/Demo-iOS/Sources/Views/EditorView.swift
@@ -165,10 +165,10 @@ private struct _EditorView: UIViewControllerRepresentable {
     private func persistPost(viewController: EditorViewController, viewModel: EditorViewModel) async {
         // 1. Trigger the editor store save lifecycle so plugins fire side-effects.
         do {
-            try await viewController.savePost()
-            print("editor.savePost() completed — editor store save lifecycle fired")
+            try await viewController.triggerSaveLifecycle()
+            print("editor.triggerSaveLifecycle() completed — editor store save lifecycle fired")
         } catch {
-            print("editor.savePost() lifecycle failed; persisting anyway: \(error)")
+            print("editor.triggerSaveLifecycle() failed; persisting anyway: \(error)")
         }
 
         // 2. Persist post content via REST API.

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -431,6 +431,21 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         evaluate("editor.redo();")
     }
 
+    /// Triggers the editor store's save lifecycle.
+    ///
+    /// This drives the WordPress `core/editor` store through its full save flow,
+    /// causing `isSavingPost()` to transition `true` → `false`. Plugins that
+    /// subscribe to this lifecycle (e.g., VideoPress syncing metadata) will fire
+    /// their side-effect API calls.
+    ///
+    /// The actual post content is **not** persisted by this method — the host app
+    /// is responsible for reading content via ``getTitleAndContent()`` and saving
+    /// it through its own REST API calls.
+    public func savePost() async throws {
+        guard isReady else { throw EditorNotReadyError() }
+        _ = try await webView.callAsyncJavaScript("await editor.savePost();", in: nil, contentWorld: .page)
+    }
+
     /// Dismisses the topmost modal dialog or menu in the editor
     public func dismissTopModal() {
         guard isReady else { return }

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -441,6 +441,11 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     /// The actual post content is **not** persisted by this method — the host app
     /// is responsible for reading content via ``getTitleAndContent()`` and saving
     /// it through its own REST API calls.
+    ///
+    /// > Important: If this call throws (for example, because a third-party plugin
+    /// > subscribed to the lifecycle errors out), hosts should still proceed to
+    /// > read and persist content. A misbehaving plugin must not block the user
+    /// > from saving their work — log the lifecycle failure and continue.
     public func savePost() async throws {
         guard isReady else { throw EditorNotReadyError() }
         _ = try await webView.callAsyncJavaScript("await editor.savePost();", in: nil, contentWorld: .page)

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -446,9 +446,9 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     /// > subscribed to the lifecycle errors out), hosts should still proceed to
     /// > read and persist content. A misbehaving plugin must not block the user
     /// > from saving their work — log the lifecycle failure and continue.
-    public func savePost() async throws {
+    public func triggerSaveLifecycle() async throws {
         guard isReady else { throw EditorNotReadyError() }
-        _ = try await webView.callAsyncJavaScript("await editor.savePost();", in: nil, contentWorld: .page)
+        _ = try await webView.callAsyncJavaScript("await editor.triggerSaveLifecycle();", in: nil, contentWorld: .page)
     }
 
     /// Dismisses the topmost modal dialog or menu in the editor

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -98,6 +98,7 @@ describe( 'useHostBridge', () => {
 		expect( window.editor.getTitleAndContent ).toBeTypeOf( 'function' );
 		expect( window.editor.undo ).toBeTypeOf( 'function' );
 		expect( window.editor.redo ).toBeTypeOf( 'function' );
+		expect( window.editor.savePost ).toBeTypeOf( 'function' );
 		expect( window.editor.switchEditorMode ).toBeTypeOf( 'function' );
 		expect( window.editor.dismissTopModal ).toBeTypeOf( 'function' );
 		expect( window.editor.focus ).toBeTypeOf( 'function' );
@@ -418,6 +419,7 @@ describe( 'useHostBridge', () => {
 		expect( window.editor.getTitleAndContent ).toBeUndefined();
 		expect( window.editor.undo ).toBeUndefined();
 		expect( window.editor.redo ).toBeUndefined();
+		expect( window.editor.savePost ).toBeUndefined();
 		expect( window.editor.switchEditorMode ).toBeUndefined();
 		expect( window.editor.dismissTopModal ).toBeUndefined();
 		expect( window.editor.focus ).toBeUndefined();

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -5,11 +5,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**
- * WordPress dependencies
- */
-import { useDispatch } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import { useHostBridge } from '../use-host-bridge';
@@ -21,8 +16,20 @@ const mockGetSelectedBlockClientId = vi.fn();
 const mockGetBlock = vi.fn();
 const mockGetSelectionStart = vi.fn();
 const mockGetSelectionEnd = vi.fn();
-const mockUpdateBlock = vi.fn();
-const mockSelectionChange = vi.fn();
+
+// Hoisted so the `vi.mock` factory below can capture references to the
+// same spies the tests assert on. `vi.mock` is hoisted above imports,
+// so plain top-level `const`s aren't visible to its factory.
+const dispatchMocks = vi.hoisted( () => ( {
+	savePost: vi.fn(),
+	removeNotice: vi.fn(),
+	undo: vi.fn(),
+	redo: vi.fn(),
+	switchEditorMode: vi.fn(),
+	editEntityRecord: vi.fn(),
+	updateBlock: vi.fn(),
+	selectionChange: vi.fn(),
+} ) );
 
 vi.mock( '@wordpress/data', () => ( {
 	useSelect: ( store ) => {
@@ -40,14 +47,7 @@ vi.mock( '@wordpress/data', () => ( {
 			getSelectionEnd: mockGetSelectionEnd,
 		};
 	},
-	useDispatch: () => ( {
-		editEntityRecord: vi.fn(),
-		undo: vi.fn(),
-		redo: vi.fn(),
-		switchEditorMode: vi.fn(),
-		updateBlock: mockUpdateBlock,
-		selectionChange: mockSelectionChange,
-	} ),
+	useDispatch: vi.fn( () => dispatchMocks ),
 } ) );
 vi.mock( '@wordpress/core-data' );
 vi.mock( '@wordpress/editor' );
@@ -297,7 +297,7 @@ describe( 'useHostBridge', () => {
 		const result = window.editor.appendTextAtCursor( ' appended' );
 
 		expect( result ).toBe( true );
-		expect( mockUpdateBlock ).toHaveBeenCalledWith( 'block-1', {
+		expect( dispatchMocks.updateBlock ).toHaveBeenCalledWith( 'block-1', {
 			attributes: expect.objectContaining( {
 				content: expect.any( String ),
 			} ),
@@ -332,7 +332,7 @@ describe( 'useHostBridge', () => {
 		const result = window.editor.appendTextAtCursor( ' World' );
 
 		expect( result ).toBe( true );
-		expect( mockUpdateBlock ).toHaveBeenCalledWith( 'block-1', {
+		expect( dispatchMocks.updateBlock ).toHaveBeenCalledWith( 'block-1', {
 			attributes: expect.objectContaining( {
 				content: expect.any( String ),
 			} ),
@@ -434,36 +434,34 @@ describe( 'useHostBridge', () => {
 
 	describe( 'window.editor.savePost', () => {
 		it( 'removes the editor-save snackbar after a successful save', async () => {
+			dispatchMocks.savePost.mockResolvedValueOnce( undefined );
+
 			renderHook( () =>
 				useHostBridge( defaultPost, editorRef, markBridgeReady )
 			);
-
-			// `useDispatch` is mocked to return the same shared actions
-			// object for every call (see `__mocks__/@wordpress/data.js`),
-			// so we can grab the action mocks here regardless of which
-			// store was passed.
-			const { savePost, removeNotice } = useDispatch();
-			savePost.mockResolvedValueOnce( undefined );
 
 			await window.editor.savePost();
 
-			expect( savePost ).toHaveBeenCalledTimes( 1 );
-			expect( removeNotice ).toHaveBeenCalledWith( 'editor-save' );
+			expect( dispatchMocks.savePost ).toHaveBeenCalledTimes( 1 );
+			expect( dispatchMocks.removeNotice ).toHaveBeenCalledWith(
+				'editor-save'
+			);
 		} );
 
 		it( 'removes the editor-save snackbar even when the save fails', async () => {
+			const failure = new Error( 'plugin lifecycle error' );
+			dispatchMocks.savePost.mockRejectedValueOnce( failure );
+
 			renderHook( () =>
 				useHostBridge( defaultPost, editorRef, markBridgeReady )
 			);
 
-			const { savePost, removeNotice } = useDispatch();
-			const failure = new Error( 'plugin lifecycle error' );
-			savePost.mockRejectedValueOnce( failure );
-
 			await expect( window.editor.savePost() ).rejects.toThrow( failure );
 
-			expect( savePost ).toHaveBeenCalledTimes( 1 );
-			expect( removeNotice ).toHaveBeenCalledWith( 'editor-save' );
+			expect( dispatchMocks.savePost ).toHaveBeenCalledTimes( 1 );
+			expect( dispatchMocks.removeNotice ).toHaveBeenCalledWith(
+				'editor-save'
+			);
 		} );
 	} );
 } );

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -46,6 +46,7 @@ vi.mock( '@wordpress/data', () => ( {
 } ) );
 vi.mock( '@wordpress/core-data' );
 vi.mock( '@wordpress/editor' );
+vi.mock( '@wordpress/notices' );
 vi.mock( '@wordpress/blocks' );
 vi.mock( '@wordpress/rich-text', () => ( {
 	create: vi.fn( ( { html } ) => ( {

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -104,7 +104,7 @@ describe( 'useHostBridge', () => {
 		expect( window.editor.getTitleAndContent ).toBeTypeOf( 'function' );
 		expect( window.editor.undo ).toBeTypeOf( 'function' );
 		expect( window.editor.redo ).toBeTypeOf( 'function' );
-		expect( window.editor.savePost ).toBeTypeOf( 'function' );
+		expect( window.editor.triggerSaveLifecycle ).toBeTypeOf( 'function' );
 		expect( window.editor.switchEditorMode ).toBeTypeOf( 'function' );
 		expect( window.editor.dismissTopModal ).toBeTypeOf( 'function' );
 		expect( window.editor.focus ).toBeTypeOf( 'function' );
@@ -375,7 +375,7 @@ describe( 'useHostBridge', () => {
 
 		// The block should contain the original content plus the
 		// appended text — not just the appended text alone.
-		expect( mockUpdateBlock ).toHaveBeenCalledWith( 'block-1', {
+		expect( dispatchMocks.updateBlock ).toHaveBeenCalledWith( 'block-1', {
 			attributes: expect.objectContaining( {
 				content: 'Existing block content @username ',
 			} ),
@@ -425,14 +425,14 @@ describe( 'useHostBridge', () => {
 		expect( window.editor.getTitleAndContent ).toBeUndefined();
 		expect( window.editor.undo ).toBeUndefined();
 		expect( window.editor.redo ).toBeUndefined();
-		expect( window.editor.savePost ).toBeUndefined();
+		expect( window.editor.triggerSaveLifecycle ).toBeUndefined();
 		expect( window.editor.switchEditorMode ).toBeUndefined();
 		expect( window.editor.dismissTopModal ).toBeUndefined();
 		expect( window.editor.focus ).toBeUndefined();
 		expect( window.editor.appendTextAtCursor ).toBeUndefined();
 	} );
 
-	describe( 'window.editor.savePost', () => {
+	describe( 'window.editor.triggerSaveLifecycle', () => {
 		it( 'removes the editor-save snackbar after a successful save', async () => {
 			dispatchMocks.savePost.mockResolvedValueOnce( undefined );
 
@@ -440,7 +440,7 @@ describe( 'useHostBridge', () => {
 				useHostBridge( defaultPost, editorRef, markBridgeReady )
 			);
 
-			await window.editor.savePost();
+			await window.editor.triggerSaveLifecycle();
 
 			expect( dispatchMocks.savePost ).toHaveBeenCalledTimes( 1 );
 			expect( dispatchMocks.removeNotice ).toHaveBeenCalledWith(
@@ -456,7 +456,9 @@ describe( 'useHostBridge', () => {
 				useHostBridge( defaultPost, editorRef, markBridgeReady )
 			);
 
-			await expect( window.editor.savePost() ).rejects.toThrow( failure );
+			await expect(
+				window.editor.triggerSaveLifecycle()
+			).rejects.toThrow( failure );
 
 			expect( dispatchMocks.savePost ).toHaveBeenCalledTimes( 1 );
 			expect( dispatchMocks.removeNotice ).toHaveBeenCalledWith(

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -5,6 +5,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import { useHostBridge } from '../use-host-bridge';
@@ -425,5 +430,40 @@ describe( 'useHostBridge', () => {
 		expect( window.editor.dismissTopModal ).toBeUndefined();
 		expect( window.editor.focus ).toBeUndefined();
 		expect( window.editor.appendTextAtCursor ).toBeUndefined();
+	} );
+
+	describe( 'window.editor.savePost', () => {
+		it( 'removes the editor-save snackbar after a successful save', async () => {
+			renderHook( () =>
+				useHostBridge( defaultPost, editorRef, markBridgeReady )
+			);
+
+			// `useDispatch` is mocked to return the same shared actions
+			// object for every call (see `__mocks__/@wordpress/data.js`),
+			// so we can grab the action mocks here regardless of which
+			// store was passed.
+			const { savePost, removeNotice } = useDispatch();
+			savePost.mockResolvedValueOnce( undefined );
+
+			await window.editor.savePost();
+
+			expect( savePost ).toHaveBeenCalledTimes( 1 );
+			expect( removeNotice ).toHaveBeenCalledWith( 'editor-save' );
+		} );
+
+		it( 'removes the editor-save snackbar even when the save fails', async () => {
+			renderHook( () =>
+				useHostBridge( defaultPost, editorRef, markBridgeReady )
+			);
+
+			const { savePost, removeNotice } = useDispatch();
+			const failure = new Error( 'plugin lifecycle error' );
+			savePost.mockRejectedValueOnce( failure );
+
+			await expect( window.editor.savePost() ).rejects.toThrow( failure );
+
+			expect( savePost ).toHaveBeenCalledTimes( 1 );
+			expect( removeNotice ).toHaveBeenCalledWith( 'editor-save' );
+		} );
 	} );
 } );

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -5,6 +5,7 @@ import { useEffect, useCallback, useRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
+import { store as noticesStore } from '@wordpress/notices';
 import { parse, serialize, getBlockType } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { insert, create, toHTMLString } from '@wordpress/rich-text';
@@ -20,6 +21,7 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 	const { editEntityRecord } = useDispatch( coreStore );
 	const { undo, redo, switchEditorMode, savePost } =
 		useDispatch( editorStore );
+	const { removeNotice } = useDispatch( noticesStore );
 	const { getEditedPostAttribute, getEditedPostContent } =
 		useSelect( editorStore );
 	const { updateBlock, selectionChange } = useDispatch( blockEditorStore );
@@ -98,7 +100,20 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 		// expose the underlying Promise here so native hosts can `await` the
 		// editor store's full save lifecycle (e.g., iOS uses
 		// `WKWebView.callAsyncJavaScript` to wait for completion).
-		window.editor.savePost = savePost;
+		//
+		// We also suppress the "Draft saved." / "Post updated." snackbar that
+		// `core/editor` dispatches as part of the save lifecycle: native hosts
+		// own their own UI for save feedback (toasts, alerts, etc.), and the
+		// editor's web snackbar would just compete with them. The notice has a
+		// stable id (`editor-save`) which we remove on both success and
+		// failure paths.
+		window.editor.savePost = async () => {
+			try {
+				return await savePost();
+			} finally {
+				removeNotice( 'editor-save' );
+			}
+		};
 
 		window.editor.switchEditorMode = ( mode ) => {
 			// Do not return the `Promise` return value to avoid host errors.
@@ -213,6 +228,7 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 		getEditedPostAttribute,
 		getEditedPostContent,
 		savePost,
+		removeNotice,
 		redo,
 		switchEditorMode,
 		undo,

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -96,7 +96,7 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 			redo();
 		};
 
-		window.editor.savePost = async () => {
+		window.editor.triggerSaveLifecycle = async () => {
 			try {
 				// Await the lifecycle so hosts can sequence persistence after
 				// plugin side-effects settle, do not return the `Promise` return value
@@ -206,7 +206,7 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 			delete window.editor.setTitle;
 			delete window.editor.getContent;
 			delete window.editor.getTitleAndContent;
-			delete window.editor.savePost;
+			delete window.editor.triggerSaveLifecycle;
 			delete window.editor.undo;
 			delete window.editor.redo;
 			delete window.editor.switchEditorMode;

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -18,7 +18,8 @@ window.editor = window.editor || {};
 
 export function useHostBridge( post, editorRef, markBridgeReady ) {
 	const { editEntityRecord } = useDispatch( coreStore );
-	const { undo, redo, switchEditorMode } = useDispatch( editorStore );
+	const { undo, redo, switchEditorMode, savePost } =
+		useDispatch( editorStore );
 	const { getEditedPostAttribute, getEditedPostContent } =
 		useSelect( editorStore );
 	const { updateBlock, selectionChange } = useDispatch( blockEditorStore );
@@ -91,6 +92,10 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 		window.editor.redo = () => {
 			// Do not return the `Promise` return value to avoid host errors.
 			redo();
+		};
+
+		window.editor.savePost = async () => {
+			await savePost();
 		};
 
 		window.editor.switchEditorMode = ( mode ) => {
@@ -191,6 +196,7 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 			delete window.editor.setTitle;
 			delete window.editor.getContent;
 			delete window.editor.getTitleAndContent;
+			delete window.editor.savePost;
 			delete window.editor.undo;
 			delete window.editor.redo;
 			delete window.editor.switchEditorMode;
@@ -204,6 +210,7 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 		markBridgeReady,
 		getEditedPostAttribute,
 		getEditedPostContent,
+		savePost,
 		redo,
 		switchEditorMode,
 		undo,

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -94,9 +94,11 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 			redo();
 		};
 
-		window.editor.savePost = async () => {
-			await savePost();
-		};
+		// Unlike `undo`/`redo`/`switchEditorMode` above, we intentionally
+		// expose the underlying Promise here so native hosts can `await` the
+		// editor store's full save lifecycle (e.g., iOS uses
+		// `WKWebView.callAsyncJavaScript` to wait for completion).
+		window.editor.savePost = savePost;
 
 		window.editor.switchEditorMode = ( mode ) => {
 			// Do not return the `Promise` return value to avoid host errors.

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -98,7 +98,10 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 
 		window.editor.savePost = async () => {
 			try {
-				return await savePost();
+				// Await the lifecycle so hosts can sequence persistence after
+				// plugin side-effects settle, do not return the `Promise` return value
+				// to avoid host errors.
+				await savePost();
 			} finally {
 				// Native hosts display their own save feedback, disable the default
 				removeNotice( 'editor-save' );

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -96,21 +96,11 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 			redo();
 		};
 
-		// Unlike `undo`/`redo`/`switchEditorMode` above, we intentionally
-		// expose the underlying Promise here so native hosts can `await` the
-		// editor store's full save lifecycle (e.g., iOS uses
-		// `WKWebView.callAsyncJavaScript` to wait for completion).
-		//
-		// We also suppress the "Draft saved." / "Post updated." snackbar that
-		// `core/editor` dispatches as part of the save lifecycle: native hosts
-		// own their own UI for save feedback (toasts, alerts, etc.), and the
-		// editor's web snackbar would just compete with them. The notice has a
-		// stable id (`editor-save`) which we remove on both success and
-		// failure paths.
 		window.editor.savePost = async () => {
 			try {
 				return await savePost();
 			} finally {
+				// Native hosts display their own save feedback, disable the default
 				removeNotice( 'editor-save' );
 			}
 		};


### PR DESCRIPTION
## What?

> [!note]
> This stacks atop #433. The ability to edit existing posts is required for testing the `savePost()` lifecycle. 

Adds a `savePost()` lifecycle bridge so native hosts can trigger the WordPress `core/editor` store's save flow without persisting content via the editor.

## Why?

Ref CMM-2024. 

Plugins like VideoPress need to fire side-effect API calls (e.g., metadata syncing) when the editor's save lifecycle runs. Given the native host app, not the web editor, manages saving, those side-effects never ran. 

Exposing the lifecycle as a bridge method that hosts can call allows host-driven saves to trigger the same `core/editor` store flow that plugins subscribe to, so plugin side-effects fire as expected.

The bridge is **lifecycle-only**: it does not persist post content. Hosts remain responsible for reading content via `getTitleAndContent()` and PUTting it through their own REST API calls. The existing `filterEndpointsMiddleware` (hardened in #432) already swallows the editor's own post-save HTTP request, so calling `savePost()` does not cause a duplicate REST round-trip.

## How?

- **JS** dispatches `dispatch('core/editor').savePost()` and removes the `editor-save` notice in a `finally` block. The call is added to the host bridge's exposed `window.editor` API and cleaned up on hook unmount.
- **iOS** uses `callAsyncJavaScript` so the Promise returned by `editor.savePost()` is awaited natively. A documented contract clarifies that lifecycle ≠ persistence and that plugin failures must not block saves.
- **Android** can't await Promises through `evaluateJavascript`, so the bridge dispatches the call with a UUID request ID, captures completion in `editorDelegate.onSavePostComplete(requestId, success, error)`, and routes it back to the per-request callback. `onDetachedFromWindow()` drains any pending callbacks with `success = false` so coroutines awaiting the bridge don't hang on view teardown.

## Testing Instructions

This PR is best tested by editing a post that contains a VideoPress block, since VideoPress is the canonical plugin that depends on the save lifecycle for metadata sync.

**Prerequisites:**
- A WordPress.com (or Jetpack-connected) site with VideoPress enabled
- An existing post on that site containing at least one VideoPress block
- The site added to the demo app via OAuth[^1] (WP.com) or Application Passwords (self-hosted)
- Temporarily allow the VideoPress block type:

    ```diff
    diff --git a/src/utils/blocks.js b/src/utils/blocks.js
    index 52a39f97..fd47f2ab 100644
    --- a/src/utils/blocks.js
    +++ b/src/utils/blocks.js
    @@ -17,7 +17,10 @@ export function unregisterDisallowedBlocks( allowedBlockTypes ) {
    
      const unregisteredBlocks = [];
      getBlockTypes().forEach( ( block ) => {
    -		if ( ! allowedBlockTypes.includes( block.name ) ) {
    +		if (
    +			! allowedBlockTypes.includes( block.name ) &&
    +			block.name !== 'videopress/video'
    +		) {
          unregisterBlockType( block.name );
          unregisteredBlocks.push( block.name );
        }

    ```

[^1]: Certain VideoPress requests fail with when using the dev server due to CORS, use `make build` instead. 

**Steps:**

1. Open the demo app (iOS or Android) and authenticate with the test site
2. From the site preparation screen, select **Post** as the Post Type and tap **Browse** 
3. From the posts list, tap the post containing the VideoPress block
4. In the editor, tap the VideoPress block to select it, then open the block inspector
5. Change the **Rating** from its current value (e.g., G → PG-13)
6. Tap the **Save** button in the top-right toolbar
7. Wait for the save to complete (the button briefly disables)
8. Open the same post in the WordPress site's web editor 
9. Inspect the VideoPress block — **verify the Rating reflects the value you set in step 5**

### Accessibility Testing Instructions

N/A, no navigation changes. 

## Screenshots or screencast

https://github.com/user-attachments/assets/d5d826a5-ea48-488e-90b2-946fb23dc680