### PR TITLE
fix(ios): bound URLCache store flush wait with exponential backoff

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/Stores/EditorURLCache.swift
+++ b/ios/Sources/GutenbergKit/Sources/Stores/EditorURLCache.swift
@@ -45,7 +45,7 @@ public struct EditorURLCache: Sendable {
         httpMethod: EditorHttpMethod,
         currentDate: Date
     ) throws {
-        let response = CachedURLResponse(
+        let cachedResponse = CachedURLResponse(
             response: HTTPURLResponse(
                 url: url,
                 statusCode: 200,
@@ -59,8 +59,9 @@ public struct EditorURLCache: Sendable {
             storagePolicy: .allowed
         )
 
-        self.cache.storeCachedResponse(response, for: URLRequest(method: httpMethod, url: url))
-        Thread.sleep(forTimeInterval: 0.05)  // Hack to make `URLCache` work
+        let request = URLRequest(method: httpMethod, url: url)
+        self.cache.storeCachedResponse(cachedResponse, for: request)
+        self.__waitForStoreToFlush(request: request, expectedData: cachedResponse.data)
     }
 
     /// Stores the contents of a downloaded file as a cached response for the given URL and HTTP method.
@@ -90,7 +91,7 @@ public struct EditorURLCache: Sendable {
         currentDate: Date
     ) throws {
 
-        let response = CachedURLResponse(
+        let cachedResponse = CachedURLResponse(
             response: HTTPURLResponse(
                 url: url,
                 statusCode: 200,
@@ -104,8 +105,9 @@ public struct EditorURLCache: Sendable {
             storagePolicy: .allowed
         )
 
-        self.cache.storeCachedResponse(response, for: URLRequest(method: httpMethod, url: url))
-        Thread.sleep(forTimeInterval: 0.05)  // Hack to make `URLCache` work
+        let request = URLRequest(method: httpMethod, url: url)
+        self.cache.storeCachedResponse(cachedResponse, for: request)
+        self.__waitForStoreToFlush(request: request, expectedData: cachedResponse.data)
     }
 
     /// Checks whether a cached response exists for the given URL and HTTP method.
@@ -161,7 +163,30 @@ public struct EditorURLCache: Sendable {
     /// - Throws: An error if the cache cannot be cleared.
     public func clear() throws {
         self.cache.removeAllCachedResponses()
-        Thread.sleep(forTimeInterval: 0.2)  // Hack to make `URLCache` work (needs longer than store)
+        Thread.sleep(forTimeInterval: 0.2)  // See store(...) — async flush needs to settle
+    }
+
+    /// Blocks until an async `URLCache.storeCachedResponse(_:for:)` flush has settled.
+    ///
+    /// `URLCache` writes to disk asynchronously. With `memoryCapacity: 0`, every read
+    /// goes to disk, so a read issued right after a write can race the flush and return
+    /// the previous entry. Sleep with exponential backoff (50 ms, 100 ms, 200 ms, ...)
+    /// up to 500 ms total, checking after each sleep whether the just-stored entry is
+    /// visible. Fast hardware exits at the first check; CI disk-I/O contention has
+    /// headroom up to the cap. A flaky 50 ms previously failed under contention.
+    private func __waitForStoreToFlush(request: URLRequest, expectedData: Data) {
+        var delay: TimeInterval = 0.05
+        var elapsed: TimeInterval = 0
+        while elapsed < 0.5 {
+            let step = min(delay, 0.5 - elapsed)
+            Thread.sleep(forTimeInterval: step)
+            elapsed += step
+            if let cached = self.cache.cachedResponse(for: request),
+               cached.data == expectedData {
+                return
+            }
+            delay *= 2
+        }
     }
 
     /// Encodes data to work around a `URLCache` bug with empty data.


### PR DESCRIPTION
## Summary

- The `EditorURLCacheTests` test `maxAge policy: re-storing refreshes the expiration` flakes intermittently on Buildkite — surfaced most recently on #458's swift-test job. Caused by `URLCache.storeCachedResponse(_:for:)` writing to disk asynchronously: with `memoryCapacity: 0`, the test's read after the second store can race the flush and return the previous entry.
- Replaces the fixed 50 ms post-store sleep with sleep-then-check exponential backoff (50 ms, 100 ms, 200 ms, …) capped at 500 ms. Fast hardware exits at the first check; CI disk-I/O contention has 10× headroom over the previously-flaking value.

## Root cause

`URLCache.storeCachedResponse(_:for:)` queues a disk write to a background queue. `EditorURLCache` papers over the async-flush race with a fixed 50 ms `Thread.sleep` after every store. 50 ms is usually enough on idle hardware; under disk-I/O contention on the shared CI Mac metal hosts (multiple VMs sharing the same SSD), the flush can take longer.

In the failing test, the second store's write doesn't propagate within 50 ms, so the read sees the *first* stored response (with `storageDate = T0`). The `.maxAge(60)` policy at `T0+80` rejects it as expired → returns `nil` → `nil == newResponse` fails.

## Fix

`__waitForStoreToFlush(request:expectedData:)` sleeps with exponential backoff and re-checks `cachedResponse(for:)` after each sleep, returning as soon as the just-stored response (matched by data) is visible:

| Iteration | Sleep | Cumulative | Note |
| --------- | ----- | ---------- | ---- |
| 1 | 0.05 s | 0.05 s | Matches the previously-baseline wait |
| 2 | 0.10 s | 0.15 s | |
| 3 | 0.20 s | 0.35 s | |
| 4 | 0.15 s | 0.50 s | Clamped to the 0.5 s cap |

Locally, the previously-flaky tests now finish in 0.4–1.5 s depending on disk pressure (vs. 1.5–2.0 s with a flat 0.5 s sleep, and 0.5 s with the original 0.05 s sleep when not flaking).

## What we explored

### 1. Polling helper, check-then-sleep, 1 ms initial delay, 5 s cap ❌

First attempt mirrored `waitForClearToTakeEffect` from #370: tight initial delay, generous cap. Surprisingly, polling was *worse* than a fixed sleep — the `cachedResponse(for:)` calls inside the loop appear to contend with the pending write on `URLCache`'s internal queue, and the data check never matched within 5 s.

### 2. Flat 0.5 s sleep ✅

Same approach #422 took for `clear()` — just bump the constant. Worked, but every store unconditionally pays the worst-case wait. ~2 s test-suite cost on fast hardware.

### 3. Sleep-then-check, 50 ms initial, 500 ms cap (this PR) ✅

Sleeping first lets the write start, so reads observe the new entry without disrupting the pending flush. Exits early on fast hardware.

## Test plan

- [x] Run `make test-swift-package` 4× locally — all suites pass on every run, including the previously-flaky `maxAge policy: re-storing refreshes the expiration`, `storing response overwrites the previous value`, and `store fileAt URL twice overwrites prior value`.
- [ ] Confirm Buildkite swift-test passes.

## Related

- #422 — same fix pattern for `clear()` (1 s → 5 s polling timeout)
- #370 — original `clear()` flake fix
- #458 — most recent observed swift-test flake from this race