### PR TITLE
feat(android): render icons and wrap labels in the block inserter

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -69,8 +69,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -143,6 +145,7 @@ private const val BLOCK_TILE_ICON_LABEL_GAP_DP = 8
 private const val BLOCK_TILE_LABEL_SP = 12
 private const val BLOCK_TILE_LABEL_MIN_SP = 9
 private const val BLOCK_TILE_LABEL_LETTER_SPACING_SP = 0.1
+private const val BLOCK_TILE_LABEL_LINE_HEIGHT_RATIO = 1.2f
 
 private const val DISABLED_ALPHA = 0.5f
 
@@ -635,9 +638,16 @@ private fun BlockTile(
 }
 
 /**
- * Label that shrinks the font size (down to [BLOCK_TILE_LABEL_MIN_SP]) until the
- * text fits on a single line, then ellipsizes if even the minimum is too wide.
- * Compose has no built-in autosize Text, so we pre-measure via [rememberTextMeasurer].
+ * Label that wraps multi-word text at whitespace (up to two lines) and shrinks
+ * single-word text to fit on one line, down to [BLOCK_TILE_LABEL_MIN_SP].
+ * Single-word labels never break mid-word: Compose's default soft-wrap will
+ * character-break an overlong single word to satisfy the maxLines budget
+ * (e.g. "Preformatted" → "Preform-" / "atted"), so we measure with
+ * `maxLines = 1` and disable `softWrap` for single-word labels to force the
+ * shrink path instead. The container reserves two lines worth of vertical
+ * space at the resolved size so tile heights stay consistent across the grid.
+ * Compose has no built-in autosize Text, so we pre-measure via
+ * [rememberTextMeasurer].
  */
 @Composable
 private fun AutoShrinkTileLabel(
@@ -648,20 +658,37 @@ private fun AutoShrinkTileLabel(
     val measurer = rememberTextMeasurer()
     BoxWithConstraints(modifier = modifier) {
         val maxWidthPx = constraints.maxWidth
+        // Centre line height around the glyphs and trim the half-leading
+        // above the first / below the last line. Without `Trim.Both` the
+        // default leading shows up as a top gap on a single-line label and
+        // an outsized gap between the two lines on a wrapped one — Material
+        // 3 typography sets this for its presets, but custom sp + lineHeight
+        // doesn't pick it up automatically.
+        val lineHeightStyle = LineHeightStyle(
+            alignment = LineHeightStyle.Alignment.Center,
+            trim = LineHeightStyle.Trim.Both,
+        )
         val style = TextStyle(
             fontWeight = FontWeight.Medium,
             letterSpacing = BLOCK_TILE_LABEL_LETTER_SPACING_SP.sp,
             textAlign = TextAlign.Center,
+            lineHeightStyle = lineHeightStyle,
         )
-        val resolvedSize = remember(text, maxWidthPx) {
+        val canWrap = text.any { it.isWhitespace() }
+        val measureMaxLines = if (canWrap) 2 else 1
+        val resolvedSize = remember(text, maxWidthPx, canWrap) {
             var size = BLOCK_TILE_LABEL_SP
             while (size > BLOCK_TILE_LABEL_MIN_SP) {
                 val result = measurer.measure(
                     text = text,
-                    style = style.copy(fontSize = size.sp),
-                    maxLines = 1,
+                    style = style.copy(
+                        fontSize = size.sp,
+                        lineHeight = (size * BLOCK_TILE_LABEL_LINE_HEIGHT_RATIO).sp,
+                    ),
+                    constraints = Constraints(maxWidth = maxWidthPx),
+                    maxLines = measureMaxLines,
                 )
-                if (result.size.width <= maxWidthPx) break
+                if (!result.didOverflowWidth && !result.didOverflowHeight) break
                 size -= 1
             }
             size
@@ -670,10 +697,14 @@ private fun AutoShrinkTileLabel(
             text = text,
             color = color,
             fontSize = resolvedSize.sp,
+            lineHeight = (resolvedSize * BLOCK_TILE_LABEL_LINE_HEIGHT_RATIO).sp,
             fontWeight = FontWeight.Medium,
             letterSpacing = BLOCK_TILE_LABEL_LETTER_SPACING_SP.sp,
             textAlign = TextAlign.Center,
-            maxLines = 1,
+            style = TextStyle(lineHeightStyle = lineHeightStyle),
+            softWrap = canWrap,
+            minLines = 2,
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.fillMaxWidth(),
         )

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Color
 import android.os.Build
 import android.view.ViewGroup
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -50,13 +51,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
@@ -70,6 +75,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import kotlin.math.roundToInt
 import org.wordpress.gutenberg.R
 import androidx.compose.ui.graphics.Color as ComposeColor
 import org.wordpress.gutenberg.model.BlockInserterPayload
@@ -129,6 +135,7 @@ private const val GRID_GAP_DP = 8
 private const val BLOCK_TILE_BUTTON_CORNER_DP = 18
 private const val BLOCK_TILE_ICON_SIZE_DP = 56
 private const val BLOCK_TILE_ICON_CORNER_DP = 18
+private const val BLOCK_TILE_ICON_GLYPH_SIZE_DP = 32
 private const val BLOCK_TILE_VERTICAL_PAD_TOP_DP = 10
 private const val BLOCK_TILE_VERTICAL_PAD_BOTTOM_DP = 12
 private const val BLOCK_TILE_HORIZONTAL_PAD_DP = 4
@@ -536,6 +543,7 @@ private fun BlockGridContent(
             }
         }
     }
+    val iconCache = rememberSvgIconCache(chipColor = MaterialTheme.colorScheme.primaryContainer)
     LazyVerticalGrid(
         columns = GridCells.Fixed(5),
         contentPadding = PaddingValues(
@@ -553,19 +561,39 @@ private fun BlockGridContent(
         ) { index ->
             BlockTile(
                 block = blocks[index],
+                iconCache = iconCache,
                 onClick = { onBlockClicked(blocks[index]) },
             )
         }
     }
 }
 
+/**
+ * One cache per grid composition. Keyed on render size and chip colour so a
+ * configuration change (font scale, theme switch) recomputes both the bitmap
+ * pixel size and the contrast surrogate the tinting decision is measured
+ * against — see `SvgIconCache.contrastSurface`.
+ */
+@Composable
+private fun rememberSvgIconCache(chipColor: ComposeColor): SvgIconCache {
+    val density = LocalDensity.current
+    val sizePx = with(density) { BLOCK_TILE_ICON_GLYPH_SIZE_DP.dp.toPx() }.roundToInt()
+    val surfaceArgb = chipColor.toArgb()
+    return remember(sizePx, surfaceArgb) {
+        SvgIconCache(renderSizePx = sizePx, contrastSurface = surfaceArgb)
+    }
+}
+
 @Composable
 private fun BlockTile(
     block: BlockType,
+    iconCache: SvgIconCache,
     onClick: () -> Unit,
 ) {
     val bg = MaterialTheme.colorScheme.primaryContainer
+    val tint = MaterialTheme.colorScheme.onSurface
     val contentAlpha = if (block.isDisabled) DISABLED_ALPHA else 1f
+    val rendered = remember(block.id) { iconCache.renderIcon(block) }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(BLOCK_TILE_ICON_LABEL_GAP_DP.dp),
@@ -581,14 +609,23 @@ private fun BlockTile(
                 bottom = BLOCK_TILE_VERTICAL_PAD_BOTTOM_DP.dp,
             ),
     ) {
-        // Plain tonal placeholder. Real icon rendering lands in #468 (the SVG
-        // icon cache PR); this PR only ships the inserter shell.
         Box(
+            contentAlignment = Alignment.Center,
             modifier = Modifier
                 .size(BLOCK_TILE_ICON_SIZE_DP.dp)
                 .clip(RoundedCornerShape(BLOCK_TILE_ICON_CORNER_DP.dp))
                 .background(bg),
-        )
+        ) {
+            rendered?.let { icon ->
+                Image(
+                    bitmap = icon.bitmap.asImageBitmap(),
+                    contentDescription = null,
+                    alpha = contentAlpha,
+                    colorFilter = if (icon.tintable) ColorFilter.tint(tint) else null,
+                    modifier = Modifier.size(BLOCK_TILE_ICON_GLYPH_SIZE_DP.dp),
+                )
+            }
+        }
         AutoShrinkTileLabel(
             text = block.title ?: block.name,
             color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -596,7 +596,7 @@ private fun BlockTile(
     val bg = MaterialTheme.colorScheme.primaryContainer
     val tint = MaterialTheme.colorScheme.onSurface
     val contentAlpha = if (block.isDisabled) DISABLED_ALPHA else 1f
-    val rendered = remember(block.id) { iconCache.renderIcon(block) }
+    val rendered = remember(block.id, iconCache) { iconCache.renderIcon(block) }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(BLOCK_TILE_ICON_LABEL_GAP_DP.dp),


### PR DESCRIPTION
Two changes layered on top of #461 — wire up the `SvgIconCache` that landed there but was never called from the dialog, and tighten the tile label layout so multi-word entries wrap at whitespace while single-word entries shrink instead of mid-word breaking.

Tab filtering / search / empty state are out of scope — #478 covers them.

## Screenshots

Pixel 9 Pro XL, Recent tab. Single-word labels stay on one line at 12sp; multi-word labels wrap at whitespace; tile heights stay aligned across rows.

<table>
<tr>
<td><img width="400" alt="inserter-light" src="https://github.com/user-attachments/assets/30d4df76-7ee4-4116-bf72-d610ac7f9349" /></td>
<td><img width="400" alt="inserter-dark" src="https://github.com/user-attachments/assets/25843e08-669e-4792-8b7a-f1a80907f824" /></td>
</tr>
<tr>
<td align="center">Light theme</td>
<td align="center">Dark theme</td>
</tr>
</table>

## Render block icons

Replaces the tonal placeholder `Box` in `BlockPickerDialog.BlockTile` with the real block icon, sourced from `SvgIconCache` (added alongside the dialog in #461 but never referenced from it). Without this the inserter ships as rows of identical solid chips: every block looks the same apart from its label.

- `BLOCK_TILE_ICON_GLYPH_SIZE_DP = 32` — inner glyph size, distinct from the 56dp chip. The cache renders at glyph pixels, not chip pixels, so bitmaps stay sharp at the displayed size.
- `rememberSvgIconCache(chipColor)` instantiates the cache once per `BlockGridContent` composition, keyed on `(renderSizePx, chipColor)`. A font-scale or theme change recomputes both the bitmap resolution and the contrast surrogate that `SvgIconCache.shouldTint` measures the brand colour against.
- `tintable == true` (monochrome / low-contrast brand) → `ColorFilter.tint(onSurface)`. `tintable == false` (multi-colour / sufficient-contrast brand) → render as-is. `block.isDisabled` → applied via `Image.alpha`, not folded into the tint, so branded icons fade uniformly instead of going monochrome on disable.

## Wrap labels with tight line height

`AutoShrinkTileLabel` previously shrank labels down to 9sp until they fit on a single line. Three things to fix:

1. **Single-word and multi-word were treated identically.** "Featured Image" got shrunk when it could have wrapped at the space at full size.
2. **Mid-word breaks on long single words.** Naively switching to `maxLines = 2` made Compose character-break "Preformatted" into "Preform" / "atted". Compose's default soft-wrap will break inside a word to satisfy the line budget, so single-word labels now measure with `maxLines = 1` and render with `softWrap = false` to force the shrink path instead.
3. **Loose vertical rhythm on wrapped labels.** With no explicit `lineHeight`, the gap between two wrapped lines tracked the font's default leading and read too tall. M3 typography presets handle this via `LineHeightStyle.Trim.Both`, but custom `sp + lineHeight` doesn't pick it up — set it explicitly so labels sit centred against the reserved two-line height.

`minLines = 2` reserves two lines worth of vertical space at the resolved size so tile heights stay consistent across the grid even when neighbouring labels need different line counts.

## Test plan

- [x] `./gradlew :Gutenberg:test detekt :Gutenberg:lintDebug :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] Manually verified on Pixel 9 Pro XL with `enableNativeBlockInserter` on: icons render correctly, single-word labels (e.g. "Preformatted") shrink rather than break, multi-word labels (e.g. "Featured Image") wrap at the space, two-line labels have tight line spacing, tile heights stay aligned across the grid.

## Related

- Builds on #461.
- Tab filtering / search / empty state: #478.
- Unblocks the visual half of #469 (cards + search).