### PR TITLE
refactor(js): harden native inserter pattern payload shape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
 				"@wordpress/env": "^11.2.0",
 				"@wordpress/eslint-plugin": "^24.3.0",
 				"@wordpress/prettier-config": "^4.43.0",
+				"ajv": "^8.18.0",
 				"eslint": "^8.57",
 				"eslint-import-resolver-typescript": "^4.4.4",
 				"eslint-plugin-react-refresh": "^0.4.26",
@@ -2604,6 +2605,23 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
 			"version": "13.24.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -2619,6 +2637,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@eslint/js": {
 			"version": "8.57.1",
@@ -10226,13 +10251,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@wp-playground/blueprints/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@wp-playground/blueprints/node_modules/pako": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
@@ -10504,13 +10522,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@wp-playground/cli/node_modules/pako": {
 			"version": "1.0.10",
@@ -11001,13 +11012,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@wp-playground/tools/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@wp-playground/tools/node_modules/pako": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
@@ -11408,16 +11412,16 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -11442,32 +11446,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/ansi-align": {
 			"version": "2.0.0",
@@ -14457,6 +14435,23 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/eslint/node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -14495,6 +14490,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/eslint/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/eslint/node_modules/strip-ansi": {
 			"version": "6.0.1",
@@ -14828,8 +14830,7 @@
 					"url": "https://opencollective.com/fastify"
 				}
 			],
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-builder": {
 			"version": "1.1.5",
@@ -16787,9 +16788,9 @@
 			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -20475,24 +20476,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
 		"node_modules/schema-utils/node_modules/ajv-keywords": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
@@ -20506,14 +20489,6 @@
 			"peerDependencies": {
 				"ajv": "^8.8.2"
 			}
-		},
-		"node_modules/schema-utils/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/semver": {
 			"version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
 		"@wordpress/env": "^11.2.0",
 		"@wordpress/eslint-plugin": "^24.3.0",
 		"@wordpress/prettier-config": "^4.43.0",
+		"ajv": "^8.18.0",
 		"eslint": "^8.57",
 		"eslint-import-resolver-typescript": "^4.4.4",
 		"eslint-plugin-react-refresh": "^0.4.26",

--- a/schemas/block-inserter-payload.schema.json
+++ b/schemas/block-inserter-payload.schema.json
@@ -1,0 +1,153 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://github.com/wordpress-mobile/GutenbergKit/schemas/block-inserter-payload.schema.json",
+	"title": "BlockInserterPayload",
+	"description": "Payload delivered to the host app when the web editor requests the native block inserter. Mirrors the Kotlin `BlockInserterPayload` data class at android/Gutenberg/src/main/java/org/wordpress/gutenberg/model/BlockInserter.kt and the formatters at src/utils/blocks.js. Consumed by vitest shape tests; intended for eventual use by cross-language codegen (e.g. quicktype, kotlinx-serialization).",
+	"type": "object",
+	"required": [ "sections", "patterns", "patternCategories" ],
+	"additionalProperties": false,
+	"properties": {
+		"sections": {
+			"type": "array",
+			"items": { "$ref": "#/definitions/BlockInserterSection" }
+		},
+		"patterns": {
+			"type": "array",
+			"items": { "$ref": "#/definitions/BlockPattern" }
+		},
+		"patternCategories": {
+			"type": "array",
+			"items": { "$ref": "#/definitions/BlockPatternCategory" }
+		},
+		"sourceRect": {
+			"anyOf": [
+				{ "type": "null" },
+				{ "$ref": "#/definitions/SourceRect" }
+			]
+		}
+	},
+	"definitions": {
+		"BlockInserterSection": {
+			"type": "object",
+			"required": [ "category", "blocks" ],
+			"additionalProperties": false,
+			"properties": {
+				"category": {
+					"type": "string",
+					"description": "Stable category slug. Synthetic sections use `gbk-`-prefixed values (e.g. `gbk-most-used`)."
+				},
+				"name": {
+					"type": [ "string", "null" ],
+					"description": "Localized display name. Null for synthetic sections that the host renders without a header."
+				},
+				"blocks": {
+					"type": "array",
+					"items": { "$ref": "#/definitions/BlockType" }
+				}
+			}
+		},
+		"BlockType": {
+			"type": "object",
+			"required": [
+				"id",
+				"name",
+				"keywords",
+				"frecency",
+				"isDisabled",
+				"isSearchOnly",
+				"parents"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string",
+					"description": "Unique identifier for this block variant. NOT the same as `name` — multiple entries can share a `name` but have different `id` values to represent variants with different initial attributes (e.g. `core/embed/youtube`)."
+				},
+				"name": { "type": "string" },
+				"title": { "type": [ "string", "null" ] },
+				"description": { "type": [ "string", "null" ] },
+				"category": { "type": [ "string", "null" ] },
+				"keywords": {
+					"type": "array",
+					"items": { "type": "string" }
+				},
+				"icon": {
+					"type": [ "string", "null" ],
+					"description": "SVG markup as a string, or null when the block has no renderable icon."
+				},
+				"frecency": { "type": "number" },
+				"isDisabled": { "type": "boolean" },
+				"isSearchOnly": { "type": "boolean" },
+				"parents": {
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			}
+		},
+		"BlockPattern": {
+			"type": "object",
+			"required": [
+				"name",
+				"title",
+				"content",
+				"blockTypes",
+				"categories",
+				"description",
+				"keywords",
+				"source",
+				"viewportWidth"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"name": { "type": "string" },
+				"title": { "type": "string" },
+				"content": {
+					"type": "string",
+					"description": "HTML with Gutenberg block delimiters."
+				},
+				"blockTypes": {
+					"type": "array",
+					"items": { "type": "string" }
+				},
+				"categories": {
+					"type": "array",
+					"items": { "type": "string" }
+				},
+				"description": { "type": [ "string", "null" ] },
+				"keywords": {
+					"type": "array",
+					"items": { "type": "string" }
+				},
+				"source": { "type": [ "string", "null" ] },
+				"viewportWidth": { "type": [ "integer", "null" ] }
+			}
+		},
+		"BlockPatternCategory": {
+			"type": "object",
+			"required": [ "name", "label" ],
+			"additionalProperties": false,
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "Category slug (e.g. `gallery`)."
+				},
+				"label": {
+					"type": "string",
+					"description": "Localized display label."
+				}
+			}
+		},
+		"SourceRect": {
+			"type": "object",
+			"required": [ "x", "y", "width", "height" ],
+			"additionalProperties": false,
+			"description": "Position of the UI element that triggered the inserter, in CSS pixels relative to the WebView. Host apps can use this to anchor a popover on tablets.",
+			"properties": {
+				"x": { "type": "number" },
+				"y": { "type": "number" },
+				"width": { "type": "number" },
+				"height": { "type": "number" }
+			}
+		}
+	}
+}

--- a/src/components/native-inserter/index.jsx
+++ b/src/components/native-inserter/index.jsx
@@ -40,7 +40,11 @@ import useBlockTypesState from '@wordpress/block-editor/build-module/components/
  * Internal dependencies
  */
 import { debug } from '../../utils/logger';
-import { preprocessBlockTypesForNativeInserter } from '../../utils/blocks';
+import {
+	preprocessBlockTypesForNativeInserter,
+	formatPatternsForNativeInserter,
+	formatPatternCategoriesForNativeInserter,
+} from '../../utils/blocks';
 import { showBlockInserter } from '../../utils/bridge';
 import { unlock } from '../../lock-unlock';
 
@@ -363,28 +367,9 @@ export default function NativeBlockInserterButton( { open, onToggle } ) {
 			categories
 		);
 
-		// Format patterns for native consumption
-		const formattedPatterns =
-			patterns?.map( ( pattern ) => ( {
-				name: pattern.name,
-				title: pattern.title,
-				content: pattern.content,
-				blockTypes: pattern.blockTypes ?? null,
-				categories:
-					pattern.categories?.filter(
-						( cat ) => ! cat.startsWith( '_' )
-					) ?? null,
-				description: pattern.description ?? null,
-				keywords: pattern.keywords ?? null,
-				source: pattern.source ?? null,
-				viewportWidth: pattern.viewportWidth ?? null,
-			} ) ) ?? [];
-
+		const formattedPatterns = formatPatternsForNativeInserter( patterns );
 		const formattedPatternCategories =
-			patternCategories?.map( ( cat ) => ( {
-				name: cat.name,
-				label: cat.label,
-			} ) ) ?? [];
+			formatPatternCategoriesForNativeInserter( patternCategories );
 
 		window.blockInserter = {
 			sections,

--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -332,3 +332,49 @@ export function preprocessBlockTypesForNativeInserter(
 
 	return sections;
 }
+
+/**
+ * Serializes WordPress block patterns into the compact shape expected by the
+ * native block inserter bridge. Array fields default to `[]` (never `null`)
+ * to match the non-nullable `List<String>` contract in the Kotlin
+ * `BlockPattern` model.
+ *
+ * @param {Array} patterns Raw patterns from `__experimentalGetAllowedPatterns`.
+ *
+ * @return {Array} Patterns formatted for the native bridge.
+ */
+export function formatPatternsForNativeInserter( patterns ) {
+	return (
+		patterns?.map( ( pattern ) => ( {
+			name: pattern.name,
+			title: pattern.title,
+			content: pattern.content,
+			blockTypes: pattern.blockTypes ?? [],
+			categories:
+				pattern.categories?.filter(
+					( cat ) => ! cat.startsWith( '_' )
+				) ?? [],
+			description: pattern.description ?? null,
+			keywords: pattern.keywords ?? [],
+			source: pattern.source ?? null,
+			viewportWidth: pattern.viewportWidth ?? null,
+		} ) ) ?? []
+	);
+}
+
+/**
+ * Serializes WordPress block pattern categories into the shape expected by the
+ * native block inserter bridge.
+ *
+ * @param {Array} categories Raw categories from `coreDataStore`.
+ *
+ * @return {Array} Categories formatted for the native bridge.
+ */
+export function formatPatternCategoriesForNativeInserter( categories ) {
+	return (
+		categories?.map( ( cat ) => ( {
+			name: cat.name,
+			label: cat.label,
+		} ) ) ?? []
+	);
+}

--- a/src/utils/blocks.test.js
+++ b/src/utils/blocks.test.js
@@ -1,0 +1,386 @@
+/**
+ * External dependencies
+ */
+import { describe, it, expect, vi } from 'vitest';
+import Ajv from 'ajv';
+
+/**
+ * Internal dependencies
+ */
+import {
+	preprocessBlockTypesForNativeInserter,
+	formatPatternsForNativeInserter,
+	formatPatternCategoriesForNativeInserter,
+} from './blocks';
+import blockInserterPayloadSchema from '../../schemas/block-inserter-payload.schema.json';
+
+vi.mock( './logger.js', () => ( {
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+	debug: vi.fn(),
+} ) );
+
+// `src/utils/blocks.js` pulls in `@wordpress/blocks` and `@wordpress/element`.
+// Neither is needed for the pure transforms under test here, and loading the
+// real packages in vitest trips on JSON import attributes.
+vi.mock( '@wordpress/blocks', () => ( {
+	unregisterBlockType: vi.fn(),
+	getBlockTypes: vi.fn( () => [] ),
+} ) );
+vi.mock( '@wordpress/element', () => ( {
+	renderToString: vi.fn( () => '' ),
+} ) );
+
+const validate = new Ajv().compile( blockInserterPayloadSchema );
+
+function assertBlockInserterPayloadShape( payload ) {
+	if ( validate( payload ) ) {
+		return;
+	}
+	const { instancePath, message } = validate.errors[ 0 ];
+	throw new Error( `${ instancePath || '/' }: ${ message }` );
+}
+
+function makeInserterItem( overrides = {} ) {
+	return {
+		id: 'core/paragraph',
+		name: 'core/paragraph',
+		title: 'Paragraph',
+		description: 'Start with the basic building block of all narrative.',
+		category: 'text',
+		keywords: [ 'text' ],
+		icon: '<svg></svg>',
+		frecency: 0,
+		isDisabled: false,
+		isSearchOnly: false,
+		parent: [],
+		...overrides,
+	};
+}
+
+const WP_CATEGORIES = [
+	{ slug: 'text', title: 'Text' },
+	{ slug: 'media', title: 'Media' },
+	{ slug: 'design', title: 'Design' },
+];
+
+describe( 'preprocessBlockTypesForNativeInserter', () => {
+	it( 'returns sections whose blocks conform to the BlockType shape', () => {
+		const sections = preprocessBlockTypesForNativeInserter(
+			[
+				makeInserterItem(),
+				makeInserterItem( {
+					id: 'core/image',
+					name: 'core/image',
+					title: 'Image',
+					category: 'media',
+					keywords: [],
+				} ),
+			],
+			null,
+			WP_CATEGORIES
+		);
+
+		expect( sections.length ).toBeGreaterThan( 0 );
+		expect( () =>
+			assertBlockInserterPayloadShape( {
+				sections,
+				patterns: [],
+				patternCategories: [],
+			} )
+		).not.toThrow();
+	} );
+
+	it( 'routes contextual blocks into a gbk-contextual section', () => {
+		const sections = preprocessBlockTypesForNativeInserter(
+			[
+				makeInserterItem( {
+					id: 'core/column',
+					name: 'core/column',
+					title: 'Column',
+					category: 'design',
+					parent: [ 'core/columns' ],
+				} ),
+			],
+			'core/columns',
+			WP_CATEGORIES
+		);
+
+		const contextual = sections.find(
+			( s ) => s.category === 'gbk-contextual'
+		);
+		expect( contextual ).toBeDefined();
+		expect( contextual.name ).toBeNull();
+		expect( contextual.blocks.map( ( b ) => b.id ) ).toEqual( [
+			'core/column',
+		] );
+	} );
+
+	it( 'splits search-only blocks into a hidden gbk-search-only section', () => {
+		const sections = preprocessBlockTypesForNativeInserter(
+			[
+				makeInserterItem(),
+				makeInserterItem( {
+					id: 'core/heading/h2',
+					name: 'core/heading',
+					title: 'Heading (H2)',
+					isSearchOnly: true,
+				} ),
+			],
+			null,
+			WP_CATEGORIES
+		);
+
+		const searchOnly = sections.find(
+			( s ) => s.category === 'gbk-search-only'
+		);
+		expect( searchOnly ).toBeDefined();
+		expect( searchOnly.blocks.map( ( b ) => b.id ) ).toEqual( [
+			'core/heading/h2',
+		] );
+	} );
+
+	it( 'defaults keywords and parents to arrays, not null', () => {
+		const sections = preprocessBlockTypesForNativeInserter(
+			[
+				makeInserterItem( {
+					keywords: undefined,
+					parent: undefined,
+				} ),
+			],
+			null,
+			WP_CATEGORIES
+		);
+
+		const block = sections[ 0 ].blocks[ 0 ];
+		expect( Array.isArray( block.keywords ) ).toBe( true );
+		expect( Array.isArray( block.parents ) ).toBe( true );
+	} );
+} );
+
+describe( 'formatPatternsForNativeInserter', () => {
+	it( 'returns an empty array for null or undefined input', () => {
+		expect( formatPatternsForNativeInserter( null ) ).toEqual( [] );
+		expect( formatPatternsForNativeInserter( undefined ) ).toEqual( [] );
+	} );
+
+	it( 'fills missing arrays with [], not null', () => {
+		const [ pattern ] = formatPatternsForNativeInserter( [
+			{ name: 'p', title: 'T', content: '' },
+		] );
+
+		expect( pattern.blockTypes ).toEqual( [] );
+		expect( pattern.categories ).toEqual( [] );
+		expect( pattern.keywords ).toEqual( [] );
+	} );
+
+	it( 'preserves nullable scalar fields as null when absent', () => {
+		const [ pattern ] = formatPatternsForNativeInserter( [
+			{ name: 'p', title: 'T', content: '' },
+		] );
+
+		expect( pattern.description ).toBeNull();
+		expect( pattern.source ).toBeNull();
+		expect( pattern.viewportWidth ).toBeNull();
+	} );
+
+	it( 'filters underscore-prefixed categories', () => {
+		const [ pattern ] = formatPatternsForNativeInserter( [
+			{
+				name: 'p',
+				title: 'T',
+				content: '',
+				categories: [ 'gallery', '_internal', 'query' ],
+			},
+		] );
+
+		expect( pattern.categories ).toEqual( [ 'gallery', 'query' ] );
+	} );
+
+	it( 'produces patterns that conform to the Pattern shape', () => {
+		const patterns = formatPatternsForNativeInserter( [
+			{
+				name: 'core/query-standard-posts',
+				title: 'Standard Posts',
+				content: '<!-- wp:query --><!-- /wp:query -->',
+				blockTypes: [ 'core/query' ],
+				categories: [ 'query', '_internal' ],
+				description: 'Standard posts query',
+				keywords: [ 'posts' ],
+				source: 'pattern-directory',
+				viewportWidth: 1200,
+			},
+			{ name: 'minimal', title: 'Minimal', content: '' },
+		] );
+
+		expect( () =>
+			assertBlockInserterPayloadShape( {
+				sections: [],
+				patterns,
+				patternCategories: [],
+			} )
+		).not.toThrow();
+	} );
+} );
+
+describe( 'formatPatternCategoriesForNativeInserter', () => {
+	it( 'returns an empty array for null or undefined input', () => {
+		expect( formatPatternCategoriesForNativeInserter( null ) ).toEqual(
+			[]
+		);
+		expect( formatPatternCategoriesForNativeInserter( undefined ) ).toEqual(
+			[]
+		);
+	} );
+
+	it( 'produces categories that conform to the PatternCategory shape', () => {
+		const categories = formatPatternCategoriesForNativeInserter( [
+			{ name: 'gallery', label: 'Gallery', extra: 'ignored' },
+		] );
+
+		expect( categories ).toEqual( [
+			{ name: 'gallery', label: 'Gallery' },
+		] );
+		expect( () =>
+			assertBlockInserterPayloadShape( {
+				sections: [],
+				patterns: [],
+				patternCategories: categories,
+			} )
+		).not.toThrow();
+	} );
+} );
+
+describe( 'assertBlockInserterPayloadShape', () => {
+	// Self-tests for the shape checker. These guard against false negatives
+	// (the checker missing real drift) and false positives (rejecting valid
+	// payloads). If these fail, the checker is broken, not the producers.
+
+	it( 'accepts a payload assembled from the real formatters', () => {
+		const payload = {
+			sections: preprocessBlockTypesForNativeInserter(
+				[ makeInserterItem() ],
+				null,
+				WP_CATEGORIES
+			),
+			patterns: formatPatternsForNativeInserter( [
+				{
+					name: 'core/query',
+					title: 'Query',
+					content: '<!-- wp:query /-->',
+				},
+			] ),
+			patternCategories: formatPatternCategoriesForNativeInserter( [
+				{ name: 'gallery', label: 'Gallery' },
+			] ),
+			sourceRect: { x: 10, y: 20, width: 30, height: 40 },
+		};
+
+		expect( () =>
+			assertBlockInserterPayloadShape( payload )
+		).not.toThrow();
+	} );
+
+	it( 'accepts a payload without a sourceRect', () => {
+		const payload = {
+			sections: [],
+			patterns: [],
+			patternCategories: [],
+		};
+
+		expect( () =>
+			assertBlockInserterPayloadShape( payload )
+		).not.toThrow();
+	} );
+
+	it( 'rejects a pattern with a null array field', () => {
+		const payload = {
+			sections: [],
+			patterns: [
+				{
+					name: 'p',
+					title: 'T',
+					content: '',
+					blockTypes: null,
+					categories: [],
+					description: null,
+					keywords: [],
+					source: null,
+					viewportWidth: null,
+				},
+			],
+			patternCategories: [],
+		};
+
+		expect( () => assertBlockInserterPayloadShape( payload ) ).toThrow(
+			/blockTypes/
+		);
+	} );
+
+	it( 'rejects a block type with a non-string id', () => {
+		const payload = {
+			sections: [
+				{
+					category: 'text',
+					name: 'Text',
+					blocks: [
+						{
+							id: 123,
+							name: 'core/paragraph',
+							keywords: [],
+							frecency: 0,
+							isDisabled: false,
+							isSearchOnly: false,
+							parents: [],
+						},
+					],
+				},
+			],
+			patterns: [],
+			patternCategories: [],
+		};
+
+		expect( () => assertBlockInserterPayloadShape( payload ) ).toThrow(
+			/id/
+		);
+	} );
+
+	it( 'rejects a payload with an unknown top-level field', () => {
+		const payload = {
+			sections: [],
+			patterns: [],
+			patternCategories: [],
+			unexpectedField: 'leak',
+		};
+
+		expect( () => assertBlockInserterPayloadShape( payload ) ).toThrow(
+			/additional/i
+		);
+	} );
+
+	it( 'rejects a pattern with an unknown field', () => {
+		const payload = {
+			sections: [],
+			patterns: [
+				{
+					name: 'p',
+					title: 'T',
+					content: '',
+					blockTypes: [],
+					categories: [],
+					description: null,
+					keywords: [],
+					source: null,
+					viewportWidth: null,
+					leakedField: 'oops',
+				},
+			],
+			patternCategories: [],
+		};
+
+		expect( () => assertBlockInserterPayloadShape( payload ) ).toThrow(
+			/additional/i
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary

- Extracts inline pattern/pattern-category serialization from `NativeBlockInserterButton` into named helpers in `src/utils/blocks.js`.
- Flips array fields (`blockTypes`, `categories`, `keywords`) from `?? null` to `?? []` to match the non-nullable `List<String>` contract in the Kotlin `BlockPattern` model (#465). Emitting `null` there would throw `SerializationException` on Android.
- Adds a JSON Schema at `schemas/block-inserter-payload.schema.json` that mirrors the Kotlin `BlockInserterPayload` contract, plus unit tests that validate the formatters against it via `ajv`.

## Dependencies

Targets `trunk` directly. Self-contained — all files it touches exist on `trunk` and #465 (the Kotlin `BlockInserterPayload` model the schema mirrors) has merged.

Landing this **early** rather than stacked on #461 is deliberate: the formatter fix and shape-validating tests act as a defensive guardrail, so when the Android native inserter (#461) flips to ready nothing lands on `trunk` already broken. The `?? []` path has no consumer until #461 lands — technically dead code today — but the cost of landing early is low and the payoff (no broken-on-trunk intermediate state) is real.

- **#465** `feat(android): add block inserter payload model` — **merged**. Kotlin `BlockInserterPayload` is now on `trunk`.
- **#461** `feat(android): add native block inserter` — _still draft_. This PR is a guardrail for it but no longer blocks on it.

## Root Cause

`NativeBlockInserterButton` produced `pattern.blockTypes ?? null`, `pattern.categories ?? null`, and `pattern.keywords ?? null`. The Kotlin model declares those fields as non-nullable `List<String>` with `emptyList()` defaults, which means `null` on the wire fails strict deserialization. The bug only surfaces once the bridge is wired up end-to-end, so the shape tests here are the earliest place to catch it.

## Fix

1. **`src/utils/blocks.js`**: Add `formatPatternsForNativeInserter` and `formatPatternCategoriesForNativeInserter`. Array fields default to `[]`; nullable scalars (`description`, `source`, `viewportWidth`) stay `null`.
2. **`src/components/native-inserter/index.jsx`**: Replace ~20 lines of inline mapping with two function calls.
3. **`schemas/block-inserter-payload.schema.json`**: Standalone JSON Schema (draft-07) with `$id`, field-level descriptions pulled from the Kotlin doc comments, and `additionalProperties: false` on every definition. Consumable by cross-language tooling (`quicktype`, `kotlinx-serialization` codegen) alongside the hand-written Kotlin `BlockInserterPayload`.
4. **`src/utils/blocks.test.js`**: Imports the schema and validates payloads via `ajv`. When either side drifts — wrong type, missing field, or unknown field — the tests fail loudly with a JSON-Pointer path instead of failing silently at bridge-deserialization time. Upstream Gutenberg ships no JSON Schema for these shapes (only JSDoc typedefs on `WPEditorInserterItem` / `WPBlockType`), so the schema is hand-written but tracks the Kotlin model as the source of truth.
5. **`package.json`**: Adds `ajv` as a direct devDependency (was transitive).

## Test plan

- [x] `npx vitest run src/utils/blocks.test.js` — 17 tests pass
- [x] `make lint-js-fix` — clean