### PR TITLE
fix(android): stabilize editor E2E tests after native inserter regression

### DIFF
--- a/android/app/src/androidTest/java/com/example/gutenbergkit/EditorTestHelpers.kt
+++ b/android/app/src/androidTest/java/com/example/gutenbergkit/EditorTestHelpers.kt
@@ -48,8 +48,8 @@ object EditorTestHelpers {
 
     /**
      * Navigates from the main list through the configuration screen
-     * and into the full-screen editor. Waits for the "Add title" element
-     * in the WebView to confirm the editor has loaded.
+     * and into the full-screen editor, then blocks until the Gutenberg
+     * JS has finished booting and `window.editor` is callable.
      */
     fun navigateToEditor(
         rule: EditorTestRule
@@ -62,8 +62,40 @@ object EditorTestHelpers {
         rule.waitForNodeWithText("Start")
         rule.onNodeWithText("Start").performClick()
 
-        // Wait for the WebView to load: poll until the title element appears.
-        waitForWebViewElement(TITLE_SELECTOR, NAVIGATE_TIMEOUT_MS)
+        // Block until the editor JS has booted and the bridge API is live.
+        waitForEditorReady(NAVIGATE_TIMEOUT_MS)
+    }
+
+    /**
+     * Polls the WebView until Gutenberg's editor API is callable AND the
+     * editor toolbar has mounted. Tests that race ahead of this see
+     * `Atom evaluation returned null!` from Espresso-Web because their
+     * DOM queries run before the editor has finished initializing.
+     *
+     * Two gates are checked:
+     *   - `window.editor.setContent` is a function — the native bridge
+     *     is wired up.
+     *   - `[aria-label="Editor toolbar"]` exists — the top-level React
+     *     tree has rendered, so toolbar-scoped selectors will resolve.
+     */
+    fun waitForEditorReady(timeoutMs: Long = NAVIGATE_TIMEOUT_MS) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        val probe = """
+            return (typeof window.editor !== 'undefined'
+                && typeof window.editor.setContent === 'function'
+                && !!document.querySelector('[aria-label="Editor toolbar"]'))
+                ? 'yes' : 'no';
+        """.trimIndent()
+        while (true) {
+            val ready = runCatching { runJs(probe) }.getOrDefault("no")
+            if (ready == "yes") return
+            if (System.currentTimeMillis() >= deadline) {
+                throw AssertionError(
+                    "Gutenberg editor did not become ready within ${timeoutMs}ms"
+                )
+            }
+            Thread.sleep(250)
+        }
     }
 
     /**
@@ -90,6 +122,7 @@ object EditorTestHelpers {
      */
     fun insertBlock(name: String) {
         // Tap the "Add block" toggle button in the WebView toolbar.
+        waitForWebViewElement(ADD_BLOCK_SELECTOR, ELEMENT_TIMEOUT_MS)
         onWebView()
             .forceJavascriptEnabled()
             .withElement(findElement(Locator.CSS_SELECTOR, ADD_BLOCK_SELECTOR))
@@ -282,26 +315,26 @@ object EditorTestHelpers {
 
     /**
      * Polls until a WebView element matching the CSS selector exists.
-     * Uses Espresso Web's `findElement` which throws when the element
-     * is not yet present, retrying until the timeout is reached.
+     *
+     * Uses a JS probe via `script()` rather than `withElement(findElement(...))`
+     * because `withElement` is lazy — the atom doesn't evaluate until a
+     * terminal operation is chained, so a bare `withElement` call never
+     * actually checks anything. `runJs` performs `script()` which is terminal.
      */
     private fun waitForWebViewElement(cssSelector: String, timeoutMs: Long) {
+        val escaped = cssSelector.replace("\\", "\\\\").replace("'", "\\'")
+        val probe = "return document.querySelector('$escaped') ? 'yes' : 'no';"
         val deadline = System.currentTimeMillis() + timeoutMs
 
         while (true) {
-            try {
-                onWebView()
-                    .forceJavascriptEnabled()
-                    .withElement(findElement(Locator.CSS_SELECTOR, cssSelector))
-                return
-            } catch (e: Exception) {
-                if (System.currentTimeMillis() >= deadline) {
-                    throw AssertionError(
-                        "Timed out waiting for WebView element: $cssSelector", e
-                    )
-                }
-                Thread.sleep(500)
+            val found = runCatching { runJs(probe) }.getOrDefault("no")
+            if (found == "yes") return
+            if (System.currentTimeMillis() >= deadline) {
+                throw AssertionError(
+                    "Timed out waiting for WebView element: $cssSelector"
+                )
             }
+            Thread.sleep(250)
         }
     }
 

--- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
@@ -19,7 +19,7 @@ import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.PostType as WpPostType
 
 data class SitePreparationUiState(
-    val enableNativeInserter: Boolean = true,
+    val enableNativeInserter: Boolean = false,
     val enableNetworkLogging: Boolean = false,
     /** All viewable post types fetched from the site, or empty while loading. */
     val postTypes: List<PostTypeDetails> = emptyList(),


### PR DESCRIPTION
## Summary

`testUndoRedoAfterTyping` was failing deterministically on CI (build [2043](https://buildkite.com/automattic/gutenbergkit/builds/2043)) with `Atom evaluation returned null!`. Two independent issues, both fixed here.

## Root Cause

### 1. `navigateToEditor` races editor startup

The existing `waitForWebViewElement(TITLE_SELECTOR)` call never actually polled anything — `withElement(findElement(...))` is lazy and requires a terminal op (`.perform()` / `.check()` / `script()`) to evaluate. The fall-through meant tests proceeded before `window.editor` was callable and before the React tree had mounted.

Confirmed locally: reproduced the failure, then hardened the gate, then re-ran green.

### 2. Demo defaulted to the native inserter

#464 flipped `SitePreparationUiState.enableNativeInserter` to `true`, which swaps the Gutenberg default `Inserter` (`aria-label="Add block"`) for `NativeInserter` (`title="Add block"`, different className). #463's `showBlockInserter` dispatches to the native bridge, but the Android `@JavascriptInterface` receiver hasn't landed yet — so tapping does nothing and the toolbar test failed. Reverting the demo default to `false` until the native handler ships.

## Changes

- **`EditorTestHelpers.kt`**: new `waitForEditorReady` gate that polls for both `window.editor.setContent` and `[aria-label="Editor toolbar"]` via a `script()` (terminal) atom. `navigateToEditor` now calls this instead of the broken element-wait.
- **`EditorTestHelpers.kt`**: rewrote `waitForWebViewElement` to use the same `script()`-based probe so it actually evaluates. Also added a defensive wait at the top of `insertBlock`.
- **`SitePreparationViewModel.kt`**: `enableNativeInserter` default back to `false`.

## Test plan

- [x] `EditorInteractionTest#testUndoRedoAfterTyping` passes locally (`gbkit_api34` AVD, API 34)
- [x] Full `EditorInteractionTest` class (2 tests) passes locally
- [x] CI goes green

## CI stability runs

Four independent runs of this commit (`e58ef3e`) all show `:android: Test Android E2E` green — the test is no longer flaky.

| Build | Android E2E | Notes |
| --- | --- | --- |
| [2045](https://buildkite.com/automattic/gutenbergkit/builds/2045) | ✅ | Initial PR build — all 11 jobs passed |
| [2046](https://buildkite.com/automattic/gutenbergkit/builds/2046) | ✅ | Rebuild 1/3 |
| [2047](https://buildkite.com/automattic/gutenbergkit/builds/2047) | ✅ | Rebuild 2/3 |
| [2048](https://buildkite.com/automattic/gutenbergkit/builds/2048) | ✅ | Rebuild 3/3 |

The rebuilds each show `:android: Publish Android Library` red — this is the pipeline's expected idempotency check rejecting the already-published artifact for commit `e58ef3e` (`'org.wordpress.gutenbergkit.android:473-e58ef3e...' is already published to S3!`). Unrelated to this PR and only fires on same-commit re-runs.