### PR TITLE
Pin XCFramework ARCHS per SDK

### DIFF
--- a/build_xcframework.sh
+++ b/build_xcframework.sh
@@ -87,6 +87,16 @@ build_framework() {
     local destination="$2"
     local archive_path="${BUILD_DIR}/${SCHEME}-${sdk}.xcarchive"
 
+    # Pin ARCHS explicitly so the slice contents stay stable as Xcode evolves
+    # its defaults. Keep `x86_64` in the simulator slice while the iOS
+    # deployment target still overlaps with Intel-Mac dev hosts.
+    local archs
+    case "${sdk}" in
+        iphoneos) archs="arm64" ;;
+        iphonesimulator) archs="arm64 x86_64" ;;
+        *) echo "Error: unknown SDK '${sdk}'" >&2; exit 1 ;;
+    esac
+
     echo "--- Building ${SCHEME} for ${sdk}"
 
     rm -rf "${archive_path}"
@@ -97,6 +107,7 @@ build_framework() {
         -derivedDataPath "${DERIVED_DATA_PATH}" \
         -sdk "${sdk}" \
         -destination "${destination}" \
+        ARCHS="${archs}" \
         BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
         INSTALL_PATH='Library/Frameworks' \
         OTHER_SWIFT_FLAGS=-no-verify-emitted-module-interface \


### PR DESCRIPTION
## What?

Pin `ARCHS` explicitly on the `xcodebuild archive` invocations in `build_xcframework.sh`:

- `iphoneos` → `arm64`
- `iphonesimulator` → `arm64 x86_64`

## Why?

Suggested by @jkmassel on PR #401: [comment thread](https://github.com/wordpress-mobile/GutenbergKit/pull/401/changes#r3025056409).

The script was relying on Xcode's per-SDK default for `ARCHS`. Apple has been quietly trimming Intel from simulator defaults across Xcode versions, so the slice contents could shift under our feet without us changing anything.
Pinning makes the contract explicit.

The simulator slice keeps `x86_64` so contributors and CI on Intel-Mac dev hosts can still run the simulator while the iOS 17 deployment target overlaps with that hardware.

<!-- blue -->
> [!NOTE]  
> Stacking this on top of #401 (rather than landing it inline) because the tradeoff isn't clear-cut and I'd like @jkmassel to weigh in on whether the cost — slightly larger simulator slice, slightly longer CI builds — is worth it given how few Intel-Mac hosts realistically touch this codebase today.

## How?

- Per-SDK `case` resolves the right `archs` string before `xcodebuild`.
- `ARCHS="${archs}"` plumbed into the existing build flag list.
- Unknown SDK → hard error.

The `resolve_slice_dir` helper already accepts whatever simulator slice name Xcode emits (`ios-arm64-simulator` or `ios-arm64_x86_64-simulator`), so no downstream changes are needed.

## Testing Instructions

There's no project-level test that exercises slice contents — JS, Android, and Swift-source test suites don't care which iOS arch slices the XCFramework contains.
The verification that matters (does `x86_64` actually run on Intel?) needs Intel-Mac hardware neither of us has.

What CI will demonstrate: the build still completes and the publish step still uploads a slice. Anything more than that is testing Apple's tooling, which feels like theatre.

---

_Posted by Claude Code (Opus 4.7) on behalf of @mokagio with approval._