### PR TITLE
fix(ios): review adjustments for #419

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/http/HTTPRequestParser.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/http/HTTPRequestParser.kt
@@ -126,10 +126,7 @@ class HTTPRequestParser(
         // whether the full Content-Length has been consumed.
         if (_state == State.DRAINING) {
             bytesWritten += data.size.toLong()
-            val offset = headerEndOffset
-            if (offset != null && bytesWritten - offset >= expectedContentLength) {
-                _state = State.COMPLETE
-            }
+            drainIfComplete()
             return
         }
 
@@ -193,6 +190,10 @@ class HTTPRequestParser(
             if (expectedContentLength > maxBodySize) {
                 parseError = HTTPRequestParseError.PAYLOAD_TOO_LARGE
                 _state = State.DRAINING
+                // Complete immediately if body bytes already received
+                // satisfy the drain — small requests may arrive as a
+                // single read.
+                drainIfComplete()
                 return
             }
         }
@@ -204,6 +205,14 @@ class HTTPRequestParser(
             State.COMPLETE
         } else {
             State.HEADERS_COMPLETE
+        }
+    }
+
+    /** Transitions from DRAINING to COMPLETE if all body bytes have been received. */
+    private fun drainIfComplete() {
+        val offset = headerEndOffset ?: return
+        if (bytesWritten - offset >= expectedContentLength) {
+            _state = State.COMPLETE
         }
     }
 

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -27,15 +27,19 @@ final class MediaUploadServer: Sendable {
     /// - Parameters:
     ///   - uploadDelegate: Optional delegate for customizing file processing and upload.
     ///   - defaultUploader: Fallback uploader used when no delegate provides `uploadFile`.
+    ///   - maxRequestBodySize: The maximum allowed request body size in bytes.
+    ///     Requests exceeding this limit receive a 413 response. Defaults to 4 GB.
     static func start(
         uploadDelegate: (any MediaUploadDelegate)? = nil,
-        defaultUploader: DefaultMediaUploader? = nil
+        defaultUploader: DefaultMediaUploader? = nil,
+        maxRequestBodySize: Int64 = HTTPRequestParser.defaultMaxBodySize
     ) async throws -> MediaUploadServer {
         let context = UploadContext(uploadDelegate: uploadDelegate, defaultUploader: defaultUploader)
 
         let server = try await HTTPServer.start(
             name: "media-upload",
             requiresAuthentication: true,
+            maxRequestBodySize: maxRequestBodySize,
             handler: { request in
                 await Self.handleRequest(request, context: context)
             }

--- a/ios/Sources/GutenbergKitHTTP/HTTPRequestParser.swift
+++ b/ios/Sources/GutenbergKitHTTP/HTTPRequestParser.swift
@@ -268,7 +268,15 @@ public final class HTTPRequestParser: @unchecked Sendable {
 
                 if expectedContentLength > maxBodySize {
                     _parseError = .payloadTooLarge
-                    _state = .draining
+                    // Check if the body bytes already received in this
+                    // chunk satisfy the drain — small requests may arrive
+                    // as a single read.
+                    if let offset = headerEndOffset,
+                       bytesWritten - Int64(offset) >= expectedContentLength {
+                        _state = .complete
+                    } else {
+                        _state = .draining
+                    }
                     return
                 }
             }

--- a/ios/Sources/GutenbergKitHTTP/HTTPRequestParser.swift
+++ b/ios/Sources/GutenbergKitHTTP/HTTPRequestParser.swift
@@ -50,7 +50,7 @@ public final class HTTPRequestParser: @unchecked Sendable {
     private var buffer: Buffer
     private let maxBodySize: Int64
     private let inMemoryBodyThreshold: Int
-    private var bytesWritten: Int = 0
+    private var bytesWritten: Int64 = 0
     private var _state: State = .needsMoreData
 
     // Lightweight scan results (populated by append)
@@ -146,7 +146,7 @@ public final class HTTPRequestParser: @unchecked Sendable {
             }
 
             if _parsedHeaders == nil {
-                let headerData = try buffer.read(from: 0, maxLength: min(bytesWritten, Self.maxHeaderSize))
+                let headerData = try buffer.read(from: 0, maxLength: Int(min(bytesWritten, Int64(Self.maxHeaderSize))))
                 switch HTTPRequestSerializer.parseHeaders(from: headerData) {
                 case .parsed(let headers):
                     _parsedHeaders = headers
@@ -203,9 +203,9 @@ public final class HTTPRequestParser: @unchecked Sendable {
             // In drain mode, discard bytes without buffering and check
             // whether the full Content-Length has been consumed.
             if case .draining = _state {
-                bytesWritten += data.count
+                bytesWritten += Int64(data.count)
                 if let offset = headerEndOffset,
-                   Int64(bytesWritten) - Int64(offset) >= expectedContentLength {
+                   bytesWritten - Int64(offset) >= expectedContentLength {
                     _state = .complete
                 }
                 return
@@ -224,12 +224,12 @@ public final class HTTPRequestParser: @unchecked Sendable {
                 _state = .complete
                 return
             }
-            bytesWritten += data.count
+            bytesWritten += Int64(data.count)
 
             if headerEndOffset == nil {
                 let buffered: Data
                 do {
-                    buffered = try buffer.read(from: 0, maxLength: min(bytesWritten, Self.maxHeaderSize))
+                    buffered = try buffer.read(from: 0, maxLength: Int(min(bytesWritten, Int64(Self.maxHeaderSize))))
                 } catch {
                     _parseError = .bufferIOError
                     _state = .complete
@@ -247,7 +247,7 @@ public final class HTTPRequestParser: @unchecked Sendable {
                 let effectiveData = buffered[scanStart...]
 
                 guard let separatorRange = effectiveData.range(of: separator) else {
-                    if bytesWritten > Self.maxHeaderSize {
+                    if bytesWritten > Int64(Self.maxHeaderSize) {
                         _parseError = .headersTooLarge
                         _state = .complete
                     } else {
@@ -274,9 +274,9 @@ public final class HTTPRequestParser: @unchecked Sendable {
             }
 
             guard let offset = headerEndOffset else { return }
-            let bodyBytesAvailable = bytesWritten - offset
+            let bodyBytesAvailable = bytesWritten - Int64(offset)
 
-            if Int64(bodyBytesAvailable) >= expectedContentLength {
+            if bodyBytesAvailable >= expectedContentLength {
                 _state = .complete
             } else {
                 _state = .headersComplete

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import GutenbergKitHTTP
-import Network
 import Testing
 @testable import GutenbergKit
 
@@ -169,59 +168,24 @@ struct MediaUploadServerTests {
     let server = try await MediaUploadServer.start(maxRequestBodySize: 1024)
     defer { server.stop() }
 
-    // Build a raw HTTP request to avoid URLSession's connection-reset
-    // behavior when the server responds before the upload completes.
     let boundary = UUID().uuidString
     let oversizedData = Data(repeating: 0x42, count: 2048)
     let body = buildMultipartBody(boundary: boundary, filename: "big.bin", mimeType: "application/octet-stream", data: oversizedData)
 
-    let headers = [
-      "POST /upload HTTP/1.1",
-      "Host: 127.0.0.1:\(server.port)",
-      "Relay-Authorization: Bearer \(server.token)",
-      "Content-Type: multipart/form-data; boundary=\(boundary)",
-      "Content-Length: \(body.count)",
-      "", ""
-    ].joined(separator: "\r\n")
+    let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
 
-    let rawRequest = Data(headers.utf8) + body
-    let responseData = try await sendRawTCP(to: server.port, data: rawRequest)
-    let responseString = String(data: responseData, encoding: .utf8) ?? ""
+    let (data, response) = try await URLSession.shared.data(for: request)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+    #expect(httpResponse.statusCode == 413)
+    #expect(httpResponse.value(forHTTPHeaderField: "Access-Control-Allow-Origin") == "*")
 
-    #expect(responseString.contains("HTTP/1.1 413"))
-    #expect(responseString.contains("Access-Control-Allow-Origin: *"))
-    #expect(responseString.contains("too large"))
-  }
-
-  /// Sends raw bytes over TCP and reads the response.
-  private func sendRawTCP(to port: UInt16, data: Data) async throws -> Data {
-    try await withCheckedThrowingContinuation { continuation in
-      let connection = NWConnection(
-        host: .ipv4(.loopback), port: NWEndpoint.Port(rawValue: port)!,
-        using: .tcp
-      )
-      connection.stateUpdateHandler = { state in
-        if case .ready = state {
-          connection.send(content: data, completion: .contentProcessed { error in
-            if let error {
-              continuation.resume(throwing: error)
-              return
-            }
-            connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { content, _, _, recvError in
-              connection.cancel()
-              if let error = recvError {
-                continuation.resume(throwing: error)
-              } else {
-                continuation.resume(returning: content ?? Data())
-              }
-            }
-          })
-        } else if case .failed(let error) = state {
-          continuation.resume(throwing: error)
-        }
-      }
-      connection.start(queue: .global())
-    }
+    let responseBody = String(data: data, encoding: .utf8) ?? ""
+    #expect(responseBody.contains("too large"))
   }
 
   private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data) -> Data {

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -163,6 +163,31 @@ struct MediaUploadServerTests {
     #expect(result.id == 99)
   }
 
+  @Test("returns 413 with CORS headers when request body exceeds max size")
+  func oversizedUploadReturns413WithCORSHeaders() async throws {
+    let server = try await MediaUploadServer.start(maxRequestBodySize: 100)
+    defer { server.stop() }
+
+    let boundary = UUID().uuidString
+    let oversizedData = Data(repeating: 0x42, count: 200)
+    let body = buildMultipartBody(boundary: boundary, filename: "big.bin", mimeType: "application/octet-stream", data: oversizedData)
+
+    let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+    #expect(httpResponse.statusCode == 413)
+    #expect(httpResponse.value(forHTTPHeaderField: "Access-Control-Allow-Origin") == "*")
+
+    let responseBody = String(data: data, encoding: .utf8) ?? ""
+    #expect(responseBody.contains("too large"))
+  }
+
   private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data) -> Data {
     var body = Data()
     body.append("--\(boundary)\r\n")

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GutenbergKitHTTP
+import Network
 import Testing
 @testable import GutenbergKit
 
@@ -168,24 +169,59 @@ struct MediaUploadServerTests {
     let server = try await MediaUploadServer.start(maxRequestBodySize: 1024)
     defer { server.stop() }
 
+    // Build a raw HTTP request to avoid URLSession's connection-reset
+    // behavior when the server responds before the upload completes.
     let boundary = UUID().uuidString
     let oversizedData = Data(repeating: 0x42, count: 2048)
     let body = buildMultipartBody(boundary: boundary, filename: "big.bin", mimeType: "application/octet-stream", data: oversizedData)
 
-    let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
-    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-    request.httpBody = body
+    let headers = [
+      "POST /upload HTTP/1.1",
+      "Host: 127.0.0.1:\(server.port)",
+      "Relay-Authorization: Bearer \(server.token)",
+      "Content-Type: multipart/form-data; boundary=\(boundary)",
+      "Content-Length: \(body.count)",
+      "", ""
+    ].joined(separator: "\r\n")
 
-    let (data, response) = try await URLSession.shared.data(for: request)
-    let httpResponse = try #require(response as? HTTPURLResponse)
-    #expect(httpResponse.statusCode == 413)
-    #expect(httpResponse.value(forHTTPHeaderField: "Access-Control-Allow-Origin") == "*")
+    let rawRequest = Data(headers.utf8) + body
+    let responseData = try await sendRawTCP(to: server.port, data: rawRequest)
+    let responseString = String(data: responseData, encoding: .utf8) ?? ""
 
-    let responseBody = String(data: data, encoding: .utf8) ?? ""
-    #expect(responseBody.contains("too large"))
+    #expect(responseString.contains("HTTP/1.1 413"))
+    #expect(responseString.contains("Access-Control-Allow-Origin: *"))
+    #expect(responseString.contains("too large"))
+  }
+
+  /// Sends raw bytes over TCP and reads the response.
+  private func sendRawTCP(to port: UInt16, data: Data) async throws -> Data {
+    try await withCheckedThrowingContinuation { continuation in
+      let connection = NWConnection(
+        host: .ipv4(.loopback), port: NWEndpoint.Port(rawValue: port)!,
+        using: .tcp
+      )
+      connection.stateUpdateHandler = { state in
+        if case .ready = state {
+          connection.send(content: data, completion: .contentProcessed { error in
+            if let error {
+              continuation.resume(throwing: error)
+              return
+            }
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { content, _, _, recvError in
+              connection.cancel()
+              if let error = recvError {
+                continuation.resume(throwing: error)
+              } else {
+                continuation.resume(returning: content ?? Data())
+              }
+            }
+          })
+        } else if case .failed(let error) = state {
+          continuation.resume(throwing: error)
+        }
+      }
+      connection.start(queue: .global())
+    }
   }
 
   private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data) -> Data {

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -165,11 +165,11 @@ struct MediaUploadServerTests {
 
   @Test("returns 413 with CORS headers when request body exceeds max size")
   func oversizedUploadReturns413WithCORSHeaders() async throws {
-    let server = try await MediaUploadServer.start(maxRequestBodySize: 100)
+    let server = try await MediaUploadServer.start(maxRequestBodySize: 1024)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
-    let oversizedData = Data(repeating: 0x42, count: 200)
+    let oversizedData = Data(repeating: 0x42, count: 2048)
     let body = buildMultipartBody(boundary: boundary, filename: "big.bin", mimeType: "application/octet-stream", data: oversizedData)
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!


### PR DESCRIPTION
Suggested changes from reviewing #419.

## Changes

### 1. Use `Int64` for `HTTPRequestParser.bytesWritten`

`bytesWritten` was `Int` while `expectedContentLength` and `maxBodySize` are already `Int64`. This is consistent on all Apple platforms today (where `Int` is 64-bit), but using `Int64` explicitly matches the convention used throughout the parser and avoids unnecessary `Int64(...)` casts at comparison sites.

### 2. Add end-to-end test for 413 + CORS headers

The core motivation for the drain+handler routing in #419 is that 413 responses include CORS headers so the WebView's `fetch()` can read them. This adds an integration test that sends an oversized request to `MediaUploadServer` and verifies both the 413 status code and the `Access-Control-Allow-Origin` header.

To support this, `MediaUploadServer.start()` now exposes a `maxRequestBodySize` parameter (defaulting to the existing 4 GB), so the test can use a small limit without sending gigabytes of data.

## Related issues

- #437 — pre-existing: `OutputStream.write` return value 0 treated as fatal in bound stream writers
- #438 — pre-existing: bound stream writer threads silently swallow errors
- #439 — pre-existing: `MediaUploadServer` tests silently skip when server can't bind