### PR TITLE
test(ios): exercise the Swift package on macOS via `swift test`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,12 +59,22 @@ steps:
           queue: android
       plugins: *plugins
 
-    - label: ':swift: Test Swift Package'
+    - label: ':swift: iOS Simulator Tests'
+      key: swift-test-swift-package
       depends_on: build-react
       command: |
           buildkite-agent artifact download dist.tar.gz .
           tar -xzf dist.tar.gz
           make test-swift-package
+      plugins: *plugins
+
+    - label: ':swift: Library Tests'
+      key: swift-test-library
+      depends_on: build-react
+      command: |
+          buildkite-agent artifact download dist.tar.gz .
+          tar -xzf dist.tar.gz
+          make test-swift-library
       plugins: *plugins
 
     - label: ':ios: Test iOS E2E'

--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,12 @@ test-js-watch: npm-dependencies ## Run JavaScript tests in watch mode
 	npm run test:unit:watch
 
 .PHONY: test-swift-package
-test-swift-package: build ## Run Swift package tests
+test-swift-package: build ## Run Swift package tests in the iOS Simulator
 	$(call XCODEBUILD_CMD, test, GutenbergKit-Package)
+
+.PHONY: test-swift-library
+test-swift-library: build ## Run Swift package tests against the host platform via `swift test`
+	swift test
 
 .PHONY: test-ios-e2e
 test-ios-e2e: ## Run iOS E2E tests against the production build

--- a/ios/Sources/GutenbergKit/Sources/Services/LockdownModeMonitor.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/LockdownModeMonitor.swift
@@ -5,6 +5,7 @@ import OSLog
 
 #if canImport(UIKit)
 import UIKit
+#endif
 
 /// Protocol for objects that can be checked for Lockdown Mode status.
 ///
@@ -39,8 +40,10 @@ class LockdownModeMonitor: ObservableObject {
     /// Indicates whether we should show the lockdown sheet on next editor load.
     private var shouldShowSheet = false
 
+    #if canImport(UIKit)
     /// Weak reference to the view controller that will present the sheet.
     private weak var presentingViewController: UIViewController?
+    #endif
 
     /// Weak reference to the detectable object for re-checking on foreground.
     private weak var detectable: LockdownModeDetectable?
@@ -77,6 +80,18 @@ class LockdownModeMonitor: ObservableObject {
             shouldShowSheet = false
         }
     }
+
+    /// Resets the monitor state to re-check Lockdown Mode status.
+    ///
+    /// Call this when the app returns from background to re-evaluate Lockdown Mode
+    /// and potentially show the sheet again if it's still enabled.
+    public func resetForForegroundCheck() {
+        hasShownSheet = false
+    }
+}
+
+#if canImport(UIKit)
+extension LockdownModeMonitor {
 
     /// Sets up the monitor with required dependencies and starts observing foreground notifications.
     ///
@@ -155,14 +170,6 @@ class LockdownModeMonitor: ObservableObject {
         return true
     }
 
-    /// Resets the monitor state to re-check Lockdown Mode status.
-    ///
-    /// Call this when the app returns from background to re-evaluate Lockdown Mode
-    /// and potentially show the sheet again if it's still enabled.
-    public func resetForForegroundCheck() {
-        hasShownSheet = false
-    }
-
     /// Dismisses the sheet if it's currently presented.
     ///
     /// - Parameter completion: Optional callback invoked after dismissal completes.
@@ -175,5 +182,4 @@ class LockdownModeMonitor: ObservableObject {
         presentingViewController.dismiss(animated: false, completion: completion)
     }
 }
-
 #endif

--- a/ios/Sources/GutenbergKit/Sources/Services/LockdownModeMonitor.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/LockdownModeMonitor.swift
@@ -57,6 +57,9 @@ class LockdownModeMonitor: ObservableObject {
     }
 
     deinit {
+        // No-op when `setup(presentingViewController:)` never ran (macOS, or an
+        // iOS instance that was created but never set up): `removeObserver(self)`
+        // is safe to call when `self` was never registered as an observer.
         NotificationCenter.default.removeObserver(self)
     }
 

--- a/ios/Sources/GutenbergKit/Sources/Services/LockdownModeMonitor.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/LockdownModeMonitor.swift
@@ -28,6 +28,10 @@ extension WKWebView: LockdownModeDetectable {
 ///
 /// This class handles detection of iOS Lockdown Mode in the WebView and manages
 /// the presentation of a warning sheet to inform users about potential editor limitations.
+///
+/// The detection state machine is host-buildable; sheet presentation and foreground
+/// handling live in a UIKit-gated extension below so the state machine can be
+/// exercised by `swift test` on macOS.
 @MainActor
 class LockdownModeMonitor: ObservableObject {
 

--- a/ios/Tests/GutenbergKitTests/Services/LockdownModeMonitorTests.swift
+++ b/ios/Tests/GutenbergKitTests/Services/LockdownModeMonitorTests.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Testing
 import WebKit
+
+#if canImport(UIKit)
 import UIKit
 
 @testable import GutenbergKit
@@ -256,3 +258,5 @@ struct LockdownModeMonitorTests {
         #expect(monitor.isLockdownModeEnabled == true)
     }
 }
+
+#endif

--- a/ios/Tests/GutenbergKitTests/Services/LockdownModeMonitorTests.swift
+++ b/ios/Tests/GutenbergKitTests/Services/LockdownModeMonitorTests.swift
@@ -121,8 +121,9 @@ struct LockdownModeMonitorTests {
 
     // MARK: - State Transition Tests
     //
-    // These tests verify the detection state machine without calling presentSheetIfNeeded,
-    // which would trigger UIViewController.present() and deadlock in CI (no window hierarchy).
+    // The detection state machine is host-buildable, so these tests run on
+    // both the iOS Simulator and macOS via `swift test`. UIKit-dependent
+    // presentation tests live in the `UIKit-Only Tests` section below.
 
     @Test("Disabled-to-enabled transition sets isLockdownModeEnabled")
     func disabledToEnabledTransitionSetsState() {

--- a/ios/Tests/GutenbergKitTests/Services/LockdownModeMonitorTests.swift
+++ b/ios/Tests/GutenbergKitTests/Services/LockdownModeMonitorTests.swift
@@ -4,6 +4,7 @@ import WebKit
 
 #if canImport(UIKit)
 import UIKit
+#endif
 
 @testable import GutenbergKit
 
@@ -41,19 +42,6 @@ struct LockdownModeMonitorTests {
         #expect(monitor.isLockdownModeEnabled == true)
     }
 
-    // MARK: - Setup Tests
-
-    @Test("Setup accepts a presenting view controller")
-    func setupAcceptsPresentingViewController() {
-        let monitor = makeMonitor()
-        let viewController = UIViewController()
-
-        monitor.setup(presentingViewController: viewController)
-
-        // Should not crash or change lockdown state
-        #expect(monitor.isLockdownModeEnabled == false)
-    }
-
     // MARK: - Detection Logic Tests
 
     @Test("detectLockdownMode updates isLockdownModeEnabled property")
@@ -74,43 +62,6 @@ struct LockdownModeMonitorTests {
         monitor.detectLockdownMode(for: webView)
 
         #expect(monitor.isLockdownModeEnabled == webView.configuration.defaultWebpagePreferences.isLockdownModeEnabled)
-    }
-
-    // MARK: - Sheet Presentation Tests
-
-    @Test("presentSheetIfNeeded returns false when not needed")
-    func presentSheetIfNeededReturnsFalseWhenNotNeeded() {
-        let monitor = makeMonitor()
-
-        let result = monitor.presentSheetIfNeeded {}
-
-        #expect(result == false)
-    }
-
-    @Test("presentSheetIfNeeded returns false without presenting view controller")
-    func presentSheetIfNeededReturnsFalseWithoutViewController() {
-        let monitor = makeMonitor()
-
-        let result = monitor.presentSheetIfNeeded {}
-
-        #expect(result == false)
-    }
-
-    // MARK: - Foreground Handling Tests
-
-    @Test("dismissSheetIfPresented calls completion immediately when no sheet")
-    func dismissSheetCallsCompletionImmediatelyWithoutSheet() {
-        let monitor = makeMonitor()
-        let viewController = UIViewController()
-
-        monitor.setup(presentingViewController: viewController)
-
-        var completionCalled = false
-        monitor.dismissSheetIfPresented {
-            completionCalled = true
-        }
-
-        #expect(completionCalled == true)
     }
 
     // MARK: - Scenario Tests
@@ -144,18 +95,6 @@ struct LockdownModeMonitorTests {
         monitor.detectLockdownMode(for: webView)
 
         #expect(monitor.isLockdownModeEnabled == webView.configuration.defaultWebpagePreferences.isLockdownModeEnabled)
-    }
-
-    @Test("Setup can be called multiple times")
-    func setupCanBeCalledMultipleTimes() {
-        let monitor = makeMonitor()
-        let vc1 = UIViewController()
-        let vc2 = UIViewController()
-
-        monitor.setup(presentingViewController: vc1)
-        monitor.setup(presentingViewController: vc2)
-
-        // Should handle gracefully
     }
 
     // MARK: - Mock-Based Detection Tests
@@ -231,19 +170,6 @@ struct LockdownModeMonitorTests {
         #expect(monitor.isLockdownModeEnabled == true)
     }
 
-    @Test("presentSheetIfNeeded returns false without setup even after detection")
-    func presentSheetReturnsFalseWithoutSetup() {
-        let monitor = makeMonitor()
-
-        // Trigger a disabled-to-enabled transition (sets shouldShowSheet)
-        let enabledMock = MockLockdownModeDetectable(isLockdownModeEnabled: true)
-        monitor.detectLockdownMode(for: enabledMock)
-
-        // Without setup(), presentingViewController is nil so this returns false
-        let didPresent = monitor.presentSheetIfNeeded {}
-        #expect(didPresent == false)
-    }
-
     @Test("resetForForegroundCheck allows re-detection")
     func resetForForegroundCheckAllowsRedetection() {
         let monitor = makeMonitor()
@@ -257,6 +183,82 @@ struct LockdownModeMonitorTests {
         // State should still reflect the last detection
         #expect(monitor.isLockdownModeEnabled == true)
     }
-}
 
-#endif
+    // MARK: - UIKit-Only Tests
+    //
+    // These exercise the UIKit-gated extension on `LockdownModeMonitor`
+    // (`setup(presentingViewController:)`, `presentSheetIfNeeded`,
+    // `dismissSheetIfPresented`). They only build/run on platforms where
+    // UIKit is available.
+
+    #if canImport(UIKit)
+    @Test("Setup accepts a presenting view controller")
+    func setupAcceptsPresentingViewController() {
+        let monitor = makeMonitor()
+        let viewController = UIViewController()
+
+        monitor.setup(presentingViewController: viewController)
+
+        // Should not crash or change lockdown state
+        #expect(monitor.isLockdownModeEnabled == false)
+    }
+
+    @Test("Setup can be called multiple times")
+    func setupCanBeCalledMultipleTimes() {
+        let monitor = makeMonitor()
+        let vc1 = UIViewController()
+        let vc2 = UIViewController()
+
+        monitor.setup(presentingViewController: vc1)
+        monitor.setup(presentingViewController: vc2)
+
+        // Should handle gracefully
+    }
+
+    @Test("presentSheetIfNeeded returns false when not needed")
+    func presentSheetIfNeededReturnsFalseWhenNotNeeded() {
+        let monitor = makeMonitor()
+
+        let result = monitor.presentSheetIfNeeded {}
+
+        #expect(result == false)
+    }
+
+    @Test("presentSheetIfNeeded returns false without presenting view controller")
+    func presentSheetIfNeededReturnsFalseWithoutViewController() {
+        let monitor = makeMonitor()
+
+        let result = monitor.presentSheetIfNeeded {}
+
+        #expect(result == false)
+    }
+
+    @Test("presentSheetIfNeeded returns false without setup even after detection")
+    func presentSheetReturnsFalseWithoutSetup() {
+        let monitor = makeMonitor()
+
+        // Trigger a disabled-to-enabled transition (sets shouldShowSheet)
+        let enabledMock = MockLockdownModeDetectable(isLockdownModeEnabled: true)
+        monitor.detectLockdownMode(for: enabledMock)
+
+        // Without setup(), presentingViewController is nil so this returns false
+        let didPresent = monitor.presentSheetIfNeeded {}
+        #expect(didPresent == false)
+    }
+
+    @Test("dismissSheetIfPresented calls completion immediately when no sheet")
+    func dismissSheetCallsCompletionImmediatelyWithoutSheet() {
+        let monitor = makeMonitor()
+        let viewController = UIViewController()
+
+        monitor.setup(presentingViewController: viewController)
+
+        var completionCalled = false
+        monitor.dismissSheetIfPresented {
+            completionCalled = true
+        }
+
+        #expect(completionCalled == true)
+    }
+    #endif
+}


### PR DESCRIPTION
## Summary

- The only Swift test job in CI runs `xcodebuild -sdk iphonesimulator`, where `canImport(UIKit)` is always true. iOS-only `#if canImport(UIKit)` gates are never exercised against macOS, so it's possible to break the host-platform build without CI noticing — and `LockdownModeMonitorTests` was in fact already broken on macOS (it imported UIKit unconditionally).
- Add a "Library Tests" Buildkite step that runs `swift test` against the host platform (macOS, where `canImport(UIKit)` is false), so this class of regression gets caught going forward.
- Refactor `LockdownModeMonitor` so the detection state machine is host-buildable and only the UIKit-dependent presentation methods live in a gated extension. Consolidate test gating in the same spirit. The state machine now runs on both the iOS Simulator and macOS — 13 more tests via `swift test` than before.

## Why

The production `LockdownModeMonitor.swift` was gated on `#if canImport(UIKit)` because it depends on UIKit + WKWebView APIs. The companion test file was *not* gated, so it imported UIKit unconditionally and referenced types that don't exist on macOS. The breakage was invisible because:

- `.buildkite/pipeline.yml`'s sole Swift test job calls `make test-swift-package` → `xcodebuild ... -sdk iphonesimulator` (UIKit available).
- `Package.swift` advertises `.macOS(.v14)` support, but no CI job builds against macOS.

So the pipeline was happy while `swift test` was broken.

## Changes

### CI

- `.buildkite/pipeline.yml`: rename `:swift: Test Swift Package` → `:swift: iOS Simulator Tests`, with `key: swift-test-swift-package` pinned so the GitHub commit-status name stays the same for branch protection. Add `:swift: Library Tests` running `make test-swift-library`.
- `Makefile`: add `test-swift-library` target running `swift test`. Tighten the existing `test-swift-package` doc comment to note it's the simulator one.

### Production split

- `ios/Sources/GutenbergKit/Sources/Services/LockdownModeMonitor.swift`: split so the state machine — `LockdownModeDetectable` protocol, `WKWebView: LockdownModeDetectable` extension, `detectLockdownMode`, `resetForForegroundCheck` — is host-buildable. Only the UIKit-dependent surface (`setup(presentingViewController:)`, `handleWillEnterForeground`, `presentSheetIfNeeded`, `dismissSheetIfPresented`, plus the `presentingViewController` stored property) is gated behind `#if canImport(UIKit)` and lives in a separate extension at the bottom.
- Class doc gains a one-sentence note explaining the split, so the next reader doesn't have to spelunk to find the gated extension.
- `deinit` calls `removeObserver(self)` unconditionally; added a comment noting that's a safe no-op when `setup()` never ran (macOS or pre-`setup()` iOS).

### Tests

- `ios/Tests/GutenbergKitTests/Services/LockdownModeMonitorTests.swift`: only the import of `UIKit` and the six tests that actually need it (`setup` / `presentSheetIfNeeded` / `dismissSheetIfPresented`) are gated. The mock-based tests and state-transition tests run on both platforms. The six gated tests are consolidated into a single `// MARK: - UIKit-Only Tests` block at the bottom of the suite under one `#if canImport(UIKit)`, instead of being scattered through six interleaved `#if`/`#endif` pairs.
- The "State Transition Tests" section comment was rewritten — its previous "would deadlock in CI" rationale was about the old shape where presentation lived as siblings; now it just notes that the state machine is host-buildable and presentation tests live in the section below.

## Test plan

- [x] `swift test` (macOS host) — 861 tests across 45 suites pass.
- [x] `make test-swift-package` (iPhone Simulator) — passes, including the consolidated `UIKit-Only Tests` block.
- [x] `make test-swift-library` (new target, macOS host) — passes.
- [x] Confirm Buildkite shows both `:swift: iOS Simulator Tests` and `:swift: Library Tests` and both pass.
- [ ] Confirm the existing `buildkite/gutenbergkit/swift-test-swift-package` commit-status name still appears (preserved via `key:`), so branch protection stays green.