### PR TITLE
fix: preserve block content when appending text at cursor

### DIFF
--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -1,5 +1,6 @@
 package com.example.gutenbergkit
 
+import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
@@ -309,6 +310,22 @@ fun EditorScreen(
                             request.responseBody?.let {
                                 Log.d("EditorActivity", "   Response Body: ${it.take(200)}...")
                             }
+                        }
+                    })
+                    setAutocompleterTriggeredListener(object : GutenbergView.AutocompleterTriggeredListener {
+                        override fun onAutocompleterTriggered(type: String) {
+                            val suggestions = when (type) {
+                                "at-symbol" -> arrayOf("alice", "bob", "charlie")
+                                "plus-symbol" -> arrayOf("photoblog", "traveldiaries", "dailydev")
+                                else -> return
+                            }
+                            AlertDialog.Builder(context)
+                                .setTitle("Select a suggestion")
+                                .setItems(suggestions) { _, which ->
+                                    appendTextAtCursor(suggestions[which] + " ")
+                                }
+                                .setNegativeButton("Cancel", null)
+                                .show()
                         }
                     })
                     // Demo app has no persistence layer, so return null.

--- a/ios/Demo-iOS/Sources/Views/EditorView.swift
+++ b/ios/Demo-iOS/Sources/Views/EditorView.swift
@@ -216,7 +216,24 @@ private struct _EditorView: UIViewControllerRepresentable {
         }
 
         func editor(_ viewController: EditorViewController, didTriggerAutocompleter type: String) {
-            // No-op for demo
+            let suggestions: [String]
+            switch type {
+            case "at-symbol":
+                suggestions = ["alice", "bob", "charlie"]
+            case "plus-symbol":
+                suggestions = ["photoblog", "traveldiaries", "dailydev"]
+            default:
+                return
+            }
+
+            let alert = UIAlertController(title: "Select a suggestion", message: nil, preferredStyle: .actionSheet)
+            for suggestion in suggestions {
+                alert.addAction(UIAlertAction(title: suggestion, style: .default) { _ in
+                    viewController.appendTextAtCursor(suggestion + " ")
+                })
+            }
+            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+            viewController.present(alert, animated: true)
         }
 
         func editor(_ viewController: EditorViewController, didOpenModalDialog dialogType: String) {

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -9,6 +9,7 @@ import { renderHook } from '@testing-library/react';
  */
 import { useHostBridge } from '../use-host-bridge';
 import { getBlockType } from '@wordpress/blocks';
+import { create } from '@wordpress/rich-text';
 
 const mockGetEditedPostAttribute = vi.fn();
 const mockGetEditedPostContent = vi.fn();
@@ -330,6 +331,49 @@ describe( 'useHostBridge', () => {
 				content: expect.any( String ),
 			} ),
 		} );
+	} );
+
+	it( 'appendTextAtCursor preserves existing content when block attribute is a RichTextData object', () => {
+		const richTextData = {
+			toString: () => '@',
+			valueOf: () => '@',
+			toHTMLString: () => '@',
+		};
+
+		mockGetSelectedBlockClientId.mockReturnValue( 'block-1' );
+		mockGetBlock.mockReturnValue( {
+			name: 'core/paragraph',
+			clientId: 'block-1',
+			attributes: { content: richTextData },
+		} );
+		getBlockType.mockReturnValue( {
+			attributes: { content: { type: 'string' } },
+		} );
+		mockGetSelectionStart.mockReturnValue( {
+			clientId: 'block-1',
+			attributeKey: 'content',
+			offset: 1,
+		} );
+		mockGetSelectionEnd.mockReturnValue( {
+			clientId: 'block-1',
+			attributeKey: 'content',
+			offset: 1,
+		} );
+
+		renderHook( () =>
+			useHostBridge( defaultPost, editorRef, markBridgeReady )
+		);
+
+		create.mockClear();
+
+		window.editor.appendTextAtCursor( 'username ' );
+
+		// create() should receive the RichTextData (or its string
+		// representation), NOT an empty string.
+		const htmlArg = create.mock.calls[ 0 ][ 0 ].html;
+		const htmlString =
+			typeof htmlArg === 'object' ? htmlArg.toString() : htmlArg;
+		expect( htmlString ).toBe( '@' );
 	} );
 
 	it( 'appendTextAtCursor returns false when no block is selected', () => {

--- a/src/components/editor/test/use-host-bridge.test.jsx
+++ b/src/components/editor/test/use-host-bridge.test.jsx
@@ -9,7 +9,6 @@ import { renderHook } from '@testing-library/react';
  */
 import { useHostBridge } from '../use-host-bridge';
 import { getBlockType } from '@wordpress/blocks';
-import { create } from '@wordpress/rich-text';
 
 const mockGetEditedPostAttribute = vi.fn();
 const mockGetEditedPostContent = vi.fn();
@@ -334,10 +333,11 @@ describe( 'useHostBridge', () => {
 	} );
 
 	it( 'appendTextAtCursor preserves existing content when block attribute is a RichTextData object', () => {
+		const existingContent = 'Existing block content @';
 		const richTextData = {
-			toString: () => '@',
-			valueOf: () => '@',
-			toHTMLString: () => '@',
+			toString: () => existingContent,
+			valueOf: () => existingContent,
+			toHTMLString: () => existingContent,
 		};
 
 		mockGetSelectedBlockClientId.mockReturnValue( 'block-1' );
@@ -352,28 +352,27 @@ describe( 'useHostBridge', () => {
 		mockGetSelectionStart.mockReturnValue( {
 			clientId: 'block-1',
 			attributeKey: 'content',
-			offset: 1,
+			offset: existingContent.length,
 		} );
 		mockGetSelectionEnd.mockReturnValue( {
 			clientId: 'block-1',
 			attributeKey: 'content',
-			offset: 1,
+			offset: existingContent.length,
 		} );
 
 		renderHook( () =>
 			useHostBridge( defaultPost, editorRef, markBridgeReady )
 		);
 
-		create.mockClear();
-
 		window.editor.appendTextAtCursor( 'username ' );
 
-		// create() should receive the RichTextData (or its string
-		// representation), NOT an empty string.
-		const htmlArg = create.mock.calls[ 0 ][ 0 ].html;
-		const htmlString =
-			typeof htmlArg === 'object' ? htmlArg.toString() : htmlArg;
-		expect( htmlString ).toBe( '@' );
+		// The block should contain the original content plus the
+		// appended text — not just the appended text alone.
+		expect( mockUpdateBlock ).toHaveBeenCalledWith( 'block-1', {
+			attributes: expect.objectContaining( {
+				content: 'Existing block content @username ',
+			} ),
+		} );
 	} );
 
 	it( 'appendTextAtCursor returns false when no block is selected', () => {

--- a/src/components/editor/use-host-bridge.js
+++ b/src/components/editor/use-host-bridge.js
@@ -150,9 +150,7 @@ export function useHostBridge( post, editorRef, markBridgeReady ) {
 				return false;
 			}
 
-			const blockContent = normalizeAttribute(
-				block.attributes?.content
-			);
+			const blockContent = block.attributes?.content || '';
 			const currentValue = create( { html: blockContent } );
 			const selectionStart = getSelectionStart();
 			const selectionEnd = getSelectionEnd();


### PR DESCRIPTION
## What?

Revert the `normalizeAttribute()` call on block content in `appendTextAtCursor`, which was incorrectly discarding existing block text.

## Why?

#429 introduced `normalizeAttribute()` to handle `{raw, rendered}` objects from the WordPress data store. It was also applied to `block.attributes.content` in `appendTextAtCursor`, but block attributes from `getBlock()` are `RichTextData` instances — not `{raw, rendered}` objects. Since `RichTextData` lacks a `.raw` property, `normalizeAttribute()` returned an empty string, discarding all existing block content before the insertion.

This caused @mentions (and any `appendTextAtCursor` usage) to lose existing block content. For example, typing `@` in a paragraph and selecting a mention would replace the entire block content with just the username, dropping both the `@` trigger and any preceding text.

Reported via [WordPress-Android#22764](https://github.com/wordpress-mobile/WordPress-Android/pull/22764).

## How?

Reverted `block.attributes.content` handling in `appendTextAtCursor` to the original `|| ''` fallback, which lets `RichTextData` objects pass through to `create()` where their `toString()` method correctly produces the HTML string.

`normalizeAttribute()` remains in place for entity record attributes (`getEditedPostAttribute`, `getEditedPostContent`) where `{raw, rendered}` objects are expected.

## Testing Instructions

1. Open the editor 
2. Focus a Rich Text block 
3. Type some content
4. Type `@`
5. Select a name from the list
6. **Verify** the content is preserved and the name is inserted with a `@` prefix 

https://github.com/user-attachments/assets/0de2841c-388c-4048-bbd1-404ccdfc2642


