### PR TITLE
feat(android): add native block inserter (UI shell)

### DIFF
--- a/android/Gutenberg/build.gradle.kts
+++ b/android/Gutenberg/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.jetbrains.kotlin.compose)
     alias(libs.plugins.jetbrains.kotlin.serialization)
     id("com.automattic.android.publish-to-s3")
     id("kotlin-parcelize")
@@ -13,6 +14,7 @@ android {
 
     buildFeatures {
         buildConfig = true
+        compose = true
     }
 
     defaultConfig {
@@ -82,6 +84,11 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.jsoup)
     implementation(libs.okhttp)
+
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
 
     testImplementation(libs.junit)
     testImplementation(kotlin("test"))

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.json.JSONException
 import org.json.JSONObject
-import org.wordpress.gutenberg.inserter.BlockInserterDialog
+import org.wordpress.gutenberg.inserter.BlockPickerDialog
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
@@ -122,7 +122,7 @@ class GutenbergView : FrameLayout {
     private var modalDialogStateListener: ModalDialogStateListener? = null
     private var networkRequestListener: NetworkRequestListener? = null
     private var latestContentProvider: LatestContentProvider? = null
-    private var blockInserterDialog: BlockInserterDialog? = null
+    private var blockInserterDialog: BlockPickerDialog? = null
 
     /**
      * Stores the contextId from the most recent openMediaLibrary call
@@ -913,7 +913,7 @@ class GutenbergView : FrameLayout {
 
     private fun presentBlockInserter(payload: BlockInserterPayload) {
         blockInserterDialog?.dismiss()
-        val dialog = BlockInserterDialog(
+        val dialog = BlockPickerDialog(
             context = context,
             payload = payload,
             onBlockSelected = { block -> insertBlock(block.id) },

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -1,0 +1,663 @@
+package org.wordpress.gutenberg.inserter
+
+import android.content.Context
+import android.graphics.Color
+import android.os.Build
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.rememberScrollableState
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import org.wordpress.gutenberg.R
+import androidx.compose.ui.graphics.Color as ComposeColor
+import org.wordpress.gutenberg.model.BlockInserterPayload
+import org.wordpress.gutenberg.model.BlockType
+
+private const val SEARCH_ONLY_CATEGORY = "gbk-search-only"
+
+/** WordPress brand navy — seed for the fallback scheme on pre-API-31 devices. */
+private const val BRAND_SEED_ARGB = 0xFF001E57.toInt()
+
+/** Medium sheet height (dp) per the design spec; drives BottomSheetBehavior's peek. */
+private const val SHEET_PEEK_HEIGHT_DP = 620
+
+private const val SHEET_CORNER_DP = 28
+private const val HANDLE_WIDTH_DP = 32
+private const val HANDLE_HEIGHT_DP = 4
+private const val HANDLE_TOP_PAD_DP = 10
+private const val HANDLE_BOTTOM_PAD_DP = 4
+private const val HANDLE_ALPHA = 0.4f
+
+private const val HEADER_HEIGHT_DP = 48
+private const val HEADER_START_PAD_DP = 24
+private const val HEADER_END_PAD_DP = 8
+private const val HEADER_VERTICAL_PAD_DP = 6
+private const val HEADER_BUTTON_GAP_DP = 6
+private const val HEADER_TITLE_SP = 22
+private const val HEADER_TITLE_LETTER_SPACING_SP = -0.1
+
+private const val ICON_BUTTON_SIZE_DP = 40
+private const val ICON_SIZE_DP = 20
+
+private const val TABS_VERTICAL_PAD_DP = 4
+private const val TABS_BOTTOM_PAD_DP = 6
+private const val TABS_CONTENT_VERTICAL_PAD_DP = 4
+private const val TABS_CONTENT_HORIZONTAL_PAD_DP = 16
+private const val TABS_GAP_DP = 8
+private const val CHIP_HEIGHT_DP = 36
+private const val CHIP_HORIZONTAL_PAD_DP = 14
+private const val CHIP_CORNER_DP = 18
+private const val CHIP_BORDER_WIDTH_DP = 1
+private const val CHIP_FONT_SP = 13
+private const val CHIP_LETTER_SPACING_SP = 0.2
+
+private const val SEARCH_TOP_PAD_DP = 8
+private const val SEARCH_HORIZONTAL_PAD_DP = 20
+private const val SEARCH_BOTTOM_PAD_DP = 10
+private const val SEARCH_HEIGHT_DP = 40
+private const val SEARCH_CORNER_DP = 20
+private const val SEARCH_INNER_HORIZONTAL_PAD_DP = 14
+private const val SEARCH_ICON_GAP_DP = 10
+private const val SEARCH_ICON_SIZE_DP = 22
+private const val SEARCH_FONT_SP = 14
+
+private const val GRID_HORIZONTAL_PAD_DP = 14
+private const val GRID_BOTTOM_PAD_DP = 8
+private const val GRID_GAP_DP = 8
+private const val BLOCK_TILE_BUTTON_CORNER_DP = 18
+private const val BLOCK_TILE_ICON_SIZE_DP = 56
+private const val BLOCK_TILE_ICON_CORNER_DP = 18
+private const val BLOCK_TILE_VERTICAL_PAD_TOP_DP = 10
+private const val BLOCK_TILE_VERTICAL_PAD_BOTTOM_DP = 12
+private const val BLOCK_TILE_HORIZONTAL_PAD_DP = 4
+private const val BLOCK_TILE_ICON_LABEL_GAP_DP = 8
+private const val BLOCK_TILE_LABEL_SP = 12
+private const val BLOCK_TILE_LABEL_MIN_SP = 9
+private const val BLOCK_TILE_LABEL_LETTER_SPACING_SP = 0.1
+
+private const val DISABLED_ALPHA = 0.5f
+
+/**
+ * Bottom-sheet block inserter. The outer shell stays a `BottomSheetDialog` so
+ * `GutenbergView`'s integration surface is unchanged; everything visible is
+ * Compose content matching the Variation B design handoff — header row,
+ * pill category tabs, rounded search, 5-column tonal tile grid.
+ *
+ * The sheet background and 28dp top corners are drawn by Compose directly; the
+ * dialog's default white pill background is cleared so it doesn't fight the
+ * Material 3 surface tokens.
+ */
+internal class BlockPickerDialog(
+    context: Context,
+    private val payload: BlockInserterPayload,
+    private val onBlockSelected: (BlockType) -> Unit,
+) : BottomSheetDialog(context) {
+
+    init {
+        val composeView = ComposeView(context).apply {
+            setContent {
+                BlockPickerSheet(
+                    payload = payload,
+                    onBlockSelected = { block ->
+                        onBlockSelected(block)
+                        dismiss()
+                    },
+                    onClose = { dismiss() },
+                )
+            }
+        }
+        setContentView(composeView)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val parent = findViewById<ViewGroup>(com.google.android.material.R.id.design_bottom_sheet)
+        parent?.setBackgroundColor(Color.TRANSPARENT)
+        parent?.let { sheet ->
+            BottomSheetBehavior.from(sheet).apply {
+                val density = context.resources.displayMetrics.density
+                peekHeight = (SHEET_PEEK_HEIGHT_DP * density).toInt()
+                skipCollapsed = false
+                state = BottomSheetBehavior.STATE_COLLAPSED
+            }
+        }
+    }
+}
+
+@Composable
+private fun BlockPickerSheet(
+    payload: BlockInserterPayload,
+    onBlockSelected: (BlockType) -> Unit,
+    onClose: () -> Unit,
+) {
+    val colorScheme = rememberColorScheme()
+    MaterialTheme(colorScheme = colorScheme) {
+        val allBlocks = remember(payload) { flattenBlocks(payload) }
+
+        var selectedTab by remember { mutableStateOf(BlockPickerTab.Recent) }
+        var query by remember { mutableStateOf("") }
+
+        SheetContent(
+            selectedTab = selectedTab,
+            onSelectTab = { selectedTab = it },
+            query = query,
+            onQueryChange = { query = it },
+            blocks = allBlocks,
+            onBlockSelected = onBlockSelected,
+            onClose = onClose,
+            surface = colorScheme.surfaceContainerLow,
+        )
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun SheetContent(
+    selectedTab: BlockPickerTab,
+    onSelectTab: (BlockPickerTab) -> Unit,
+    query: String,
+    onQueryChange: (String) -> Unit,
+    blocks: List<BlockType>,
+    onBlockSelected: (BlockType) -> Unit,
+    onClose: () -> Unit,
+    surface: ComposeColor,
+) {
+    // Bridge Compose scroll deltas (grid, tabs) into the View-hierarchy
+    // nested-scroll system so `BottomSheetBehavior` only drags the sheet when
+    // an inner scroller is at its own edge. Without this the sheet and inner
+    // scrollers compete for each touch.
+    val nestedScroll = rememberNestedScrollInteropConnection()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(nestedScroll)
+            .clip(RoundedCornerShape(topStart = SHEET_CORNER_DP.dp, topEnd = SHEET_CORNER_DP.dp))
+            .background(surface)
+    ) {
+        DragHandle()
+        Header(onClose = onClose)
+        CategoryTabs(selected = selectedTab, onSelect = onSelectTab)
+        SearchField(query = query, onQueryChange = onQueryChange)
+        BlockGridContent(
+            blocks = blocks,
+            onBlockClicked = onBlockSelected,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f, fill = true),
+        )
+    }
+}
+
+private fun flattenBlocks(payload: BlockInserterPayload): List<BlockType> =
+    dedupeById(
+        payload.sections
+            .filter { it.category != SEARCH_ONLY_CATEGORY }
+            .flatMap { it.blocks }
+    )
+
+@Composable
+private fun rememberColorScheme(): ColorScheme {
+    val dark = isSystemInDarkTheme()
+    val context = LocalContext.current
+    return remember(dark) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (dark) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        } else {
+            brandFallback(dark, if (dark) darkColorScheme() else lightColorScheme())
+        }
+    }
+}
+
+private fun brandFallback(dark: Boolean, base: ColorScheme): ColorScheme {
+    fun ComposeColor.lighten(f: Float): ComposeColor = copy(
+        red = red + (1f - red) * f,
+        green = green + (1f - green) * f,
+        blue = blue + (1f - blue) * f,
+    )
+    fun ComposeColor.darken(f: Float): ComposeColor = copy(
+        red = red * (1f - f),
+        green = green * (1f - f),
+        blue = blue * (1f - f),
+    )
+    val seed = ComposeColor(BRAND_SEED_ARGB)
+    return if (dark) {
+        base.copy(
+            primary = seed.lighten(0.4f),
+            onPrimary = ComposeColor.White,
+            primaryContainer = seed.darken(0.2f),
+            onPrimaryContainer = seed.lighten(0.6f),
+        )
+    } else {
+        base.copy(
+            primary = seed,
+            onPrimary = ComposeColor.White,
+            primaryContainer = seed.lighten(0.75f),
+            onPrimaryContainer = seed,
+        )
+    }
+}
+
+@Composable
+private fun DragHandle() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = HANDLE_TOP_PAD_DP.dp, bottom = HANDLE_BOTTOM_PAD_DP.dp),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        Box(
+            modifier = Modifier
+                .width(HANDLE_WIDTH_DP.dp)
+                .height(HANDLE_HEIGHT_DP.dp)
+                .clip(RoundedCornerShape(HANDLE_HEIGHT_DP.dp / 2))
+                .background(
+                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = HANDLE_ALPHA)
+                ),
+        )
+    }
+}
+
+@Composable
+private fun Header(onClose: () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(HEADER_BUTTON_GAP_DP.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = HEADER_HEIGHT_DP.dp)
+            .padding(
+                start = HEADER_START_PAD_DP.dp,
+                end = HEADER_END_PAD_DP.dp,
+                top = HEADER_VERTICAL_PAD_DP.dp,
+                bottom = HEADER_VERTICAL_PAD_DP.dp,
+            ),
+    ) {
+        Text(
+            text = stringResource(R.string.gbk_block_inserter_title),
+            color = MaterialTheme.colorScheme.onSurface,
+            fontSize = HEADER_TITLE_SP.sp,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = HEADER_TITLE_LETTER_SPACING_SP.sp,
+            modifier = Modifier.weight(1f),
+        )
+        CloseButton(onClose = onClose)
+    }
+}
+
+@Composable
+private fun CloseButton(onClose: () -> Unit) {
+    IconButton(onClick = onClose, modifier = Modifier.size(ICON_BUTTON_SIZE_DP.dp)) {
+        Icon(
+            imageVector = Icons.Filled.Close,
+            contentDescription = stringResource(R.string.gbk_block_inserter_close),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(ICON_SIZE_DP.dp),
+        )
+    }
+}
+
+@Composable
+private fun CategoryTabs(
+    selected: BlockPickerTab,
+    onSelect: (BlockPickerTab) -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    val verticalRelay = rememberScrollableState { 0f }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = TABS_VERTICAL_PAD_DP.dp, bottom = TABS_BOTTOM_PAD_DP.dp),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(TABS_GAP_DP.dp),
+            modifier = Modifier
+                .horizontalScroll(scrollState)
+                .scrollable(verticalRelay, Orientation.Vertical)
+                .padding(
+                    horizontal = TABS_CONTENT_HORIZONTAL_PAD_DP.dp,
+                    vertical = TABS_CONTENT_VERTICAL_PAD_DP.dp,
+                ),
+        ) {
+            BlockPickerTab.entries.forEach { tab ->
+                CategoryChip(
+                    label = stringResource(tab.labelRes),
+                    selected = tab == selected,
+                    onClick = { onSelect(tab) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryChip(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val background = if (selected) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        ComposeColor.Transparent
+    }
+    val textColor = if (selected) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+    val borderColor = if (selected) {
+        ComposeColor.Transparent
+    } else {
+        MaterialTheme.colorScheme.outlineVariant
+    }
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .height(CHIP_HEIGHT_DP.dp)
+            .clip(RoundedCornerShape(CHIP_CORNER_DP.dp))
+            .background(background)
+            .border(
+                width = CHIP_BORDER_WIDTH_DP.dp,
+                color = borderColor,
+                shape = RoundedCornerShape(CHIP_CORNER_DP.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = CHIP_HORIZONTAL_PAD_DP.dp),
+    ) {
+        Text(
+            text = label,
+            color = textColor,
+            fontSize = CHIP_FONT_SP.sp,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = CHIP_LETTER_SPACING_SP.sp,
+        )
+    }
+}
+
+@Composable
+private fun SearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SEARCH_ICON_GAP_DP.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                top = SEARCH_TOP_PAD_DP.dp,
+                bottom = SEARCH_BOTTOM_PAD_DP.dp,
+                start = SEARCH_HORIZONTAL_PAD_DP.dp,
+                end = SEARCH_HORIZONTAL_PAD_DP.dp,
+            )
+            .height(SEARCH_HEIGHT_DP.dp)
+            .clip(RoundedCornerShape(SEARCH_CORNER_DP.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .padding(horizontal = SEARCH_INNER_HORIZONTAL_PAD_DP.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Search,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(SEARCH_ICON_SIZE_DP.dp),
+        )
+        SearchInput(
+            query = query,
+            onQueryChange = onQueryChange,
+            modifier = Modifier.weight(1f),
+        )
+        if (query.isNotEmpty()) {
+            IconButton(
+                onClick = { onQueryChange("") },
+                modifier = Modifier.size(SEARCH_ICON_SIZE_DP.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    contentDescription = stringResource(R.string.gbk_block_inserter_clear_search),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(ICON_SIZE_DP.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchInput(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BasicTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        singleLine = true,
+        textStyle = TextStyle(
+            fontSize = SEARCH_FONT_SP.sp,
+            color = MaterialTheme.colorScheme.onSurface,
+        ),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        modifier = modifier,
+        decorationBox = { inner ->
+            if (query.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.gbk_block_inserter_search),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = SEARCH_FONT_SP.sp,
+                )
+            }
+            inner()
+        },
+    )
+}
+
+@Composable
+private fun BlockGridContent(
+    blocks: List<BlockType>,
+    onBlockClicked: (BlockType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val keyboard = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+    // Snap-dismiss the keyboard on the first user drag — reliable fallback for
+    // per-pixel interactive dismiss, which doesn't work cleanly inside a
+    // BottomSheetDialog window. Clear focus too so the search field doesn't
+    // silently re-summon the keyboard on the next tap elsewhere.
+    val hideKeyboardOnDrag = remember(keyboard, focusManager) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (source == NestedScrollSource.UserInput && available.y != 0f) {
+                    keyboard?.hide()
+                    focusManager.clearFocus()
+                }
+                return Offset.Zero
+            }
+        }
+    }
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(5),
+        contentPadding = PaddingValues(
+            start = GRID_HORIZONTAL_PAD_DP.dp,
+            end = GRID_HORIZONTAL_PAD_DP.dp,
+            bottom = GRID_BOTTOM_PAD_DP.dp,
+        ),
+        horizontalArrangement = Arrangement.spacedBy(GRID_GAP_DP.dp),
+        verticalArrangement = Arrangement.spacedBy(GRID_GAP_DP.dp),
+        modifier = modifier.nestedScroll(hideKeyboardOnDrag),
+    ) {
+        items(
+            count = blocks.size,
+            key = { blocks[it].id },
+        ) { index ->
+            BlockTile(
+                block = blocks[index],
+                onClick = { onBlockClicked(blocks[index]) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BlockTile(
+    block: BlockType,
+    onClick: () -> Unit,
+) {
+    val bg = MaterialTheme.colorScheme.primaryContainer
+    val contentAlpha = if (block.isDisabled) DISABLED_ALPHA else 1f
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(BLOCK_TILE_ICON_LABEL_GAP_DP.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(BLOCK_TILE_BUTTON_CORNER_DP.dp))
+            .clickable(enabled = !block.isDisabled, onClick = onClick)
+            .padding(
+                horizontal = BLOCK_TILE_HORIZONTAL_PAD_DP.dp,
+            )
+            .padding(
+                top = BLOCK_TILE_VERTICAL_PAD_TOP_DP.dp,
+                bottom = BLOCK_TILE_VERTICAL_PAD_BOTTOM_DP.dp,
+            ),
+    ) {
+        // Plain tonal placeholder. Real icon rendering lands in #468 (the SVG
+        // icon cache PR); this PR only ships the inserter shell.
+        Box(
+            modifier = Modifier
+                .size(BLOCK_TILE_ICON_SIZE_DP.dp)
+                .clip(RoundedCornerShape(BLOCK_TILE_ICON_CORNER_DP.dp))
+                .background(bg),
+        )
+        AutoShrinkTileLabel(
+            text = block.title ?: block.name,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+/**
+ * Label that shrinks the font size (down to [BLOCK_TILE_LABEL_MIN_SP]) until the
+ * text fits on a single line, then ellipsizes if even the minimum is too wide.
+ * Compose has no built-in autosize Text, so we pre-measure via [rememberTextMeasurer].
+ */
+@Composable
+private fun AutoShrinkTileLabel(
+    text: String,
+    color: ComposeColor,
+    modifier: Modifier = Modifier,
+) {
+    val measurer = rememberTextMeasurer()
+    BoxWithConstraints(modifier = modifier) {
+        val maxWidthPx = constraints.maxWidth
+        val style = TextStyle(
+            fontWeight = FontWeight.Medium,
+            letterSpacing = BLOCK_TILE_LABEL_LETTER_SPACING_SP.sp,
+            textAlign = TextAlign.Center,
+        )
+        val resolvedSize = remember(text, maxWidthPx) {
+            var size = BLOCK_TILE_LABEL_SP
+            while (size > BLOCK_TILE_LABEL_MIN_SP) {
+                val result = measurer.measure(
+                    text = text,
+                    style = style.copy(fontSize = size.sp),
+                    maxLines = 1,
+                )
+                if (result.size.width <= maxWidthPx) break
+                size -= 1
+            }
+            size
+        }
+        Text(
+            text = text,
+            color = color,
+            fontSize = resolvedSize.sp,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = BLOCK_TILE_LABEL_LETTER_SPACING_SP.sp,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+private fun dedupeById(blocks: List<BlockType>): List<BlockType> {
+    val seen = HashSet<String>()
+    return blocks.filter { seen.add(it.id) }
+}
+
+/**
+ * Hardcoded tab labels from the design handoff. The chips are visible but
+ * non-functional in this PR — filtering behavior ships in the follow-up.
+ */
+private enum class BlockPickerTab(val labelRes: Int) {
+    Recent(R.string.gbk_block_inserter_tab_recent),
+    Text(R.string.gbk_block_inserter_tab_text),
+    Media(R.string.gbk_block_inserter_tab_media),
+    Design(R.string.gbk_block_inserter_tab_design),
+    Widgets(R.string.gbk_block_inserter_tab_widgets),
+    Theme(R.string.gbk_block_inserter_tab_theme),
+    Embeds(R.string.gbk_block_inserter_tab_embeds);
+}

--- a/android/Gutenberg/src/main/res/values/strings.xml
+++ b/android/Gutenberg/src/main/res/values/strings.xml
@@ -3,4 +3,15 @@
     <string name="gbk_block_inserter_section_most_used">Most used</string>
     <string name="gbk_block_inserter_section_suggested">Suggested</string>
     <string name="gbk_block_inserter_failure">Unable to display the block inserter.</string>
+    <string name="gbk_block_inserter_search">Search blocks</string>
+    <string name="gbk_block_inserter_title">Add block</string>
+    <string name="gbk_block_inserter_close">Close</string>
+    <string name="gbk_block_inserter_tab_recent">Recent</string>
+    <string name="gbk_block_inserter_tab_text">Text</string>
+    <string name="gbk_block_inserter_tab_media">Media</string>
+    <string name="gbk_block_inserter_tab_design">Design</string>
+    <string name="gbk_block_inserter_tab_widgets">Widgets</string>
+    <string name="gbk_block_inserter_tab_theme">Theme</string>
+    <string name="gbk_block_inserter_tab_embeds">Embeds</string>
+    <string name="gbk_block_inserter_clear_search">Clear search</string>
 </resources>


### PR DESCRIPTION
## Summary

- Compose bottom-sheet block inserter replacing the legacy WebView picker.
- Visual shell only: tiles are placeholder rounded rects (icons in #468), chips and search are non-functional (filtering in #478, media strip in #479).

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/43f47a16-2d67-4bec-b8ae-cdc1caf45de2" width="320" alt="Inserter, full-height, light"></td>
    <td><img src="https://github.com/user-attachments/assets/6fb2b491-6f1f-4f1f-9fa5-3bc92b820c34" width="320" alt="Inserter, full-height, dark"></td>
  </tr>
  <tr>
    <td align="center"><sub>Light mode</sub></td>
    <td align="center"><sub>Dark mode</sub></td>
  </tr>
</table>

## Test plan

- [ ] Inserter opens, 5-column grid renders, long labels auto-shrink instead of wrapping
- [ ] Dark mode + Android 12+ dynamic color render correctly
- [ ] `./gradlew :Gutenberg:detekt :Gutenberg:assembleDebug` passes