### PR TITLE
feat(android): wire up block inserter search and tab filtering

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -78,12 +79,15 @@ import androidx.compose.ui.unit.sp
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import kotlin.math.roundToInt
+import kotlinx.coroutines.delay
 import org.wordpress.gutenberg.R
 import androidx.compose.ui.graphics.Color as ComposeColor
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.BlockType
 
 private const val SEARCH_ONLY_CATEGORY = "gbk-search-only"
+private const val MOST_USED_CATEGORY = "gbk-most-used"
+private const val SEARCH_DEBOUNCE_MS = 150L
 
 /** WordPress brand navy — seed for the fallback scheme on pre-API-31 devices. */
 private const val BRAND_SEED_ARGB = 0xFF001E57.toInt()
@@ -147,6 +151,10 @@ private const val BLOCK_TILE_LABEL_MIN_SP = 9
 private const val BLOCK_TILE_LABEL_LETTER_SPACING_SP = 0.1
 private const val BLOCK_TILE_LABEL_LINE_HEIGHT_RATIO = 1.2f
 
+private const val EMPTY_STATE_HORIZONTAL_PAD_DP = 12
+private const val EMPTY_STATE_VERTICAL_PAD_DP = 32
+private const val EMPTY_STATE_FONT_SP = 14
+
 private const val DISABLED_ALPHA = 0.5f
 
 /**
@@ -205,16 +213,28 @@ private fun BlockPickerSheet(
     val colorScheme = rememberColorScheme()
     MaterialTheme(colorScheme = colorScheme) {
         val allBlocks = remember(payload) { flattenBlocks(payload) }
+        val recentBlocks = remember(payload, allBlocks) { recentBlocks(payload, allBlocks) }
 
         var selectedTab by remember { mutableStateOf(BlockPickerTab.Recent) }
         var query by remember { mutableStateOf("") }
+        var debounced by remember { mutableStateOf("") }
+        LaunchedEffect(query) {
+            delay(SEARCH_DEBOUNCE_MS)
+            debounced = query.trim()
+        }
+
+        val filtered = remember(selectedTab, debounced, allBlocks, recentBlocks) {
+            val tabBlocks = filterByTab(selectedTab, allBlocks, recentBlocks)
+            if (debounced.isEmpty()) tabBlocks else searchBlocks(debounced, tabBlocks)
+        }
 
         SheetContent(
             selectedTab = selectedTab,
             onSelectTab = { selectedTab = it },
             query = query,
             onQueryChange = { query = it },
-            blocks = allBlocks,
+            debouncedQuery = debounced,
+            blocks = filtered,
             onBlockSelected = onBlockSelected,
             onClose = onClose,
             surface = colorScheme.surfaceContainerLow,
@@ -229,6 +249,7 @@ private fun SheetContent(
     onSelectTab: (BlockPickerTab) -> Unit,
     query: String,
     onQueryChange: (String) -> Unit,
+    debouncedQuery: String,
     blocks: List<BlockType>,
     onBlockSelected: (BlockType) -> Unit,
     onClose: () -> Unit,
@@ -252,6 +273,7 @@ private fun SheetContent(
         SearchField(query = query, onQueryChange = onQueryChange)
         BlockGridContent(
             blocks = blocks,
+            query = debouncedQuery,
             onBlockClicked = onBlockSelected,
             modifier = Modifier
                 .fillMaxWidth()
@@ -266,6 +288,17 @@ private fun flattenBlocks(payload: BlockInserterPayload): List<BlockType> =
             .filter { it.category != SEARCH_ONLY_CATEGORY }
             .flatMap { it.blocks }
     )
+
+private fun recentBlocks(
+    payload: BlockInserterPayload,
+    allBlocks: List<BlockType>,
+): List<BlockType> {
+    val mostUsed = payload.sections
+        .firstOrNull { it.category == MOST_USED_CATEGORY }
+        ?.blocks
+        .orEmpty()
+    return if (mostUsed.isNotEmpty()) dedupeById(mostUsed) else allBlocks
+}
 
 @Composable
 private fun rememberColorScheme(): ColorScheme {
@@ -526,9 +559,14 @@ private fun SearchInput(
 @Composable
 private fun BlockGridContent(
     blocks: List<BlockType>,
+    query: String,
     onBlockClicked: (BlockType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    if (blocks.isEmpty()) {
+        EmptyState(query = query, modifier = modifier)
+        return
+    }
     val keyboard = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
     // Snap-dismiss the keyboard on the first user drag — reliable fallback for
@@ -711,21 +749,78 @@ private fun AutoShrinkTileLabel(
     }
 }
 
+@Composable
+private fun EmptyState(query: String, modifier: Modifier = Modifier) {
+    val text = if (query.isNotBlank()) {
+        stringResource(R.string.gbk_block_inserter_no_results_for, query)
+    } else {
+        stringResource(R.string.gbk_block_inserter_no_results)
+    }
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = EMPTY_STATE_HORIZONTAL_PAD_DP.dp,
+                vertical = EMPTY_STATE_VERTICAL_PAD_DP.dp,
+            ),
+    ) {
+        Text(
+            text = text,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = EMPTY_STATE_FONT_SP.sp,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
 private fun dedupeById(blocks: List<BlockType>): List<BlockType> {
     val seen = HashSet<String>()
     return blocks.filter { seen.add(it.id) }
 }
 
+private fun filterByTab(
+    tab: BlockPickerTab,
+    allBlocks: List<BlockType>,
+    recentBlocks: List<BlockType>,
+): List<BlockType> {
+    if (tab == BlockPickerTab.Recent) return recentBlocks
+    val ids = tab.blockIds ?: return allBlocks
+    return allBlocks.filter { it.name.substringAfterLast('/') in ids }
+}
+
 /**
- * Hardcoded tab labels from the design handoff. The chips are visible but
- * non-functional in this PR — filtering behavior ships in the follow-up.
+ * Hardcoded block-id groupings from the design handoff. Production will likely
+ * derive these from the payload, but the design freezes the taxonomy shown in
+ * the tabs so we pin it here to match Variation B exactly.
  */
-private enum class BlockPickerTab(val labelRes: Int) {
-    Recent(R.string.gbk_block_inserter_tab_recent),
-    Text(R.string.gbk_block_inserter_tab_text),
-    Media(R.string.gbk_block_inserter_tab_media),
-    Design(R.string.gbk_block_inserter_tab_design),
-    Widgets(R.string.gbk_block_inserter_tab_widgets),
-    Theme(R.string.gbk_block_inserter_tab_theme),
-    Embeds(R.string.gbk_block_inserter_tab_embeds);
+private enum class BlockPickerTab(
+    val labelRes: Int,
+    val blockIds: Set<String>?,
+) {
+    Recent(R.string.gbk_block_inserter_tab_recent, null),
+    Text(
+        R.string.gbk_block_inserter_tab_text,
+        setOf("paragraph", "heading", "list", "quote", "preformatted"),
+    ),
+    Media(
+        R.string.gbk_block_inserter_tab_media,
+        setOf("image", "gallery", "video", "audio", "cover", "file"),
+    ),
+    Design(
+        R.string.gbk_block_inserter_tab_design,
+        setOf("table", "separator", "code", "columns", "button", "buttons"),
+    ),
+    Widgets(
+        R.string.gbk_block_inserter_tab_widgets,
+        setOf("button", "buttons", "separator"),
+    ),
+    Theme(
+        R.string.gbk_block_inserter_tab_theme,
+        setOf("cover", "columns", "gallery"),
+    ),
+    Embeds(
+        R.string.gbk_block_inserter_tab_embeds,
+        setOf("video", "audio", "embed"),
+    );
 }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockSearch.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockSearch.kt
@@ -1,0 +1,118 @@
+package org.wordpress.gutenberg.inserter
+
+import org.wordpress.gutenberg.model.BlockType
+
+/**
+ * Weighted fuzzy search for [BlockType]. Ports
+ * `ios/Sources/GutenbergKit/Sources/Helpers/SearchEngine.swift` so the Android
+ * inserter ranks results identically to iOS.
+ *
+ * Fields are scored in priority order — title, name, keywords, description,
+ * category. Exact and prefix matches dominate; a Levenshtein fallback catches
+ * near-misses on short queries.
+ */
+internal fun searchBlocks(query: String, blocks: List<BlockType>): List<BlockType> {
+    val normalized = query.lowercase().trim()
+    if (normalized.isEmpty()) return blocks
+    return blocks
+        .map { it to scoreBlock(it, normalized) }
+        .filter { it.second > 0.0 }
+        .sortedByDescending { it.second }
+        .map { it.first }
+}
+
+private const val MAX_EDIT_DISTANCE = 2
+private const val MIN_SIMILARITY_THRESHOLD = 0.7
+private const val EXACT_MATCH_MULTIPLIER = 2.0
+private const val PREFIX_MATCH_MULTIPLIER = 1.5
+private const val WORD_PREFIX_MATCH_MULTIPLIER = 0.8
+private const val FUZZY_MATCH_MULTIPLIER = 0.6
+private const val FULL_FIELD_FUZZY_DAMPEN = 0.7
+private const val FULL_FIELD_FUZZY_MAX_QUERY_LEN = 10
+
+private const val WEIGHT_TITLE = 10.0
+private const val WEIGHT_NAME = 8.0
+private const val WEIGHT_KEYWORD = 5.0
+private const val WEIGHT_DESCRIPTION = 2.0
+private const val WEIGHT_CATEGORY = 2.0
+
+private data class SearchField(val content: String, val weight: Double, val allowFuzzy: Boolean)
+
+private fun BlockType.searchableFields(): List<SearchField> = buildList {
+    title?.let { add(SearchField(it, WEIGHT_TITLE, allowFuzzy = true)) }
+    add(SearchField(name, WEIGHT_NAME, allowFuzzy = false))
+    keywords.forEach { add(SearchField(it, WEIGHT_KEYWORD, allowFuzzy = true)) }
+    description?.let { add(SearchField(it, WEIGHT_DESCRIPTION, allowFuzzy = false)) }
+    category?.let { add(SearchField(it, WEIGHT_CATEGORY, allowFuzzy = true)) }
+}
+
+private fun scoreBlock(block: BlockType, query: String): Double =
+    block.searchableFields().sumOf { field ->
+        if (field.content.isEmpty()) 0.0
+        else fieldScore(field.content.lowercase(), query, field.weight, field.allowFuzzy)
+    }
+
+private fun fieldScore(field: String, query: String, weight: Double, allowFuzzy: Boolean): Double {
+    if (field.isEmpty() || query.isEmpty()) return 0.0
+    val literal = literalMatchScore(field, query, weight)
+    if (literal != null) return literal
+    if (!allowFuzzy) return 0.0
+    return fuzzyMatchScore(field, query, weight)
+}
+
+private fun literalMatchScore(field: String, query: String, weight: Double): Double? = when {
+    field == query -> weight * EXACT_MATCH_MULTIPLIER
+    field.startsWith(query) -> weight * PREFIX_MATCH_MULTIPLIER
+    field.contains(query) -> weight
+    else -> null
+}
+
+private fun fuzzyMatchScore(field: String, query: String, weight: Double): Double {
+    field.split(' ').forEach { word ->
+        val wordScore = wordFuzzyScore(word, query, weight)
+        if (wordScore > 0.0) return wordScore
+    }
+    if (query.length <= FULL_FIELD_FUZZY_MAX_QUERY_LEN) {
+        val fieldSimilarity = similarity(field, query)
+        if (fieldSimilarity >= MIN_SIMILARITY_THRESHOLD) {
+            return weight * fieldSimilarity * FUZZY_MATCH_MULTIPLIER * FULL_FIELD_FUZZY_DAMPEN
+        }
+    }
+    return 0.0
+}
+
+private fun wordFuzzyScore(word: String, query: String, weight: Double): Double {
+    if (word.startsWith(query)) return weight * WORD_PREFIX_MATCH_MULTIPLIER
+    val wordSimilarity = similarity(word, query)
+    if (wordSimilarity >= MIN_SIMILARITY_THRESHOLD) {
+        return weight * wordSimilarity * FUZZY_MATCH_MULTIPLIER
+    }
+    return 0.0
+}
+
+private fun similarity(a: String, b: String): Double {
+    if (a.isEmpty() || b.isEmpty()) return 0.0
+    val distance = levenshtein(a, b)
+    val maxLen = maxOf(a.length, b.length)
+    if (distance > minOf(MAX_EDIT_DISTANCE, maxLen / 3)) return 0.0
+    return 1.0 - distance.toDouble() / maxLen
+}
+
+private fun levenshtein(a: String, b: String): Int {
+    if (a.isEmpty()) return b.length
+    if (b.isEmpty()) return a.length
+    val matrix = Array(a.length + 1) { IntArray(b.length + 1) }
+    for (i in 0..a.length) matrix[i][0] = i
+    for (j in 0..b.length) matrix[0][j] = j
+    for (i in 1..a.length) {
+        for (j in 1..b.length) {
+            val cost = if (a[i - 1] == b[j - 1]) 0 else 1
+            matrix[i][j] = minOf(
+                matrix[i - 1][j] + 1,
+                matrix[i][j - 1] + 1,
+                matrix[i - 1][j - 1] + cost,
+            )
+        }
+    }
+    return matrix[a.length][b.length]
+}

--- a/android/Gutenberg/src/main/res/values/strings.xml
+++ b/android/Gutenberg/src/main/res/values/strings.xml
@@ -14,4 +14,6 @@
     <string name="gbk_block_inserter_tab_theme">Theme</string>
     <string name="gbk_block_inserter_tab_embeds">Embeds</string>
     <string name="gbk_block_inserter_clear_search">Clear search</string>
+    <string name="gbk_block_inserter_no_results">No results</string>
+    <string name="gbk_block_inserter_no_results_for">No blocks match “%1$s”</string>
 </resources>

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/BlockSearchTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/BlockSearchTest.kt
@@ -1,0 +1,87 @@
+package org.wordpress.gutenberg.inserter
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.gutenberg.model.BlockType
+
+class BlockSearchTest {
+
+    private val paragraph = block(
+        id = "core/paragraph", name = "core/paragraph", title = "Paragraph",
+        keywords = listOf("text"),
+    )
+    private val heading = block(
+        id = "core/heading", name = "core/heading", title = "Heading",
+    )
+    private val image = block(
+        id = "core/image", name = "core/image", title = "Image",
+        keywords = listOf("photo", "picture"),
+    )
+    private val gallery = block(
+        id = "core/gallery", name = "core/gallery", title = "Gallery",
+        description = "Display multiple images in a gallery.",
+    )
+
+    private val all = listOf(paragraph, heading, image, gallery)
+
+    @Test
+    fun `empty query returns all blocks unchanged`() {
+        assertEquals(all, searchBlocks("", all))
+        assertEquals(all, searchBlocks("   ", all))
+    }
+
+    @Test
+    fun `exact title match ranks first`() {
+        val results = searchBlocks("image", all)
+        assertEquals(image, results.first())
+    }
+
+    @Test
+    fun `keyword match surfaces blocks with matching keyword`() {
+        val results = searchBlocks("photo", all)
+        assertTrue(image in results)
+    }
+
+    @Test
+    fun `prefix match is preferred over generic contains`() {
+        val results = searchBlocks("head", all)
+        assertEquals(heading, results.first())
+    }
+
+    @Test
+    fun `description match returns the block when nothing else matches`() {
+        val results = searchBlocks("display", all)
+        assertEquals(listOf(gallery), results)
+    }
+
+    @Test
+    fun `fuzzy match tolerates a single typo in title`() {
+        val results = searchBlocks("imge", all)
+        assertEquals(image, results.first())
+    }
+
+    @Test
+    fun `no match returns empty`() {
+        assertTrue(searchBlocks("asdfghjkl", all).isEmpty())
+    }
+
+    @Test
+    fun `search is case insensitive`() {
+        assertEquals(image, searchBlocks("IMAGE", all).first())
+    }
+
+    private fun block(
+        id: String,
+        name: String,
+        title: String? = null,
+        description: String? = null,
+        keywords: List<String> = emptyList(),
+    ) = BlockType(
+        id = id,
+        name = name,
+        title = title,
+        description = description,
+        keywords = keywords,
+    )
+}


### PR DESCRIPTION
## Summary

Activates the tab chips and search field shipped as a non-functional shell in #469 — keeps the visual layer untouched, only adds behavior.

- **Tab filter** — selecting a category narrows the grid to a fixed id allowlist per `InserterTab`. The Recent tab surfaces the payload's `gbk-most-used` section when present, otherwise all blocks.
- **Search** — debounced 150ms, runs over the active tab's slice. Fuzzy scorer in `BlockSearch.kt` weights name/title/keyword/category matches.
- **Empty state** — renders `No results` / `No blocks match "X"` when the filter yields nothing.

Stacked on #461; rebase onto `trunk` once that lands.

## Test plan

- [x] Open the inserter on the sample app
- [x] Verify each tab chip shows appropriate blocks
- [x] Type a multi-character query quickly — confirm the debounce holds the grid steady mid-type and it settles once after you stop
- [x] Type a query that matches nothing — confirm empty-state copy renders
- [x] Clear the search — confirm the active tab's blocks come back
- [x] `./gradlew :Gutenberg:detekt :Gutenberg:assembleDebug :Gutenberg:testDebugUnitTest` passes