### PR TITLE
feat(android): add enableNativeBlockInserter feature flag

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/EditorConfiguration.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/EditorConfiguration.kt
@@ -28,7 +28,14 @@ data class EditorConfiguration(
     val cachedAssetHosts: Set<String> = emptySet(),
     val editorAssetsEndpoint: String? = null,
     val enableNetworkLogging: Boolean = false,
-    var enableOfflineMode: Boolean = false
+    var enableOfflineMode: Boolean = false,
+    /**
+     * When true, the web editor delegates block inserter UI to a native
+     * bottom sheet owned by [org.wordpress.gutenberg.GutenbergView] instead of
+     * showing the built-in Gutenberg inserter. Defaults to false so existing
+     * consumers keep the web-based inserter until they opt in.
+     */
+    val enableNativeBlockInserter: Boolean = false
 ): Parcelable {
 
     /**
@@ -73,6 +80,7 @@ data class EditorConfiguration(
         private var editorAssetsEndpoint: String? = null
         private var enableNetworkLogging: Boolean = false
         private var enableOfflineMode: Boolean = false
+        private var enableNativeBlockInserter: Boolean = false
 
         fun setTitle(title: String) = apply { this.title = title }
         fun setContent(content: String) = apply { this.content = content }
@@ -95,6 +103,9 @@ data class EditorConfiguration(
         fun setEditorAssetsEndpoint(editorAssetsEndpoint: String?) = apply { this.editorAssetsEndpoint = editorAssetsEndpoint }
         fun setEnableNetworkLogging(enableNetworkLogging: Boolean) = apply { this.enableNetworkLogging = enableNetworkLogging }
         fun setEnableOfflineMode(enableOfflineMode: Boolean) = apply { this.enableOfflineMode = enableOfflineMode }
+        fun setEnableNativeBlockInserter(enabled: Boolean) = apply {
+            this.enableNativeBlockInserter = enabled
+        }
 
         fun build(): EditorConfiguration = EditorConfiguration(
             title = title,
@@ -117,7 +128,8 @@ data class EditorConfiguration(
             cachedAssetHosts = cachedAssetHosts,
             editorAssetsEndpoint = editorAssetsEndpoint,
             enableNetworkLogging = enableNetworkLogging,
-            enableOfflineMode = enableOfflineMode
+            enableOfflineMode = enableOfflineMode,
+            enableNativeBlockInserter = enableNativeBlockInserter
         )
     }
 
@@ -145,6 +157,7 @@ data class EditorConfiguration(
         .setEditorAssetsEndpoint(editorAssetsEndpoint)
         .setEnableNetworkLogging(enableNetworkLogging)
         .setEnableOfflineMode(enableOfflineMode)
+        .setEnableNativeBlockInserter(enableNativeBlockInserter)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -173,6 +186,7 @@ data class EditorConfiguration(
         if (editorAssetsEndpoint != other.editorAssetsEndpoint) return false
         if (enableNetworkLogging != other.enableNetworkLogging) return false
         if (enableOfflineMode != other.enableOfflineMode) return false
+        if (enableNativeBlockInserter != other.enableNativeBlockInserter) return false
         if (siteId != other.siteId) return false
 
         return true
@@ -200,6 +214,7 @@ data class EditorConfiguration(
         result = 31 * result + (editorAssetsEndpoint?.hashCode() ?: 0)
         result = 31 * result + enableNetworkLogging.hashCode()
         result = 31 * result + enableOfflineMode.hashCode()
+        result = 31 * result + enableNativeBlockInserter.hashCode()
         result = 31 * result + siteId.hashCode()
         return result
     }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/GBKitGlobal.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/GBKitGlobal.kt
@@ -109,6 +109,7 @@ data class GBKitGlobal(
                 authHeader = configuration.authHeader,
                 themeStyles = configuration.themeStyles,
                 plugins = configuration.plugins,
+                enableNativeBlockInserter = configuration.enableNativeBlockInserter,
                 hideTitle = configuration.hideTitle,
                 locale = configuration.locale ?: "en",
                 post = Post(

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/EditorConfigurationTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/EditorConfigurationTest.kt
@@ -47,6 +47,7 @@ class EditorConfigurationBuilderTest {
         assertNull(config.editorAssetsEndpoint)
         assertFalse(config.enableNetworkLogging)
         assertFalse(config.enableOfflineMode)
+        assertFalse(config.enableNativeBlockInserter)
     }
 
     // MARK: - Individual Setter Tests
@@ -267,6 +268,15 @@ class EditorConfigurationBuilderTest {
         assertTrue(config.enableOfflineMode)
     }
 
+    @Test
+    fun `setEnableNativeBlockInserter updates enableNativeBlockInserter`() {
+        val config = builder()
+            .setEnableNativeBlockInserter(true)
+            .build()
+
+        assertTrue(config.enableNativeBlockInserter)
+    }
+
     // MARK: - Method Chaining Tests
 
     @Test
@@ -328,11 +338,13 @@ class EditorConfigurationBuilderTest {
             .setEditorAssetsEndpoint("https://example.com/roundtrip-assets")
             .setEnableNetworkLogging(true)
             .setEnableOfflineMode(true)
+            .setEnableNativeBlockInserter(true)
             .build()
 
         val rebuilt = original.toBuilder().build()
 
         assertEquals(original, rebuilt)
+        assertTrue(rebuilt.enableNativeBlockInserter)
     }
 
     @Test
@@ -523,6 +535,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -536,6 +549,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -549,6 +563,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -560,6 +575,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -573,6 +589,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -586,6 +603,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -599,6 +617,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -612,6 +631,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -623,6 +643,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -634,6 +655,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -647,6 +669,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -660,6 +683,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -673,6 +697,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -686,6 +711,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -699,6 +725,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -712,6 +739,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -725,6 +753,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -738,6 +767,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -751,6 +781,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -764,6 +795,7 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -777,6 +809,21 @@ class EditorConfigurationTest {
             .build()
 
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
+    }
+
+    @Test
+    fun `Configurations with different enableNativeBlockInserter are not equal`() {
+        val config1 = builder()
+            .setEnableNativeBlockInserter(true)
+            .build()
+
+        val config2 = builder()
+            .setEnableNativeBlockInserter(false)
+            .build()
+
+        assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     @Test
@@ -790,6 +837,7 @@ class EditorConfigurationTest {
 
         assertNotEquals(config1.siteId, config2.siteId)
         assertNotEquals(config1, config2)
+        assertNotEquals(config1.hashCode(), config2.hashCode())
     }
 
     // MARK: - Hashable Tests
@@ -872,6 +920,7 @@ class EditorConfigurationTest {
             .setEditorAssetsEndpoint("https://example.com/assets")
             .setEnableNetworkLogging(true)
             .setEnableOfflineMode(false)
+            .setEnableNativeBlockInserter(true)
             .build()
 
         assertEquals("Test Title", config.title)
@@ -895,5 +944,6 @@ class EditorConfigurationTest {
         assertEquals("https://example.com/assets", config.editorAssetsEndpoint)
         assertTrue(config.enableNetworkLogging)
         assertFalse(config.enableOfflineMode)
+        assertTrue(config.enableNativeBlockInserter)
     }
 }

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/GBKitGlobalTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/model/GBKitGlobalTest.kt
@@ -35,22 +35,38 @@ class GBKitGlobalTest {
         )
     }
 
+    @Suppress("LongParameterList")
     private fun makeConfiguration(
         postId: UInt? = null,
         title: String? = null,
         content: String? = null,
         siteURL: String = TEST_SITE_URL,
         postType: PostTypeDetails = PostTypeDetails.post,
+        postStatus: String = "draft",
         shouldUsePlugins: Boolean = true,
-        shouldUseThemeStyles: Boolean = true
+        shouldUseThemeStyles: Boolean = true,
+        hideTitle: Boolean = false,
+        locale: String? = "en",
+        authHeader: String = "Bearer test-token",
+        siteApiNamespace: Array<String> = arrayOf(),
+        namespaceExcludedPaths: Array<String> = arrayOf(),
+        enableNetworkLogging: Boolean = false,
+        enableNativeBlockInserter: Boolean = false
     ): EditorConfiguration {
         return EditorConfiguration.builder(siteURL, TEST_API_ROOT, postType)
             .setPostId(postId)
             .setTitle(title ?: "")
             .setContent(content ?: "")
+            .setPostStatus(postStatus)
             .setPlugins(shouldUsePlugins)
             .setThemeStyles(shouldUseThemeStyles)
-            .setAuthHeader("Bearer test-token")
+            .setHideTitle(hideTitle)
+            .setLocale(locale)
+            .setAuthHeader(authHeader)
+            .setSiteApiNamespace(siteApiNamespace)
+            .setNamespaceExcludedPaths(namespaceExcludedPaths)
+            .setEnableNetworkLogging(enableNetworkLogging)
+            .setEnableNativeBlockInserter(enableNativeBlockInserter)
             .build()
     }
 
@@ -103,6 +119,84 @@ class GBKitGlobalTest {
 
         assertTrue(globalWith.plugins)
         assertFalse(globalWithout.plugins)
+    }
+
+    @Test
+    fun `maps enableNativeBlockInserter from configuration`() {
+        val withFlag = makeConfiguration(enableNativeBlockInserter = true)
+        val withoutFlag = makeConfiguration(enableNativeBlockInserter = false)
+
+        val globalWith = GBKitGlobal.fromConfiguration(withFlag, makeDependencies())
+        val globalWithout = GBKitGlobal.fromConfiguration(withoutFlag, makeDependencies())
+
+        assertTrue(globalWith.enableNativeBlockInserter)
+        assertFalse(globalWithout.enableNativeBlockInserter)
+    }
+
+    @Test
+    fun `maps hideTitle from configuration`() {
+        val withHideTitle = makeConfiguration(hideTitle = true)
+        val withoutHideTitle = makeConfiguration(hideTitle = false)
+
+        val globalWith = GBKitGlobal.fromConfiguration(withHideTitle, makeDependencies())
+        val globalWithout = GBKitGlobal.fromConfiguration(withoutHideTitle, makeDependencies())
+
+        assertTrue(globalWith.hideTitle)
+        assertFalse(globalWithout.hideTitle)
+    }
+
+    @Test
+    fun `maps enableNetworkLogging from configuration`() {
+        val withLogging = makeConfiguration(enableNetworkLogging = true)
+        val withoutLogging = makeConfiguration(enableNetworkLogging = false)
+
+        val globalWith = GBKitGlobal.fromConfiguration(withLogging, makeDependencies())
+        val globalWithout = GBKitGlobal.fromConfiguration(withoutLogging, makeDependencies())
+
+        assertTrue(globalWith.enableNetworkLogging)
+        assertFalse(globalWithout.enableNetworkLogging)
+    }
+
+    @Test
+    fun `maps locale from configuration`() {
+        val configuration = makeConfiguration(locale = "fr_FR")
+        val global = GBKitGlobal.fromConfiguration(configuration, makeDependencies())
+        assertEquals("fr_FR", global.locale)
+    }
+
+    @Test
+    fun `defaults locale to en when configuration locale is null`() {
+        val configuration = makeConfiguration(locale = null)
+        val global = GBKitGlobal.fromConfiguration(configuration, makeDependencies())
+        assertEquals("en", global.locale)
+    }
+
+    @Test
+    fun `maps authHeader from configuration`() {
+        val configuration = makeConfiguration(authHeader = "Bearer my-token")
+        val global = GBKitGlobal.fromConfiguration(configuration, makeDependencies())
+        assertEquals("Bearer my-token", global.authHeader)
+    }
+
+    @Test
+    fun `maps postStatus from configuration`() {
+        val configuration = makeConfiguration(postStatus = "publish")
+        val global = GBKitGlobal.fromConfiguration(configuration, makeDependencies())
+        assertEquals("publish", global.post.status)
+    }
+
+    @Test
+    fun `maps siteApiNamespace from configuration`() {
+        val configuration = makeConfiguration(siteApiNamespace = arrayOf("sites/123", "wp/v2"))
+        val global = GBKitGlobal.fromConfiguration(configuration, makeDependencies())
+        assertEquals(listOf("sites/123", "wp/v2"), global.siteApiNamespace)
+    }
+
+    @Test
+    fun `maps namespaceExcludedPaths from configuration`() {
+        val configuration = makeConfiguration(namespaceExcludedPaths = arrayOf("/oembed", "/batch"))
+        val global = GBKitGlobal.fromConfiguration(configuration, makeDependencies())
+        assertEquals(listOf("/oembed", "/batch"), global.namespaceExcludedPaths)
     }
 
     @Test
@@ -197,7 +291,14 @@ class GBKitGlobalTest {
 
     @Test
     fun `toJsonString round-trips through serialization`() {
-        val configuration = makeConfiguration(postId = 99u, title = "Round Trip", content = "Test content")
+        val configuration = makeConfiguration(
+            postId = 99u,
+            title = "Round Trip",
+            content = "Test content",
+            hideTitle = true,
+            enableNetworkLogging = true,
+            enableNativeBlockInserter = true
+        )
         val original = GBKitGlobal.fromConfiguration(configuration, makeDependencies())
 
         val jsonString = original.toJsonString()
@@ -208,6 +309,9 @@ class GBKitGlobalTest {
         assertEquals(original.post.title, decoded.post.title)
         assertEquals(original.themeStyles, decoded.themeStyles)
         assertEquals(original.plugins, decoded.plugins)
+        assertEquals(original.hideTitle, decoded.hideTitle)
+        assertEquals(original.enableNetworkLogging, decoded.enableNetworkLogging)
+        assertEquals(original.enableNativeBlockInserter, decoded.enableNativeBlockInserter)
     }
 
     // MARK: - Special Characters

--- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
@@ -336,7 +336,7 @@ class SitePreparationViewModel(
 
         return baseConfig.toBuilder()
             .setEnableNetworkLogging(_uiState.value.enableNetworkLogging)
-            // TODO: Add setNativeInserterEnabled when it's available in EditorConfiguration
+            .setEnableNativeBlockInserter(_uiState.value.enableNativeInserter)
             .setPostType(selectedPostType)
             .build()
     }


### PR DESCRIPTION
## Summary

Third of four stacked PRs for the native block inserter. Adds `EditorConfiguration.setEnableNativeBlockInserter(Boolean)` and propagates the flag to `GBKitGlobal` so the web editor can decide whether to delegate inserter UI to the host. Defaults to `false`, so existing consumers keep the web-based inserter until they opt in.

Demo app wires the existing "Enable Native Inserter" toggle to the new setter, replacing the `// TODO` placeholder.

No UI is rendered by turning the flag on alone — it suppresses the web inserter and dispatches `showBlockInserter` to the native bridge (dispatch wiring added in #463). The native handler lands in #461.


---

Note: This PR also increases the test coverage of `EditorConfiguration` because I saw some gaps and this was a small PR.

## Test plan

- [x] `./gradlew :Gutenberg:compileDebugKotlin :app:compileDebugKotlin :Gutenberg:test detekt` — BUILD SUCCESSFUL

## Related

Third of four stacked PRs:
- #465 — Kotlin payload model
- #463 — JS dispatch fix (base of this PR)
- #464 (this PR) — `enableNativeBlockInserter` feature flag
- #461 — native dialog + `GutenbergView` wiring