### PR TITLE
feat!: seed user capabilities from host to avoid cross-origin canUser regression

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/EditorConfiguration.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/EditorConfiguration.kt
@@ -29,7 +29,7 @@ data class EditorConfiguration(
     val editorAssetsEndpoint: String? = null,
     val enableNetworkLogging: Boolean = false,
     var enableOfflineMode: Boolean = false,
-    val userCapabilities: UserCapabilities = UserCapabilities()
+    val userCapabilities: UserCapabilities
 ): Parcelable {
 
     /**
@@ -47,15 +47,30 @@ data class EditorConfiguration(
     }
     companion object {
         @JvmStatic
-        fun builder(siteURL: String, siteApiRoot: String, postType: PostTypeDetails = PostTypeDetails.post): Builder = Builder(siteURL, siteApiRoot, postType = postType)
+        fun builder(
+            siteURL: String,
+            siteApiRoot: String,
+            userCapabilities: UserCapabilities,
+            postType: PostTypeDetails = PostTypeDetails.post
+        ): Builder = Builder(siteURL, siteApiRoot, userCapabilities, postType = postType)
 
         @JvmStatic
-        fun bundled(): EditorConfiguration = Builder("https://example.com", "https://example.com/wp-json/", PostTypeDetails.post)
+        fun bundled(): EditorConfiguration = Builder(
+            "https://example.com",
+            "https://example.com/wp-json/",
+            UserCapabilities(uploadFiles = false),
+            PostTypeDetails.post
+        )
             .setEnableOfflineMode(true)
             .build()
     }
 
-    class Builder(private var siteURL: String, private var siteApiRoot: String, private var postType: PostTypeDetails) {
+    class Builder(
+        private var siteURL: String,
+        private var siteApiRoot: String,
+        private var userCapabilities: UserCapabilities,
+        private var postType: PostTypeDetails
+    ) {
         private var title: String = ""
         private var content: String = ""
         private var postId: UInt? = null
@@ -74,7 +89,6 @@ data class EditorConfiguration(
         private var editorAssetsEndpoint: String? = null
         private var enableNetworkLogging: Boolean = false
         private var enableOfflineMode: Boolean = false
-        private var userCapabilities: UserCapabilities = UserCapabilities()
 
         fun setTitle(title: String) = apply { this.title = title }
         fun setContent(content: String) = apply { this.content = content }
@@ -130,7 +144,7 @@ data class EditorConfiguration(
      *
      * This allows modifying specific fields while preserving others.
      */
-    fun toBuilder(): Builder = Builder(siteURL, siteApiRoot, postType)
+    fun toBuilder(): Builder = Builder(siteURL, siteApiRoot, userCapabilities, postType)
         .setTitle(title)
         .setContent(content)
         .setPostId(postId)
@@ -149,7 +163,6 @@ data class EditorConfiguration(
         .setEditorAssetsEndpoint(editorAssetsEndpoint)
         .setEnableNetworkLogging(enableNetworkLogging)
         .setEnableOfflineMode(enableOfflineMode)
-        .setUserCapabilities(userCapabilities)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/EditorConfiguration.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/EditorConfiguration.kt
@@ -28,7 +28,8 @@ data class EditorConfiguration(
     val cachedAssetHosts: Set<String> = emptySet(),
     val editorAssetsEndpoint: String? = null,
     val enableNetworkLogging: Boolean = false,
-    var enableOfflineMode: Boolean = false
+    var enableOfflineMode: Boolean = false,
+    val userCapabilities: UserCapabilities = UserCapabilities()
 ): Parcelable {
 
     /**
@@ -73,6 +74,7 @@ data class EditorConfiguration(
         private var editorAssetsEndpoint: String? = null
         private var enableNetworkLogging: Boolean = false
         private var enableOfflineMode: Boolean = false
+        private var userCapabilities: UserCapabilities = UserCapabilities()
 
         fun setTitle(title: String) = apply { this.title = title }
         fun setContent(content: String) = apply { this.content = content }
@@ -95,6 +97,7 @@ data class EditorConfiguration(
         fun setEditorAssetsEndpoint(editorAssetsEndpoint: String?) = apply { this.editorAssetsEndpoint = editorAssetsEndpoint }
         fun setEnableNetworkLogging(enableNetworkLogging: Boolean) = apply { this.enableNetworkLogging = enableNetworkLogging }
         fun setEnableOfflineMode(enableOfflineMode: Boolean) = apply { this.enableOfflineMode = enableOfflineMode }
+        fun setUserCapabilities(userCapabilities: UserCapabilities) = apply { this.userCapabilities = userCapabilities }
 
         fun build(): EditorConfiguration = EditorConfiguration(
             title = title,
@@ -117,7 +120,8 @@ data class EditorConfiguration(
             cachedAssetHosts = cachedAssetHosts,
             editorAssetsEndpoint = editorAssetsEndpoint,
             enableNetworkLogging = enableNetworkLogging,
-            enableOfflineMode = enableOfflineMode
+            enableOfflineMode = enableOfflineMode,
+            userCapabilities = userCapabilities
         )
     }
 
@@ -145,6 +149,7 @@ data class EditorConfiguration(
         .setEditorAssetsEndpoint(editorAssetsEndpoint)
         .setEnableNetworkLogging(enableNetworkLogging)
         .setEnableOfflineMode(enableOfflineMode)
+        .setUserCapabilities(userCapabilities)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -173,6 +178,7 @@ data class EditorConfiguration(
         if (editorAssetsEndpoint != other.editorAssetsEndpoint) return false
         if (enableNetworkLogging != other.enableNetworkLogging) return false
         if (enableOfflineMode != other.enableOfflineMode) return false
+        if (userCapabilities != other.userCapabilities) return false
         if (siteId != other.siteId) return false
 
         return true
@@ -200,6 +206,7 @@ data class EditorConfiguration(
         result = 31 * result + (editorAssetsEndpoint?.hashCode() ?: 0)
         result = 31 * result + enableNetworkLogging.hashCode()
         result = 31 * result + enableOfflineMode.hashCode()
+        result = 31 * result + userCapabilities.hashCode()
         result = 31 * result + siteId.hashCode()
         return result
     }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/GBKitGlobal.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/GBKitGlobal.kt
@@ -58,6 +58,15 @@ data class GBKitGlobal(
     val logLevel: String = "warn",
     /** Whether to log network requests in the JavaScript console. */
     val enableNetworkLogging: Boolean,
+    /**
+     * Host-declared user capabilities used by the JS editor to preseed
+     * `@wordpress/core-data`'s `canUser` results.
+     *
+     * Non-optional so `window.GBKit.userCapabilities` is always present;
+     * the JS editor can rely on reading it rather than guarding for
+     * absence.
+     */
+    val userCapabilities: UserCapabilities,
     /** The raw editor settings JSON from the WordPress REST API. */
     val editorSettings: JsonElement?,
     /** Pre-fetched API responses JSON for faster editor initialization. */
@@ -121,6 +130,7 @@ data class GBKitGlobal(
                     content = configuration.content.encodeForEditor()
                 ),
                 enableNetworkLogging = configuration.enableNetworkLogging,
+                userCapabilities = configuration.userCapabilities,
                 editorSettings = dependencies?.editorSettings?.jsonValue,
                 preloadData = dependencies?.preloadList?.build(),
                 editorAssets = dependencies?.assetBundle?.let { bundle ->

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/UserCapabilities.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/UserCapabilities.kt
@@ -1,0 +1,20 @@
+package org.wordpress.gutenberg.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
+
+/**
+ * Host-declared user capabilities passed into the editor.
+ *
+ * These are serialized into `window.GBKit.userCapabilities` and used by
+ * the JavaScript editor to preseed `@wordpress/core-data`'s `canUser`
+ * results, bypassing the cross-origin OPTIONS inference path that cannot
+ * read the REST `Allow` header.
+ */
+@Parcelize
+@Serializable
+data class UserCapabilities(
+    /** Whether the user has the `upload_files` WordPress capability. */
+    val uploadFiles: Boolean = false
+) : Parcelable

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/UserCapabilities.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/UserCapabilities.kt
@@ -16,5 +16,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UserCapabilities(
     /** Whether the user has the `upload_files` WordPress capability. */
-    val uploadFiles: Boolean = false
+    val uploadFiles: Boolean
 ) : Parcelable

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/EditorAssetsLibraryTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/EditorAssetsLibraryTest.kt
@@ -17,6 +17,7 @@ import org.wordpress.gutenberg.model.EditorProgress
 import org.wordpress.gutenberg.model.LocalEditorAssetManifest
 import org.wordpress.gutenberg.model.PostTypeDetails
 import org.wordpress.gutenberg.model.TestResources
+import org.wordpress.gutenberg.model.UserCapabilities
 import org.wordpress.gutenberg.model.http.EditorHTTPHeaders
 import org.wordpress.gutenberg.model.http.EditorHttpMethod
 import org.wordpress.gutenberg.stores.EditorAssetsLibrary
@@ -36,18 +37,20 @@ class EditorAssetsLibraryTest {
         private const val TEST_API_ROOT = "https://example.com/wp-json"
 
         val testConfiguration: EditorConfiguration = EditorConfiguration.builder(
-            TEST_SITE_URL,
-            TEST_API_ROOT,
-            PostTypeDetails.post
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false),
+            postType = PostTypeDetails.post
         )
             .setPlugins(true)
             .setThemeStyles(true)
             .build()
 
         val minimalConfiguration: EditorConfiguration = EditorConfiguration.builder(
-            TEST_SITE_URL,
-            TEST_API_ROOT,
-            PostTypeDetails.post
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false),
+            postType = PostTypeDetails.post
         )
             .setPlugins(false)
             .setThemeStyles(false)

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
+import org.wordpress.gutenberg.model.UserCapabilities
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [28], manifest = Config.NONE)
@@ -170,8 +171,11 @@ class GutenbergViewTest {
     @Test
     fun `shouldOverrideUrlLoading allows asset path URLs on site domain`() {
         val siteView = GutenbergView(
-            EditorConfiguration.builder("https://example.com", "https://example.com/wp-json/")
-                .build(),
+            EditorConfiguration.builder(
+                siteURL = "https://example.com",
+                siteApiRoot = "https://example.com/wp-json/",
+                userCapabilities = UserCapabilities(uploadFiles = false)
+            ).build(),
             EditorDependencies.empty,
             testScope,
             RuntimeEnvironment.getApplication()
@@ -187,8 +191,11 @@ class GutenbergViewTest {
     @Test
     fun `shouldOverrideUrlLoading blocks non-asset URLs on site domain`() {
         val siteView = GutenbergView(
-            EditorConfiguration.builder("https://example.com", "https://example.com/wp-json/")
-                .build(),
+            EditorConfiguration.builder(
+                siteURL = "https://example.com",
+                siteApiRoot = "https://example.com/wp-json/",
+                userCapabilities = UserCapabilities(uploadFiles = false)
+            ).build(),
             EditorDependencies.empty,
             testScope,
             RuntimeEnvironment.getApplication()

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/RESTAPIRepositoryTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/RESTAPIRepositoryTest.kt
@@ -13,6 +13,7 @@ import org.wordpress.gutenberg.model.EditorCachePolicy
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorSettings
 import org.wordpress.gutenberg.model.PostTypeDetails
+import org.wordpress.gutenberg.model.UserCapabilities
 import org.wordpress.gutenberg.model.http.EditorHTTPHeaders
 import org.wordpress.gutenberg.model.http.EditorHttpMethod
 import org.wordpress.gutenberg.stores.EditorURLCache
@@ -43,7 +44,12 @@ class RESTAPIRepositoryTest {
         siteApiRoot: String = TEST_API_ROOT,
         siteApiNamespace: Array<String> = arrayOf()
     ): EditorConfiguration {
-        return EditorConfiguration.builder(TEST_SITE_URL, siteApiRoot, PostTypeDetails.post)
+        return EditorConfiguration.builder(
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = siteApiRoot,
+            userCapabilities = UserCapabilities(uploadFiles = false),
+            postType = PostTypeDetails.post
+        )
             .setPlugins(shouldUsePlugins)
             .setThemeStyles(shouldUseThemeStyles)
             .setAuthHeader("Bearer test-token")
@@ -289,9 +295,10 @@ class RESTAPIRepositoryTest {
         val capturingClient = createCapturingClient { capturedURLs.add(it) }
 
         val configuration = EditorConfiguration.builder(
-            TEST_SITE_URL,
-            "https://example.com/wp-json",  // No trailing slash
-            PostTypeDetails.post
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = "https://example.com/wp-json",  // No trailing slash
+            userCapabilities = UserCapabilities(uploadFiles = false),
+            postType = PostTypeDetails.post
         ).setPlugins(true).setThemeStyles(true).setAuthHeader("Bearer test").build()
 
         val cache = EditorURLCache(cacheRoot, EditorCachePolicy.Always)
@@ -318,9 +325,10 @@ class RESTAPIRepositoryTest {
         val capturingClient = createCapturingClient { capturedURLs.add(it) }
 
         val configuration = EditorConfiguration.builder(
-            TEST_SITE_URL,
-            "https://example.com/wp-json/",  // With trailing slash
-            PostTypeDetails.post
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = "https://example.com/wp-json/",  // With trailing slash
+            userCapabilities = UserCapabilities(uploadFiles = false),
+            postType = PostTypeDetails.post
         ).setPlugins(true).setThemeStyles(true).setAuthHeader("Bearer test").build()
 
         val cache = EditorURLCache(cacheRoot, EditorCachePolicy.Always)

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/EditorConfigurationTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/EditorConfigurationTest.kt
@@ -47,6 +47,17 @@ class EditorConfigurationBuilderTest {
         assertNull(config.editorAssetsEndpoint)
         assertFalse(config.enableNetworkLogging)
         assertFalse(config.enableOfflineMode)
+        assertEquals(UserCapabilities(), config.userCapabilities)
+        assertFalse(config.userCapabilities.uploadFiles)
+    }
+
+    @Test
+    fun `setUserCapabilities updates userCapabilities`() {
+        val config = builder()
+            .setUserCapabilities(UserCapabilities(uploadFiles = true))
+            .build()
+
+        assertTrue(config.userCapabilities.uploadFiles)
     }
 
     // MARK: - Individual Setter Tests

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/EditorConfigurationTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/EditorConfigurationTest.kt
@@ -18,7 +18,12 @@ class EditorConfigurationBuilderTest {
         val TEST_POST_TYPE = PostTypeDetails.post
     }
 
-    private fun builder() = EditorConfiguration.builder(TEST_SITE_URL, TEST_API_ROOT, TEST_POST_TYPE)
+    private fun builder() = EditorConfiguration.builder(
+        siteURL = TEST_SITE_URL,
+        siteApiRoot = TEST_API_ROOT,
+        userCapabilities = UserCapabilities(uploadFiles = false),
+        postType = TEST_POST_TYPE
+    )
 
     // MARK: - Default Values Tests
 
@@ -47,7 +52,7 @@ class EditorConfigurationBuilderTest {
         assertNull(config.editorAssetsEndpoint)
         assertFalse(config.enableNetworkLogging)
         assertFalse(config.enableOfflineMode)
-        assertEquals(UserCapabilities(), config.userCapabilities)
+        assertEquals(UserCapabilities(uploadFiles = false), config.userCapabilities)
         assertFalse(config.userCapabilities.uploadFiles)
     }
 
@@ -432,32 +437,44 @@ class EditorConfigurationBuilderTest {
 
     @Test
     fun `siteId extracts host from siteURL`() {
-        val config = EditorConfiguration.builder("https://example.com/blog", TEST_API_ROOT)
-            .build()
+        val config = EditorConfiguration.builder(
+            siteURL = "https://example.com/blog",
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
         assertEquals("example.com", config.siteId)
     }
 
     @Test
     fun `siteId extracts host from siteURL with port`() {
-        val config = EditorConfiguration.builder("https://example.com:8080/blog", TEST_API_ROOT)
-            .build()
+        val config = EditorConfiguration.builder(
+            siteURL = "https://example.com:8080/blog",
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
         assertEquals("example.com", config.siteId)
     }
 
     @Test
     fun `siteId extracts subdomain from siteURL`() {
-        val config = EditorConfiguration.builder("https://blog.example.com/posts", TEST_API_ROOT)
-            .build()
+        val config = EditorConfiguration.builder(
+            siteURL = "https://blog.example.com/posts",
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
         assertEquals("blog.example.com", config.siteId)
     }
 
     @Test
     fun `siteId returns UUID for empty siteURL`() {
-        val config = EditorConfiguration.builder("", TEST_API_ROOT)
-            .build()
+        val config = EditorConfiguration.builder(
+            siteURL = "",
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
         // Should be a valid UUID format (36 characters with hyphens)
         assertTrue(config.siteId.matches(Regex("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")))
@@ -465,8 +482,11 @@ class EditorConfigurationBuilderTest {
 
     @Test
     fun `siteId returns UUID for invalid URL`() {
-        val config = EditorConfiguration.builder("not a valid url", TEST_API_ROOT)
-            .build()
+        val config = EditorConfiguration.builder(
+            siteURL = "not a valid url",
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
         // Should be a valid UUID format
         assertTrue(config.siteId.matches(Regex("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")))
@@ -503,7 +523,12 @@ class EditorConfigurationTest {
         val TEST_POST_TYPE = PostTypeDetails.post
     }
 
-    private fun builder() = EditorConfiguration.builder(TEST_SITE_URL, TEST_API_ROOT, TEST_POST_TYPE)
+    private fun builder() = EditorConfiguration.builder(
+        siteURL = TEST_SITE_URL,
+        siteApiRoot = TEST_API_ROOT,
+        userCapabilities = UserCapabilities(uploadFiles = false),
+        postType = TEST_POST_TYPE
+    )
 
     // MARK: - Equatable Tests
     // Tests are ordered to match property declaration order in EditorConfiguration
@@ -564,11 +589,19 @@ class EditorConfigurationTest {
 
     @Test
     fun `Configurations with different postType are not equal`() {
-        val config1 = EditorConfiguration.builder(TEST_SITE_URL, TEST_API_ROOT, PostTypeDetails.post)
-            .build()
+        val config1 = EditorConfiguration.builder(
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false),
+            postType = PostTypeDetails.post
+        ).build()
 
-        val config2 = EditorConfiguration.builder(TEST_SITE_URL, TEST_API_ROOT, PostTypeDetails.page)
-            .build()
+        val config2 = EditorConfiguration.builder(
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false),
+            postType = PostTypeDetails.page
+        ).build()
 
         assertNotEquals(config1, config2)
     }
@@ -627,22 +660,34 @@ class EditorConfigurationTest {
 
     @Test
     fun `Configurations with different siteURL are not equal`() {
-        val config1 = EditorConfiguration.builder("https://site1.com", TEST_API_ROOT)
-            .build()
+        val config1 = EditorConfiguration.builder(
+            siteURL = "https://site1.com",
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
-        val config2 = EditorConfiguration.builder("https://site2.com", TEST_API_ROOT)
-            .build()
+        val config2 = EditorConfiguration.builder(
+            siteURL = "https://site2.com",
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
         assertNotEquals(config1, config2)
     }
 
     @Test
     fun `Configurations with different siteApiRoot are not equal`() {
-        val config1 = EditorConfiguration.builder(TEST_SITE_URL, "https://example.com/wp-json/v1")
-            .build()
+        val config1 = EditorConfiguration.builder(
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = "https://example.com/wp-json/v1",
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
-        val config2 = EditorConfiguration.builder(TEST_SITE_URL, "https://example.com/wp-json/v2")
-            .build()
+        val config2 = EditorConfiguration.builder(
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = "https://example.com/wp-json/v2",
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
         assertNotEquals(config1, config2)
     }
@@ -793,11 +838,17 @@ class EditorConfigurationTest {
     @Test
     fun `Configurations with different siteId are not equal`() {
         // siteId is derived from siteURL, so different URLs with different hosts produce different siteIds
-        val config1 = EditorConfiguration.builder("https://site1.example.com", TEST_API_ROOT)
-            .build()
+        val config1 = EditorConfiguration.builder(
+            siteURL = "https://site1.example.com",
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
-        val config2 = EditorConfiguration.builder("https://site2.example.com", TEST_API_ROOT)
-            .build()
+        val config2 = EditorConfiguration.builder(
+            siteURL = "https://site2.example.com",
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false)
+        ).build()
 
         assertNotEquals(config1.siteId, config2.siteId)
         assertNotEquals(config1, config2)
@@ -861,7 +912,12 @@ class EditorConfigurationTest {
 
     @Test
     fun `test EditorConfiguration builder sets all properties correctly`() {
-        val config = EditorConfiguration.builder("https://example.com", "https://example.com/wp-json", PostTypeDetails.post)
+        val config = EditorConfiguration.builder(
+            siteURL = "https://example.com",
+            siteApiRoot = "https://example.com/wp-json",
+            userCapabilities = UserCapabilities(uploadFiles = false),
+            postType = PostTypeDetails.post
+        )
             .setTitle("Test Title")
             .setContent("Test Content")
             .setPostId(123u)

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/GBKitGlobalTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/GBKitGlobalTest.kt
@@ -44,7 +44,12 @@ class GBKitGlobalTest {
         shouldUsePlugins: Boolean = true,
         shouldUseThemeStyles: Boolean = true
     ): EditorConfiguration {
-        return EditorConfiguration.builder(siteURL, TEST_API_ROOT, postType)
+        return EditorConfiguration.builder(
+            siteURL = siteURL,
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false),
+            postType = postType
+        )
             .setPostId(postId)
             .setTitle(title ?: "")
             .setContent(content ?: "")
@@ -198,9 +203,12 @@ class GBKitGlobalTest {
 
     @Test
     fun `maps userCapabilities from configuration`() {
-        val withUpload = EditorConfiguration.builder(TEST_SITE_URL, TEST_API_ROOT, PostTypeDetails.post)
-            .setUserCapabilities(UserCapabilities(uploadFiles = true))
-            .build()
+        val withUpload = EditorConfiguration.builder(
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = true),
+            postType = PostTypeDetails.post
+        ).build()
         val withoutUpload = makeConfiguration()
 
         val globalWith = GBKitGlobal.fromConfiguration(withUpload, makeDependencies())

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/GBKitGlobalTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/GBKitGlobalTest.kt
@@ -193,6 +193,21 @@ class GBKitGlobalTest {
         assertTrue(jsonString.contains("post"))
         assertTrue(jsonString.contains("locale"))
         assertTrue(jsonString.contains("logLevel"))
+        assertTrue(jsonString.contains("userCapabilities"))
+    }
+
+    @Test
+    fun `maps userCapabilities from configuration`() {
+        val withUpload = EditorConfiguration.builder(TEST_SITE_URL, TEST_API_ROOT, PostTypeDetails.post)
+            .setUserCapabilities(UserCapabilities(uploadFiles = true))
+            .build()
+        val withoutUpload = makeConfiguration()
+
+        val globalWith = GBKitGlobal.fromConfiguration(withUpload, makeDependencies())
+        val globalWithout = GBKitGlobal.fromConfiguration(withoutUpload, makeDependencies())
+
+        assertTrue(globalWith.userCapabilities.uploadFiles)
+        assertFalse(globalWithout.userCapabilities.uploadFiles)
     }
 
     @Test

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/services/EditorServiceTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/services/EditorServiceTest.kt
@@ -13,6 +13,7 @@ import org.wordpress.gutenberg.EditorHTTPClientProtocol
 import org.wordpress.gutenberg.EditorHTTPClientResponse
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.PostTypeDetails
+import org.wordpress.gutenberg.model.UserCapabilities
 import org.wordpress.gutenberg.model.http.EditorHTTPHeaders
 import org.wordpress.gutenberg.model.http.EditorHttpMethod
 import java.io.File
@@ -34,9 +35,10 @@ class EditorServiceTest {
         private const val TEST_API_ROOT = "https://example.com/wp-json"
 
         val testConfiguration: EditorConfiguration = EditorConfiguration.builder(
-            TEST_SITE_URL,
-            TEST_API_ROOT,
-            PostTypeDetails.post
+            siteURL = TEST_SITE_URL,
+            siteApiRoot = TEST_API_ROOT,
+            userCapabilities = UserCapabilities(uploadFiles = false),
+            postType = PostTypeDetails.post
         )
             .setPlugins(true)
             .setThemeStyles(true)

--- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
@@ -14,6 +14,7 @@ import org.wordpress.gutenberg.model.EditorCachePolicy
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
 import org.wordpress.gutenberg.model.PostTypeDetails
+import org.wordpress.gutenberg.model.UserCapabilities
 import org.wordpress.gutenberg.services.EditorService
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.PostType as WpPostType
@@ -211,6 +212,7 @@ class SitePreparationViewModel(
         return EditorConfiguration.builder(
             siteURL = "https://example.com",
             siteApiRoot = "https://example.com",
+            userCapabilities = UserCapabilities(uploadFiles = false),
             postType = PostTypeDetails.post
         )
             .setPlugins(false)
@@ -260,6 +262,7 @@ class SitePreparationViewModel(
         return EditorConfiguration.builder(
             siteURL = config.siteUrl,
             siteApiRoot = siteApiRoot,
+            userCapabilities = UserCapabilities(uploadFiles = true),
             postType = defaultPostType
         )
             .setPlugins(capabilities.supportsPlugins)

--- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
@@ -329,23 +329,17 @@ class SitePreparationViewModel(
      * Fetches the signed-in user's capabilities so the editor can seed
      * `canUser` without relying on the REST `Allow` header (which is not
      * exposed cross-origin by default in core WordPress).
-     *
-     * Falls back to `uploadFiles = false` if the call fails, matching the
-     * offline/bundled default — if we can't confirm the user can upload, we
-     * opt them out rather than silently enabling a feature they may not have.
      */
     private suspend fun loadUserCapabilities(
         config: ConfigurationItem.ConfiguredEditor
     ): UserCapabilities {
         val app = getApplication<GutenbergKitApplication>()
-        val account = app.accountRepository.all().firstOrNull { it.id() == config.accountId }
-            ?: return UserCapabilities(uploadFiles = false)
+        val account = app.accountRepository.all().first { it.id() == config.accountId }
         val client = app.createApiClient(account)
 
         val result = client.request { builder ->
             builder.users().retrieveMeWithEditContext()
-        }
-        if (result !is WpRequestResult.Success) return UserCapabilities(uploadFiles = false)
+        } as WpRequestResult.Success
 
         return UserCapabilities(
             uploadFiles = result.response.data.capabilities[UserCapability.UploadFiles] ?: false

--- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
@@ -18,6 +18,7 @@ import org.wordpress.gutenberg.model.UserCapabilities
 import org.wordpress.gutenberg.services.EditorService
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.PostType as WpPostType
+import uniffi.wp_api.UserCapability
 
 data class SitePreparationUiState(
     val enableNativeInserter: Boolean = true,
@@ -259,10 +260,12 @@ class SitePreparationViewModel(
             )
         }
 
+        val userCapabilities = loadUserCapabilities(config)
+
         return EditorConfiguration.builder(
             siteURL = config.siteUrl,
             siteApiRoot = siteApiRoot,
-            userCapabilities = UserCapabilities(uploadFiles = true),
+            userCapabilities = userCapabilities,
             postType = defaultPostType
         )
             .setPlugins(capabilities.supportsPlugins)
@@ -320,6 +323,33 @@ class SitePreparationViewModel(
                 )
             }
             .sortedBy { it.postType }
+    }
+
+    /**
+     * Fetches the signed-in user's capabilities so the editor can seed
+     * `canUser` without relying on the REST `Allow` header (which is not
+     * exposed cross-origin by default in core WordPress).
+     *
+     * Falls back to `uploadFiles = false` if the call fails, matching the
+     * offline/bundled default — if we can't confirm the user can upload, we
+     * opt them out rather than silently enabling a feature they may not have.
+     */
+    private suspend fun loadUserCapabilities(
+        config: ConfigurationItem.ConfiguredEditor
+    ): UserCapabilities {
+        val app = getApplication<GutenbergKitApplication>()
+        val account = app.accountRepository.all().firstOrNull { it.id() == config.accountId }
+            ?: return UserCapabilities(uploadFiles = false)
+        val client = app.createApiClient(account)
+
+        val result = client.request { builder ->
+            builder.users().retrieveMeWithEditContext()
+        }
+        if (result !is WpRequestResult.Success) return UserCapabilities(uploadFiles = false)
+
+        return UserCapabilities(
+            uploadFiles = result.response.data.capabilities[UserCapability.UploadFiles] ?: false
+        )
     }
 
     /**

--- a/docs/code/preloading.md
+++ b/docs/code/preloading.md
@@ -272,7 +272,8 @@ When `EditorConfiguration.networkFallbackMode` is set to `.automatic`, the edito
 let config = EditorConfigurationBuilder(
     postType: .post,
     siteURL: siteURL,
-    siteApiRoot: apiRoot
+    siteApiRoot: apiRoot,
+    userCapabilities: UserCapabilities(uploadFiles: true)
 )
 .setNetworkFallbackMode(.automatic)
 .build()

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -41,7 +41,8 @@ import GutenbergKit
 let configuration = EditorConfigurationBuilder(
     postType: "post",
     siteURL: URL(string: "https://example.com")!,
-    siteApiRoot: URL(string: "https://example.com/wp-json")!
+    siteApiRoot: URL(string: "https://example.com/wp-json")!,
+    userCapabilities: UserCapabilities(uploadFiles: true)
 )
     .setTitle("My Post")
     .setContent("<!-- wp:paragraph --><p>Hello world</p><!-- /wp:paragraph -->")
@@ -165,12 +166,13 @@ import org.wordpress.gutenberg.EditorConfiguration
 val gutenbergView = GutenbergView(context)
 gutenbergView.initializeWebView()
 
-val configuration = EditorConfiguration.builder()
+val configuration = EditorConfiguration.builder(
+    siteURL = "https://example.com",
+    siteApiRoot = "https://example.com/wp-json",
+    userCapabilities = UserCapabilities(uploadFiles = true)
+)
     .setTitle("My Post")
     .setContent("<!-- wp:paragraph --><p>Hello world</p><!-- /wp:paragraph -->")
-    .setPostType("post")
-    .setSiteURL("https://example.com")
-    .setSiteApiRoot("https://example.com/wp-json")
     .setAuthHeader("Bearer your-token")
     .build()
 
@@ -238,7 +240,11 @@ GutenbergView.warmup(context, configuration)
 Enable asset caching for plugin and theme styles:
 
 ```kotlin
-val configuration = EditorConfiguration.builder()
+val configuration = EditorConfiguration.builder(
+    siteURL = "https://example.com",
+    siteApiRoot = "https://example.com/wp-json",
+    userCapabilities = UserCapabilities(uploadFiles = true)
+)
     .setEnableAssetCaching(true)
     .setCachedAssetHosts(setOf("example.com", "cdn.example.com"))
     .build()
@@ -260,7 +266,11 @@ let configuration = EditorConfigurationBuilder(...)
 
 ```kotlin
 // Android
-val configuration = EditorConfiguration.builder()
+val configuration = EditorConfiguration.builder(
+    siteURL = "https://example.com",
+    siteApiRoot = "https://example.com/wp-json",
+    userCapabilities = UserCapabilities(uploadFiles = true)
+)
     .setPlugins(true)
     .setEditorAssetsEndpoint("https://example.com/editor-assets")
     .build()
@@ -286,7 +296,11 @@ let configuration = EditorConfigurationBuilder(...)
 // Fetch editor settings JSON from your WordPress site
 val editorSettingsJSON = fetchEditorSettings()
 
-val configuration = EditorConfiguration.builder()
+val configuration = EditorConfiguration.builder(
+    siteURL = "https://example.com",
+    siteApiRoot = "https://example.com/wp-json",
+    userCapabilities = UserCapabilities(uploadFiles = true)
+)
     .setThemeStyles(true)
     .setEditorSettings(editorSettingsJSON)
     .build()
@@ -311,7 +325,8 @@ Some Gutenberg blocks and features use WordPress AJAX (`admin-ajax.php`) for fun
 let configuration = EditorConfigurationBuilder(
     postType: "post",
     siteURL: URL(string: "https://example.com")!,
-    siteApiRoot: URL(string: "https://example.com/wp-json")!
+    siteApiRoot: URL(string: "https://example.com/wp-json")!,
+    userCapabilities: UserCapabilities(uploadFiles: true)
 )
     .setAuthHeader("Bearer your-token")
     .build()
@@ -321,7 +336,8 @@ let configuration = EditorConfigurationBuilder(
 // Android
 val configuration = EditorConfiguration.builder(
     siteURL = "https://example.com",
-    siteApiRoot = "https://example.com/wp-json"
+    siteApiRoot = "https://example.com/wp-json",
+    userCapabilities = UserCapabilities(uploadFiles = true)
 )
     .setPostType("post")
     .setAuthHeader("Bearer your-token")

--- a/ios/Demo-iOS/Sources/Views/EditorView.swift
+++ b/ios/Demo-iOS/Sources/Views/EditorView.swift
@@ -324,7 +324,8 @@ extension EditorConfiguration {
     static let bundled = EditorConfigurationBuilder(
         postType: .post,
         siteURL: URL(string: "https://example.com")!,
-        siteApiRoot: URL(string: "https://example.com/wp-json")!
+        siteApiRoot: URL(string: "https://example.com/wp-json")!,
+        userCapabilities: UserCapabilities(uploadFiles: false)
     )
     .setShouldUsePlugins(false)
     .setAuthHeader("")

--- a/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
+++ b/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
@@ -298,7 +298,8 @@ class SitePreparationViewModel {
         EditorConfigurationBuilder(
             postType: .post,
             siteURL: URL(string: account.siteUrl)!,
-            siteApiRoot: URL(string: account.siteApiRoot)!
+            siteApiRoot: URL(string: account.siteApiRoot)!,
+            userCapabilities: UserCapabilities(uploadFiles: false)
         )
         // Optimistically enable theme styles and plugins so that
         // previously-cached assets from an earlier online session can still be
@@ -426,7 +427,8 @@ class SitePreparationViewModel {
         return EditorConfigurationBuilder(
             postType: selectedPostTypeDetails,
             siteURL: URL(string: apiRoot.homeUrlString())!,
-            siteApiRoot: siteApiRoot
+            siteApiRoot: siteApiRoot,
+            userCapabilities: UserCapabilities(uploadFiles: true)
         )
         .setShouldUseThemeStyles(canUseEditorStyles)
         .setShouldUsePlugins(canUsePlugins)

--- a/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
+++ b/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
@@ -424,11 +424,13 @@ class SitePreparationViewModel {
             siteApiNamespace = []
         }
 
+        let userCapabilities = try await loadUserCapabilities()
+
         return EditorConfigurationBuilder(
             postType: selectedPostTypeDetails,
             siteURL: URL(string: apiRoot.homeUrlString())!,
             siteApiRoot: siteApiRoot,
-            userCapabilities: UserCapabilities(uploadFiles: true)
+            userCapabilities: userCapabilities
         )
         .setShouldUseThemeStyles(canUseEditorStyles)
         .setShouldUsePlugins(canUsePlugins)
@@ -436,6 +438,19 @@ class SitePreparationViewModel {
         .setAuthHeader(account.authHeader)
         .setLogLevel(.debug)
         .build()
+    }
+
+    /// Fetches the signed-in user's capabilities so the editor can seed
+    /// `canUser` without relying on the REST `Allow` header (which is not
+    /// exposed cross-origin by default in core WordPress).
+    @MainActor
+    private func loadUserCapabilities() async throws -> UserCapabilities {
+        guard let client = self.client else {
+            return UserCapabilities(uploadFiles: false)
+        }
+
+        let user = try await client.users.retrieveMeWithEditContext().data
+        return UserCapabilities(uploadFiles: user.capabilities[.uploadFiles] ?? false)
     }
 
     /// Extract the numeric WP.com site ID from a WP.com API root URL.

--- a/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
+++ b/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
@@ -445,11 +445,7 @@ class SitePreparationViewModel {
     /// exposed cross-origin by default in core WordPress).
     @MainActor
     private func loadUserCapabilities() async throws -> UserCapabilities {
-        guard let client = self.client else {
-            return UserCapabilities(uploadFiles: false)
-        }
-
-        let user = try await client.users.retrieveMeWithEditContext().data
+        let user = try await client!.users.retrieveMeWithEditContext().data
         return UserCapabilities(uploadFiles: user.capabilities[.uploadFiles] ?? false)
     }
 

--- a/ios/Sources/GutenbergKit/Sources/Model/EditorConfiguration.swift
+++ b/ios/Sources/GutenbergKit/Sources/Model/EditorConfiguration.swift
@@ -96,7 +96,7 @@ public struct EditorConfiguration: Sendable, Hashable, Equatable {
     enableNetworkLogging: Bool = false,
     isOfflineModeEnabled: Bool = false,
     networkFallbackMode: NetworkFallbackMode = .disabled,
-    userCapabilities: UserCapabilities = UserCapabilities()
+    userCapabilities: UserCapabilities
   ) {
     self.title = title
     self.content = content
@@ -225,7 +225,7 @@ public struct EditorConfigurationBuilder {
     enableNetworkLogging: Bool = false,
     isOfflineModeEnabled: Bool = false,
     networkFallbackMode: NetworkFallbackMode = .disabled,
-    userCapabilities: UserCapabilities = UserCapabilities()
+    userCapabilities: UserCapabilities
   ) {
     self.title = title
     self.content = content

--- a/ios/Sources/GutenbergKit/Sources/Model/EditorConfiguration.swift
+++ b/ios/Sources/GutenbergKit/Sources/Model/EditorConfiguration.swift
@@ -63,6 +63,12 @@ public struct EditorConfiguration: Sendable, Hashable, Equatable {
   public let isOfflineModeEnabled: Bool
   /// Controls whether the editor falls back to the bundled editor on network failure
   public let networkFallbackMode: NetworkFallbackMode
+  /// Host-declared capabilities for the authenticated user.
+  ///
+  /// Injected into the editor as `window.GBKit.userCapabilities` so the JS
+  /// side can preseed `canUser` results without relying on cross-origin
+  /// OPTIONS inference. See `UserCapabilities`.
+  public let userCapabilities: UserCapabilities
   /// A site ID derived from the URL that can be used in file system paths
   let siteId: String
 
@@ -89,7 +95,8 @@ public struct EditorConfiguration: Sendable, Hashable, Equatable {
     logLevel: EditorLogLevel,
     enableNetworkLogging: Bool = false,
     isOfflineModeEnabled: Bool = false,
-    networkFallbackMode: NetworkFallbackMode = .disabled
+    networkFallbackMode: NetworkFallbackMode = .disabled,
+    userCapabilities: UserCapabilities = UserCapabilities()
   ) {
     self.title = title
     self.content = content
@@ -113,6 +120,7 @@ public struct EditorConfiguration: Sendable, Hashable, Equatable {
     self.enableNetworkLogging = enableNetworkLogging
     self.isOfflineModeEnabled = isOfflineModeEnabled
     self.networkFallbackMode = networkFallbackMode
+    self.userCapabilities = userCapabilities
 
     // Derived Properties
     self.siteId = self.siteURL.host(percentEncoded: false) ?? UUID().uuidString
@@ -144,7 +152,8 @@ public struct EditorConfiguration: Sendable, Hashable, Equatable {
       logLevel: logLevel,
       enableNetworkLogging: enableNetworkLogging,
       isOfflineModeEnabled: isOfflineModeEnabled,
-      networkFallbackMode: networkFallbackMode
+      networkFallbackMode: networkFallbackMode,
+      userCapabilities: userCapabilities
     )
   }
 
@@ -191,6 +200,7 @@ public struct EditorConfigurationBuilder {
   private var enableNetworkLogging: Bool
   private var isOfflineModeEnabled: Bool
   private var networkFallbackMode: NetworkFallbackMode
+  private var userCapabilities: UserCapabilities
 
   public init(
     title: String = "",
@@ -214,7 +224,8 @@ public struct EditorConfigurationBuilder {
     logLevel: EditorLogLevel = .error,
     enableNetworkLogging: Bool = false,
     isOfflineModeEnabled: Bool = false,
-    networkFallbackMode: NetworkFallbackMode = .disabled
+    networkFallbackMode: NetworkFallbackMode = .disabled,
+    userCapabilities: UserCapabilities = UserCapabilities()
   ) {
     self.title = title
     self.content = content
@@ -238,6 +249,7 @@ public struct EditorConfigurationBuilder {
     self.enableNetworkLogging = enableNetworkLogging
     self.isOfflineModeEnabled = isOfflineModeEnabled
     self.networkFallbackMode = networkFallbackMode
+    self.userCapabilities = userCapabilities
   }
 
   public func setTitle(_ title: String) -> EditorConfigurationBuilder {
@@ -376,6 +388,13 @@ public struct EditorConfigurationBuilder {
     return copy
   }
 
+  public func setUserCapabilities(_ userCapabilities: UserCapabilities)
+    -> EditorConfigurationBuilder {
+    var copy = self
+    copy.userCapabilities = userCapabilities
+    return copy
+  }
+
   /// Simplify conditionally applying a configuration change
   ///
   /// Sample Code:
@@ -424,7 +443,8 @@ public struct EditorConfigurationBuilder {
       logLevel: logLevel,
       enableNetworkLogging: enableNetworkLogging,
       isOfflineModeEnabled: isOfflineModeEnabled,
-      networkFallbackMode: networkFallbackMode
+      networkFallbackMode: networkFallbackMode,
+      userCapabilities: userCapabilities
     )
   }
 }

--- a/ios/Sources/GutenbergKit/Sources/Model/GBKitGlobal.swift
+++ b/ios/Sources/GutenbergKit/Sources/Model/GBKitGlobal.swift
@@ -79,7 +79,15 @@ public struct GBKitGlobal: Sendable, Codable {
     
     /// Whether to log network requests in the JavaScript console.
     let enableNetworkLogging: Bool
-    
+
+    /// Host-declared user capabilities used by the JS editor to preseed
+    /// `@wordpress/core-data`'s `canUser` results.
+    ///
+    /// Non-optional so `window.GBKit.userCapabilities` is always present;
+    /// the JS editor can rely on reading it rather than guarding for
+    /// absence.
+    let userCapabilities: UserCapabilities
+
     let editorSettings: JSON?
     
     let preloadData: JSON?
@@ -117,6 +125,7 @@ public struct GBKitGlobal: Sendable, Codable {
         )
         self.logLevel = configuration.logLevel.rawValue
         self.enableNetworkLogging = configuration.enableNetworkLogging
+        self.userCapabilities = configuration.userCapabilities
         self.editorSettings = dependencies.editorSettings.jsonValue
         self.preloadData = try dependencies.preloadList?.build()
         self.editorAssets = Self.buildEditorAssets(from: dependencies.assetBundle)

--- a/ios/Sources/GutenbergKit/Sources/Model/UserCapabilities.swift
+++ b/ios/Sources/GutenbergKit/Sources/Model/UserCapabilities.swift
@@ -10,7 +10,7 @@ public struct UserCapabilities: Sendable, Codable, Hashable {
     /// Whether the user has the `upload_files` WordPress capability.
     public let uploadFiles: Bool
 
-    public init(uploadFiles: Bool = false) {
+    public init(uploadFiles: Bool) {
         self.uploadFiles = uploadFiles
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/Model/UserCapabilities.swift
+++ b/ios/Sources/GutenbergKit/Sources/Model/UserCapabilities.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Host-declared user capabilities passed into the editor.
+///
+/// These are serialized into `window.GBKit.userCapabilities` and used by
+/// the JavaScript editor to preseed `@wordpress/core-data`'s `canUser`
+/// results, bypassing the cross-origin OPTIONS inference path that cannot
+/// read the REST `Allow` header.
+public struct UserCapabilities: Sendable, Codable, Hashable {
+    /// Whether the user has the `upload_files` WordPress capability.
+    public let uploadFiles: Bool
+
+    public init(uploadFiles: Bool = false) {
+        self.uploadFiles = uploadFiles
+    }
+}

--- a/ios/Tests/GutenbergKitTests/Model/EditorConfigurationTests.swift
+++ b/ios/Tests/GutenbergKitTests/Model/EditorConfigurationTests.swift
@@ -34,7 +34,7 @@ struct EditorConfigurationBuilderTests: MakesTestFixtures {
     #expect(config.isNativeInserterEnabled == false)
     #expect(config.logLevel == .error)
     #expect(config.enableNetworkLogging == false)
-    #expect(config.userCapabilities == UserCapabilities())
+    #expect(config.userCapabilities == UserCapabilities(uploadFiles: false))
     #expect(config.userCapabilities.uploadFiles == false)
   }
 
@@ -513,13 +513,15 @@ struct EditorConfigurationTests: MakesTestFixtures {
     let config1 = EditorConfigurationBuilder(
       postType: .post,
       siteURL: Self.testSiteURL,
-      siteApiRoot: Self.testApiRoot
+      siteApiRoot: Self.testApiRoot,
+      userCapabilities: UserCapabilities(uploadFiles: false)
     ).setPostID(1).build()
 
     let config2 = EditorConfigurationBuilder(
       postType: .post,
       siteURL: Self.testSiteURL,
-      siteApiRoot: Self.testApiRoot
+      siteApiRoot: Self.testApiRoot,
+      userCapabilities: UserCapabilities(uploadFiles: false)
     ).setPostID(2).build()
 
     #expect(config1 != config2)
@@ -548,19 +550,22 @@ struct EditorConfigurationTests: MakesTestFixtures {
     let config1 = EditorConfigurationBuilder(
       postType: .post,
       siteURL: Self.testSiteURL,
-      siteApiRoot: Self.testApiRoot
+      siteApiRoot: Self.testApiRoot,
+      userCapabilities: UserCapabilities(uploadFiles: false)
     ).setPostID(1).build()
 
     let config2 = EditorConfigurationBuilder(
       postType: .post,
       siteURL: Self.testSiteURL,
-      siteApiRoot: Self.testApiRoot
+      siteApiRoot: Self.testApiRoot,
+      userCapabilities: UserCapabilities(uploadFiles: false)
     ).setPostID(2).build()
 
     let config3 = EditorConfigurationBuilder(
       postType: .post,
       siteURL: Self.testSiteURL,
-      siteApiRoot: Self.testApiRoot
+      siteApiRoot: Self.testApiRoot,
+      userCapabilities: UserCapabilities(uploadFiles: false)
     ).setPostID(1).build()
 
     let set: Set<EditorConfiguration> = [config1, config2, config3]

--- a/ios/Tests/GutenbergKitTests/Model/EditorConfigurationTests.swift
+++ b/ios/Tests/GutenbergKitTests/Model/EditorConfigurationTests.swift
@@ -34,6 +34,17 @@ struct EditorConfigurationBuilderTests: MakesTestFixtures {
     #expect(config.isNativeInserterEnabled == false)
     #expect(config.logLevel == .error)
     #expect(config.enableNetworkLogging == false)
+    #expect(config.userCapabilities == UserCapabilities())
+    #expect(config.userCapabilities.uploadFiles == false)
+  }
+
+  @Test("setUserCapabilities updates userCapabilities")
+  func setUserCapabilitiesUpdates() {
+    let config = makeConfigurationBuilder()
+      .setUserCapabilities(UserCapabilities(uploadFiles: true))
+      .build()
+
+    #expect(config.userCapabilities.uploadFiles == true)
   }
 
   // MARK: - Individual Setter Tests

--- a/ios/Tests/GutenbergKitTests/Model/GBKitGlobalTests.swift
+++ b/ios/Tests/GutenbergKitTests/Model/GBKitGlobalTests.swift
@@ -170,6 +170,22 @@ struct GBKitGlobalTests: MakesTestFixtures {
     #expect(jsonString.contains("\"status\""))
     #expect(jsonString.contains("locale"))
     #expect(jsonString.contains("logLevel"))
+    #expect(jsonString.contains("userCapabilities"))
+  }
+
+  @Test("maps userCapabilities from configuration")
+  func mapsUserCapabilities() throws {
+    let withUpload = makeConfigurationBuilder()
+      .setUserCapabilities(UserCapabilities(uploadFiles: true))
+      .build()
+    let withoutUpload = makeConfiguration()
+
+    let globalWith = try GBKitGlobal(configuration: withUpload, dependencies: makeDependencies())
+    let globalWithout = try GBKitGlobal(
+      configuration: withoutUpload, dependencies: makeDependencies())
+
+    #expect(globalWith.userCapabilities.uploadFiles == true)
+    #expect(globalWithout.userCapabilities.uploadFiles == false)
   }
 
   @Test("toString round-trips through Codable")

--- a/ios/Tests/GutenbergKitTests/Stores/EditorAssetLibraryTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorAssetLibraryTests.swift
@@ -12,6 +12,7 @@ struct EditorAssetLibraryTests {
             postType: .post,
             siteURL: URL(string: "https://example.com")!,
             siteApiRoot: URL(string: "https://example.com/wp-json")!,
+            userCapabilities: UserCapabilities(uploadFiles: false)
         )
         .setShouldUsePlugins(true)
         .setShouldUseThemeStyles(true)
@@ -22,7 +23,8 @@ struct EditorAssetLibraryTests {
         EditorConfigurationBuilder(
             postType: .post,
             siteURL: URL(string: "https://example.com")!,
-            siteApiRoot: URL(string: "https://example.com/wp-json")!
+            siteApiRoot: URL(string: "https://example.com/wp-json")!,
+            userCapabilities: UserCapabilities(uploadFiles: false)
         )
         .setShouldUsePlugins(false)
         .setShouldUseThemeStyles(false)

--- a/ios/Tests/GutenbergKitTests/TestHelpers.swift
+++ b/ios/Tests/GutenbergKitTests/TestHelpers.swift
@@ -47,7 +47,8 @@ extension MakesTestFixtures {
             postType: postType,
             siteURL: siteURL,
             siteApiRoot: Self.testApiRoot,
-            siteApiNamespace: siteApiNamespace
+            siteApiNamespace: siteApiNamespace,
+            userCapabilities: UserCapabilities(uploadFiles: false)
         )
             .apply(title, { $0.setTitle($1) })
             .apply(content, { $0.setContent($1) })
@@ -66,7 +67,8 @@ extension MakesTestFixtures {
         EditorConfigurationBuilder(
             postType: postType,
             siteURL: Self.testSiteURL,
-            siteApiRoot: Self.testApiRoot
+            siteApiRoot: Self.testApiRoot,
+            userCapabilities: UserCapabilities(uploadFiles: false)
         )
     }
 

--- a/src/components/editor/index.jsx
+++ b/src/components/editor/index.jsx
@@ -15,6 +15,7 @@ import { useHostBridge } from './use-host-bridge';
 import { useEditorReady } from './use-editor-ready';
 import { useHostExceptionLogging } from './use-host-exception-logging';
 import { useEditorSetup } from './use-editor-setup';
+import { useSeededPermissions } from './use-seeded-permissions';
 import { useMediaUpload } from './use-media-upload';
 import TextEditor from '../text-editor';
 import { useSyncFeaturedImage } from './use-sync-featured-image';
@@ -43,6 +44,7 @@ export default function Editor( { post, children, hideTitle } ) {
 	useSyncHistoryControls();
 	useHostExceptionLogging();
 	useEditorSetup( post );
+	useSeededPermissions();
 	useMediaUpload();
 	useDevModeNotice();
 	useAtAutocompleter();

--- a/src/components/editor/test/use-seeded-permissions.test.jsx
+++ b/src/components/editor/test/use-seeded-permissions.test.jsx
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useSeededPermissions } from '../use-seeded-permissions';
+
+const mockReceiveUserPermissions = vi.fn();
+const mockFinishResolutions = vi.fn();
+const mockHasStartedResolution = vi.fn();
+
+vi.mock( '@wordpress/data', () => ( {
+	dispatch: () => ( {
+		receiveUserPermissions: mockReceiveUserPermissions,
+		finishResolutions: mockFinishResolutions,
+	} ),
+	select: () => ( {
+		hasStartedResolution: mockHasStartedResolution,
+	} ),
+} ) );
+vi.mock( '@wordpress/core-data', () => ( { store: { name: 'core' } } ) );
+
+vi.mock( '../../../utils/bridge', () => ( {
+	getGBKit: vi.fn(),
+} ) );
+
+import { getGBKit } from '../../../utils/bridge';
+
+describe( 'useSeededPermissions', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+		mockHasStartedResolution.mockReturnValue( false );
+	} );
+
+	it( 'seeds attachment permissions when uploadFiles is true', () => {
+		getGBKit.mockReturnValue( {
+			userCapabilities: { uploadFiles: true },
+		} );
+
+		renderHook( () => useSeededPermissions() );
+
+		expect( mockReceiveUserPermissions ).toHaveBeenCalledWith( {
+			'create/postType/attachment': true,
+			'read/postType/attachment': true,
+			'update/postType/attachment': true,
+			'delete/postType/attachment': true,
+		} );
+		expect( mockFinishResolutions ).toHaveBeenCalledWith( 'canUser', [
+			[ 'create', { kind: 'postType', name: 'attachment' } ],
+			[ 'read', { kind: 'postType', name: 'attachment' } ],
+			[ 'update', { kind: 'postType', name: 'attachment' } ],
+			[ 'delete', { kind: 'postType', name: 'attachment' } ],
+		] );
+	} );
+
+	it( 'does nothing when userCapabilities is absent', () => {
+		getGBKit.mockReturnValue( {} );
+
+		renderHook( () => useSeededPermissions() );
+
+		expect( mockReceiveUserPermissions ).not.toHaveBeenCalled();
+		expect( mockFinishResolutions ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing when uploadFiles is not strictly true', () => {
+		for ( const value of [ false, undefined, 'true', 1 ] ) {
+			getGBKit.mockReturnValue( {
+				userCapabilities: { uploadFiles: value },
+			} );
+
+			renderHook( () => useSeededPermissions() );
+		}
+
+		expect( mockReceiveUserPermissions ).not.toHaveBeenCalled();
+		expect( mockFinishResolutions ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing when userCapabilities lacks uploadFiles', () => {
+		getGBKit.mockReturnValue( {
+			userCapabilities: {},
+		} );
+
+		renderHook( () => useSeededPermissions() );
+
+		expect( mockReceiveUserPermissions ).not.toHaveBeenCalled();
+		expect( mockFinishResolutions ).not.toHaveBeenCalled();
+	} );
+
+	it( 'early-returns when a canUser resolution is already in flight', () => {
+		getGBKit.mockReturnValue( {
+			userCapabilities: { uploadFiles: true },
+		} );
+		mockHasStartedResolution.mockReturnValue( true );
+
+		renderHook( () => useSeededPermissions() );
+
+		expect( mockHasStartedResolution ).toHaveBeenCalledWith( 'canUser', [
+			'create',
+			{ kind: 'postType', name: 'attachment' },
+		] );
+		expect( mockReceiveUserPermissions ).not.toHaveBeenCalled();
+		expect( mockFinishResolutions ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/components/editor/use-seeded-permissions.js
+++ b/src/components/editor/use-seeded-permissions.js
@@ -1,0 +1,73 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { dispatch, select } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { getGBKit } from '../../utils/bridge';
+
+const ATTACHMENT_RESOURCE = { kind: 'postType', name: 'attachment' };
+const RESOURCE_ACTIONS = [ 'create', 'read', 'update', 'delete' ];
+
+/**
+ * Preseeds `canUser` results in the `@wordpress/core-data` store from
+ * host-supplied capabilities, bypassing the REST `OPTIONS` resolver.
+ *
+ * Cross-origin editor hosts cannot read the `Allow` response header unless
+ * the server explicitly exposes it via `Access-Control-Expose-Headers`.
+ * Since `@wordpress/core-data` 7.42.0, a missing `Allow` header causes
+ * `canUser` to return `false`, which hides the upload button in
+ * `MediaPlaceholder`. Seeding the store with the host's authoritative
+ * capability information avoids this inference path entirely.
+ *
+ * The host may supply `userCapabilities` via `window.GBKit`, e.g.:
+ *   window.GBKit = {
+ *     ...,
+ *     userCapabilities: { uploadFiles: true },
+ *   };
+ *
+ * If `userCapabilities` is absent, the default `canUser` resolver runs
+ * (matching existing behavior).
+ *
+ * @return {void}
+ */
+export function useSeededPermissions() {
+	useEffect( () => {
+		const { userCapabilities } = getGBKit();
+		if ( ! userCapabilities ) {
+			return;
+		}
+
+		const storeSelect = select( coreStore );
+		// Avoid clobbering a resolution already in flight.
+		if (
+			storeSelect.hasStartedResolution( 'canUser', [
+				'create',
+				ATTACHMENT_RESOURCE,
+			] )
+		) {
+			return;
+		}
+
+		const permissions = {};
+		const resolutions = [];
+
+		if ( userCapabilities.uploadFiles === true ) {
+			for ( const action of RESOURCE_ACTIONS ) {
+				permissions[ `${ action }/postType/attachment` ] = true;
+				resolutions.push( [ action, ATTACHMENT_RESOURCE ] );
+			}
+		}
+
+		if ( resolutions.length === 0 ) {
+			return;
+		}
+
+		dispatch( coreStore ).receiveUserPermissions( permissions );
+		dispatch( coreStore ).finishResolutions( 'canUser', resolutions );
+	}, [] );
+}

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -203,16 +203,23 @@ export function onNetworkRequest( requestData ) {
 }
 
 /**
+ * @typedef {Object} UserCapabilities
+ *
+ * @property {boolean} [uploadFiles] Whether the user has the `upload_files` capability.
+ */
+
+/**
  * @typedef GBKitConfig
  *
- * @property {boolean}  [themeStyles]            Controls if theme styles are applied to the editor.
- * @property {string}   [siteApiRoot]            The root URL of the site's API.
- * @property {string[]} [siteApiNamespace]       The namespace of the site's API; if multiple namespaces are provided, the first one is used as the default.
- * @property {string[]} [namespaceExcludedPaths] The paths that should not be namespaced.
- * @property {string}   [authHeader]             The authentication header.
- * @property {string}   [hideTitle]              Whether to hide the title.
- * @property {Post}     [post]                   The post data.
- * @property {boolean}  [enableNetworkLogging]   Enables logging of all network requests/responses to the native host via onNetworkRequest bridge method.
+ * @property {boolean}          [themeStyles]            Controls if theme styles are applied to the editor.
+ * @property {string}           [siteApiRoot]            The root URL of the site's API.
+ * @property {string[]}         [siteApiNamespace]       The namespace of the site's API; if multiple namespaces are provided, the first one is used as the default.
+ * @property {string[]}         [namespaceExcludedPaths] The paths that should not be namespaced.
+ * @property {string}           [authHeader]             The authentication header.
+ * @property {string}           [hideTitle]              Whether to hide the title.
+ * @property {Post}             [post]                   The post data.
+ * @property {boolean}          [enableNetworkLogging]   Enables logging of all network requests/responses to the native host via onNetworkRequest bridge method.
+ * @property {UserCapabilities} [userCapabilities]       Host-declared user capabilities used to preseed the core-data store, bypassing cross-origin OPTIONS inference.
  */
 
 /**

--- a/wp-env/mu-plugins/gutenbergkit-cors.php
+++ b/wp-env/mu-plugins/gutenbergkit-cors.php
@@ -34,6 +34,9 @@ function gutenbergkit_cors_send_origin_headers( $origin ) {
 
 	header( 'Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS' );
 	header( 'Access-Control-Allow-Headers: Authorization, Content-Type, X-WP-Nonce' );
+	// Expose `Allow` so cross-origin JS can read it — `@wordpress/core-data`'s
+	// `canUser` relies on this header to compute permissions.
+	header( 'Access-Control-Expose-Headers: X-WP-Total, X-WP-TotalPages, Link, Allow' );
 }
 
 add_action( 'rest_api_init', function () {
@@ -43,15 +46,24 @@ add_action( 'rest_api_init', function () {
 	add_filter( 'rest_pre_serve_request', function ( $served ) {
 		gutenbergkit_cors_send_origin_headers( get_http_origin() );
 		return $served;
-	});
-}, 15 );
+	}, 15 );
+} );
 
-// Handle preflight OPTIONS requests early.
+// Handle preflight OPTIONS requests early for non-REST routes. REST OPTIONS
+// must be dispatched by WP_REST_Server so the `Allow:` header is attached —
+// `@wordpress/core-data`'s `canUser` depends on it.
 add_action( 'init', function () {
-	if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) {
-		gutenbergkit_cors_send_origin_headers( get_http_origin() );
-		header( 'Access-Control-Max-Age: 86400' );
-		status_header( 204 );
-		exit;
+	if ( 'OPTIONS' !== ( $_SERVER['REQUEST_METHOD'] ?? '' ) ) {
+		return;
 	}
-});
+
+	$request_uri = $_SERVER['REQUEST_URI'] ?? '';
+	if ( str_contains( $request_uri, '/wp-json/' ) || str_contains( $request_uri, 'rest_route=' ) ) {
+		return;
+	}
+
+	gutenbergkit_cors_send_origin_headers( get_http_origin() );
+	header( 'Access-Control-Max-Age: 86400' );
+	status_header( 204 );
+	exit;
+} );


### PR DESCRIPTION
## What?

Introduces a `useSeededPermissions` hook that reads host-supplied `userCapabilities` from `window.GBKit` and preseeds the `@wordpress/core-data` store so `canUser( ..., { kind: 'postType', name: 'attachment' } )` returns `true` without an OPTIONS request. Extends the native iOS/Android SDKs with a matching `UserCapabilities` type that flows through `EditorConfiguration` into `GBKitGlobal`, and extends the `wp-env` CORS mu-plugin to expose the `Allow` header and route REST `OPTIONS` through `WP_REST_Server` so the local environment matches production CORS behaviour.

**Breaking change**: `userCapabilities` is a required parameter on `EditorConfiguration.init` / `EditorConfigurationBuilder` (iOS) and `EditorConfiguration.Builder` / `EditorConfiguration.builder(...)` (Android). Every call site must pass `UserCapabilities(uploadFiles: <Bool>)` explicitly — a missing argument becomes a compile error rather than a silent `uploadFiles = false` default that hides the upload button.

## Why?

`@wordpress/core-data` 7.42.0 ([Gutenberg #76307](https://github.com/WordPress/gutenberg/pull/76307)) changed `canUser` to return `false` instead of `undefined` when the REST `Allow` header is missing. This breaks `@wordpress/editor`'s `hasUploadPermissions = canUser(...) ?? true` fallback — when `canUser` returns `false`, `??` doesn't fall through, `settings.mediaUpload` becomes `undefined`, `MediaUploadCheck` evaluates falsy, and **the Upload button disappears from every MediaPlaceholder**.

GutenbergKit hits this in production, not just in wp-env. The editor is a local bundle (`bundle://` / `appassets.androidplatform.net`) and the REST API lives on the user's WordPress site, so every request is cross-origin. Browsers hide response headers from JS unless the server lists them in `Access-Control-Expose-Headers`, and WordPress core's default `rest_send_cors_headers()` only exposes `X-WP-Total, X-WP-TotalPages, Link` — not `Allow`. Confirmed empirically against `https://vanilla.wpmt.co/wp-json/wp/v2/media`.

Fixing WP core's CORS allowlist is a Trac-level change with a multi-release timeline, and reverting #76307 upstream is unlikely. This PR must land before the pending Dependabot bump at #456 (`@wordpress/editor` 14.41.0 → 14.44.0), otherwise every cross-origin GBKit host silently regresses.

Required-vs-optional: an earlier iteration made `userCapabilities` optional with a `uploadFiles = false` default. That silently opted every un-updated host into the broken behaviour — the opposite of the fix. Making the parameter required forces every integration to consciously declare what the signed-in user can do, which is the whole point of the seeded-permissions pathway.

## How?

### What we explored

1. **Patch `@wordpress/core-data` to restore the `undefined` behaviour.** ❌ Fragile, drifts on every upstream bump, ignores upstream intent.
2. **Land the bump and fix via a WP core CORS change.** ❌ Trac-level change on a multi-release timeline; only helps sites that update.
3. **Seed `canUser` from host-declared capabilities.** ✅ The host already authenticates the user and knows their capabilities via `GET /wp/v2/users/me?context=edit&_fields=capabilities`. Passing `userCapabilities` into the editor via the existing `window.GBKit` bridge and dispatching `receiveUserPermissions` + `finishResolutions` into the core-data store bypasses the OPTIONS inference entirely.

### Changes

**JS**

- **`src/components/editor/use-seeded-permissions.js`**: new hook reading `userCapabilities.uploadFiles` from `getGBKit()` and dispatching seed data into the core-data store on mount. Uses only public core-data actions (`receiveUserPermissions`, `finishResolutions`) — no patches. Additive: if the host doesn't supply capabilities, the editor falls back to today's path.
- **`src/components/editor/index.jsx`**: calls `useSeededPermissions()` before `<EditorProvider>` mounts.
- **`src/utils/bridge.js`**: documents the new `userCapabilities` field on the `GBKitConfig` typedef.
- **`wp-env/mu-plugins/gutenbergkit-cors.php`**: exposes `Allow` to cross-origin JS; routes REST `OPTIONS` through WP's dispatcher (non-REST `OPTIONS` are still short-circuited).

**Native SDKs**

- **`UserCapabilities` type** on both iOS (Swift) and Android (Kotlin) with a single required `uploadFiles: Bool` field (designed to grow).
- **`EditorConfiguration`** on both platforms carries a required `userCapabilities`, which flows through `GBKitGlobal` into the JS bridge.
- **`EditorConfigurationBuilder`** (iOS) and `EditorConfiguration.Builder` / `EditorConfiguration.builder(...)` (Android) require `userCapabilities` as a constructor argument — a host app that forgets to supply it gets a compile error telling it exactly what to add.
- Demo apps, tests, and `docs/integration.md` / `docs/code/preloading.md` updated to pass `userCapabilities` at every call site.

Host-app changes (fetching capabilities after auth and injecting into the `window.GBKit` payload) are out of scope here and will ship as separate coordinated PRs on WordPress iOS/Android and Jetpack iOS/Android.

## Testing Instructions

- [ ] `make test-js` — all 136 existing tests plus 5 new `useSeededPermissions` tests pass
- [ ] `make test-swift-package` — passes clean
- [ ] `make test-android` — passes clean
- [ ] `make lint-js-fix` — clean
- [ ] `make build` — builds without errors
- [ ] E2E: `npx playwright test image-upload audio-upload video-upload file-upload cover-block gallery-block` — all pass
- [ ] Manual: set `window.GBKit.userCapabilities = { uploadFiles: true }` via devtools before the editor mounts; verify Upload button appears in the Image block
- [ ] Manual: omit `userCapabilities` entirely; verify editor falls back to existing `canUser` resolver path without crashing
- [ ] Verify no OPTIONS request is made to `/wp/v2/media` when the seed is active (Network tab)
- [ ] Verify the iOS/Android demo apps pass a realistic `UserCapabilities(uploadFiles: true)` through the authenticated flow and `uploadFiles: false` through the bundled/offline flow

## Related issues

- Precedes the Dependabot bump at #456 (must land first).
- Upstream: https://github.com/WordPress/gutenberg/pull/76307