### PR TITLE
refactor(ios): back EditorURLCache with SQLiteKVCache

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/Model/EditorCachePolicy.swift
+++ b/ios/Sources/GutenbergKit/Sources/Model/EditorCachePolicy.swift
@@ -10,13 +10,13 @@ import Foundation
 ///
 /// ```swift
 /// // Never use cached responses
-/// let cache = EditorURLCache(cachePolicy: .ignore)
+/// let cache = EditorURLCache(siteId: configuration.siteId, cachePolicy: .ignore)
 ///
 /// // Use cached responses if they're less than 1 hour old
-/// let cache = EditorURLCache(cachePolicy: .maxAge(3600))
+/// let cache = EditorURLCache(siteId: configuration.siteId, cachePolicy: .maxAge(3600))
 ///
 /// // Always use cached responses regardless of age
-/// let cache = EditorURLCache(cachePolicy: .always)
+/// let cache = EditorURLCache(siteId: configuration.siteId, cachePolicy: .always)
 /// ```
 ///
 /// ## Choosing a Policy

--- a/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
@@ -58,8 +58,9 @@ public actor EditorService {
     ///     This policy applies to both API response caching and asset manifest caching.
     ///   - storageRoot: The directory for storing downloaded asset bundles. If `nil`, uses
     ///     a default location based on the site ID.
-    ///   - cacheRoot: The directory for caching API responses. If `nil`, uses a default
-    ///     location based on the site ID.
+    ///   - cacheRoot: The parent directory for caching API responses. The configuration's
+    ///     `siteId` is appended internally so different sites cannot collide. If `nil`,
+    ///     uses `Paths.defaultCacheRoot`.
     public init(
         configuration: EditorConfiguration,
         httpClient: (any EditorHTTPClientProtocol)? = nil,
@@ -79,7 +80,8 @@ public actor EditorService {
             configuration: configuration,
             httpClient: httpClient,
             cache: EditorURLCache(
-                cacheRoot: cacheRoot ?? Paths.cacheRoot(for: configuration),
+                siteId: configuration.siteId,
+                parentDirectory: cacheRoot ?? Paths.defaultCacheRoot,
                 cachePolicy: cachePolicy
             ),
         )

--- a/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
@@ -58,15 +58,36 @@ public actor EditorService {
     ///     This policy applies to both API response caching and asset manifest caching.
     ///   - storageRoot: The directory for storing downloaded asset bundles. If `nil`, uses
     ///     a default location based on the site ID.
-    ///   - cacheRoot: The parent directory for caching API responses. The configuration's
-    ///     `siteId` is appended internally so different sites cannot collide. If `nil`,
-    ///     uses `Paths.defaultCacheRoot`.
     public init(
         configuration: EditorConfiguration,
         httpClient: (any EditorHTTPClientProtocol)? = nil,
         cachePolicy: EditorCachePolicy = .always,
+        storageRoot: URL? = nil
+    ) {
+        self.init(
+            configuration: configuration,
+            httpClient: httpClient,
+            cachePolicy: cachePolicy,
+            storageRoot: storageRoot,
+            cacheRoot: nil
+        )
+    }
+
+    /// Test-only init that exposes a `cacheRoot` override. Production callers
+    /// have no reason to override this — the parent directory is always
+    /// `Paths.defaultCacheRoot` and the per-site directory is appended
+    /// internally — but tests need to redirect the cache to a temporary
+    /// directory for isolation.
+    ///
+    /// - Parameter cacheRoot: The parent directory for caching API responses.
+    ///   The configuration's `siteId` is appended internally so different
+    ///   sites cannot collide. If `nil`, uses `Paths.defaultCacheRoot`.
+    init(
+        configuration: EditorConfiguration,
+        httpClient: (any EditorHTTPClientProtocol)? = nil,
+        cachePolicy: EditorCachePolicy = .always,
         storageRoot: URL? = nil,
-        cacheRoot: URL? = nil
+        cacheRoot: URL?
     ) {
         self.configuration = configuration
 

--- a/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
+++ b/ios/Sources/GutenbergKit/Sources/Services/EditorService.swift
@@ -56,37 +56,38 @@ public actor EditorService {
     ///     Use `.ignore` to always fetch fresh data, `.maxAge(_:)` to expire entries after
     ///     a time interval, or `.always` (the default) to use cached data regardless of age.
     ///     This policy applies to both API response caching and asset manifest caching.
-    ///   - storageRoot: The directory for storing downloaded asset bundles. If `nil`, uses
-    ///     a default location based on the site ID.
     public init(
         configuration: EditorConfiguration,
         httpClient: (any EditorHTTPClientProtocol)? = nil,
-        cachePolicy: EditorCachePolicy = .always,
-        storageRoot: URL? = nil
+        cachePolicy: EditorCachePolicy = .always
     ) {
         self.init(
             configuration: configuration,
             httpClient: httpClient,
             cachePolicy: cachePolicy,
-            storageRoot: storageRoot,
+            storageRoot: nil,
             cacheRoot: nil
         )
     }
 
-    /// Test-only init that exposes a `cacheRoot` override. Production callers
-    /// have no reason to override this — the parent directory is always
-    /// `Paths.defaultCacheRoot` and the per-site directory is appended
-    /// internally — but tests need to redirect the cache to a temporary
-    /// directory for isolation.
+    /// Test-only init that exposes `storageRoot` and `cacheRoot` overrides for
+    /// per-test directory isolation. Production callers have no reason to
+    /// override these — the parent directories are always
+    /// `Paths.defaultStorageRoot` / `Paths.defaultCacheRoot` and the per-site
+    /// directory is appended internally — but tests need to redirect storage
+    /// and cache to a temporary directory.
     ///
-    /// - Parameter cacheRoot: The parent directory for caching API responses.
-    ///   The configuration's `siteId` is appended internally so different
-    ///   sites cannot collide. If `nil`, uses `Paths.defaultCacheRoot`.
+    /// - Parameters:
+    ///   - storageRoot: The directory for storing downloaded asset bundles.
+    ///     If `nil`, uses a default location based on the site ID.
+    ///   - cacheRoot: The parent directory for caching API responses. The
+    ///     configuration's `siteId` is appended internally so different sites
+    ///     cannot collide. If `nil`, uses `Paths.defaultCacheRoot`.
     init(
         configuration: EditorConfiguration,
         httpClient: (any EditorHTTPClientProtocol)? = nil,
         cachePolicy: EditorCachePolicy = .always,
-        storageRoot: URL? = nil,
+        storageRoot: URL?,
         cacheRoot: URL?
     ) {
         self.configuration = configuration

--- a/ios/Sources/GutenbergKit/Sources/Stores/EditorURLCache.swift
+++ b/ios/Sources/GutenbergKit/Sources/Stores/EditorURLCache.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 import OSLog
 
@@ -6,8 +5,15 @@ import OSLog
 ///
 /// Responses are stored on disk and survive process termination. Responses are keyed by both URL and HTTP method, so GET and OPTIONS requests to the
 /// same URL are stored independently.
+///
+/// Backed by `SQLiteKVCache`. The "one instance per backing file" contract from
+/// `SQLiteKVCache` carries over: two `EditorURLCache` instances pointed at the
+/// same `cacheRoot` is undefined behavior.
 public struct EditorURLCache: Sendable {
-    private let cache: URLCache
+    /// About enough for 10 sites of cached responses.
+    private static let diskCapacity = 100 * 1024 * 1024
+
+    private let store: SQLiteKVCache
     private let cachePolicy: EditorCachePolicy
     private let performanceMonitor = SignpostMonitor(for: Logger.performance)
 
@@ -21,8 +27,11 @@ public struct EditorURLCache: Sendable {
     ///     Use `.ignore` to always fetch fresh data, `.maxAge(_:)` to expire entries after
     ///     a time interval, or `.always` (the default) to use cached data regardless of age.
     public init(cacheRoot: URL? = nil, cachePolicy: EditorCachePolicy = .always) {
-        // About enough for 10 sites
-        self.cache = URLCache(memoryCapacity: 0, diskCapacity: 100 * 1024 * 1024, directory: cacheRoot)
+        self.store = SQLiteKVCache(
+            handle: "editorurlcache",
+            directory: cacheRoot ?? URL.cachesDirectory,
+            diskCapacity: Self.diskCapacity
+        )
         self.cachePolicy = cachePolicy
     }
 
@@ -45,22 +54,12 @@ public struct EditorURLCache: Sendable {
         httpMethod: EditorHttpMethod,
         currentDate: Date
     ) throws {
-        let response = CachedURLResponse(
-            response: HTTPURLResponse(
-                url: url,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: response.responseHeaders.dictionaryValue
-            )!,
-            data: __fixEmptyDataBugEncode(response.data),
-            userInfo: [
-                "storageDate": currentDate
-            ],
-            storagePolicy: .allowed
+        try self.store.put(
+            key: Self.key(url: url, httpMethod: httpMethod),
+            storageDate: currentDate,
+            metadata: try JSONEncoder().encode(response.responseHeaders),
+            value: response.data
         )
-
-        self.cache.storeCachedResponse(response, for: URLRequest(method: httpMethod, url: url))
-        Thread.sleep(forTimeInterval: 0.05)  // Hack to make `URLCache` work
     }
 
     /// Stores the contents of a downloaded file as a cached response for the given URL and HTTP method.
@@ -89,23 +88,12 @@ public struct EditorURLCache: Sendable {
         httpMethod: EditorHttpMethod,
         currentDate: Date
     ) throws {
-
-        let response = CachedURLResponse(
-            response: HTTPURLResponse(
-                url: url,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: headers.dictionaryValue
-            )!,
-            data: __fixEmptyDataBugEncode(try Data(contentsOf: path)),
-            userInfo: [
-                "storageDate": currentDate
-            ],
-            storagePolicy: .allowed
+        try self.store.put(
+            key: Self.key(url: url, httpMethod: httpMethod),
+            storageDate: currentDate,
+            metadata: try JSONEncoder().encode(headers),
+            value: try Data(contentsOf: path)
         )
-
-        self.cache.storeCachedResponse(response, for: URLRequest(method: httpMethod, url: url))
-        Thread.sleep(forTimeInterval: 0.05)  // Hack to make `URLCache` work
     }
 
     /// Checks whether a cached response exists for the given URL and HTTP method.
@@ -139,20 +127,15 @@ public struct EditorURLCache: Sendable {
         httpMethod: EditorHttpMethod,
         currentDate: Date
     ) throws -> EditorURLResponse? {
-        performanceMonitor.measure { () -> EditorURLResponse? in
+        try performanceMonitor.measure { () throws -> EditorURLResponse? in
             guard
-                let response = self.cache.cachedResponse(for: URLRequest(method: httpMethod, url: url)),
-                let storageDate = response.userInfo?["storageDate"] as? Date,
-                self.cachePolicy.allowsResponseWith(date: storageDate, currentDate: currentDate)
+                let entry = try self.store.get(key: Self.key(url: url, httpMethod: httpMethod)),
+                self.cachePolicy.allowsResponseWith(date: entry.storageDate, currentDate: currentDate)
             else {
                 return nil
             }
-
-            let headers = EditorHTTPHeaders((response.response as! HTTPURLResponse).allHeaderFields)
-            return EditorURLResponse(
-                data: __fixEmptyDataBugDecode(response.data),
-                responseHeaders: headers
-            )
+            let headers = try JSONDecoder().decode(EditorHTTPHeaders.self, from: entry.metadata)
+            return EditorURLResponse(data: entry.value, responseHeaders: headers)
         }
     }
 
@@ -160,28 +143,13 @@ public struct EditorURLCache: Sendable {
     ///
     /// - Throws: An error if the cache cannot be cleared.
     public func clear() throws {
-        self.cache.removeAllCachedResponses()
-        Thread.sleep(forTimeInterval: 0.2)  // Hack to make `URLCache` work (needs longer than store)
+        try self.store.clear()
     }
 
-    /// Encodes data to work around a `URLCache` bug with empty data.
-    ///
-    /// `URLCache` doesn't properly store an empty `Data` object, so we use a sentinel
-    /// value to represent empty data.
-    ///
-    /// - Parameter data: The data to encode.
-    /// - Returns: The encoded data, or a sentinel value if the data is empty.
-    private func __fixEmptyDataBugEncode(_ data: Data) -> Data {
-        guard data.isEmpty else { return data }
-        return Data("__is_empty__".utf8)
-    }
-
-    /// Decodes data that was encoded with `__fixEmptyDataBugEncode`.
-    ///
-    /// - Parameter data: The data to decode.
-    /// - Returns: The original data, or empty data if the sentinel value was detected.
-    private func __fixEmptyDataBugDecode(_ data: Data) -> Data {
-        guard data.count == 12, data == Data("__is_empty__".utf8) else { return data }
-        return Data()
+    /// Combines the HTTP method and URL into a single string key. `SQLiteKVCache`
+    /// hashes the key with SHA-256 before binding to SQLite, so length, escaping,
+    /// and encoding aren't concerns here.
+    private static func key(url: URL, httpMethod: EditorHttpMethod) -> String {
+        "\(httpMethod.rawValue) \(url.absoluteString)"
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/Stores/EditorURLCache.swift
+++ b/ios/Sources/GutenbergKit/Sources/Stores/EditorURLCache.swift
@@ -11,7 +11,7 @@ import OSLog
 /// same `cacheRoot` is undefined behavior.
 public struct EditorURLCache: Sendable {
     /// About enough for 10 sites of cached responses.
-    private static let diskCapacity = 100 * 1024 * 1024
+    private static let diskCapacity = Measurement<UnitInformationStorage>(value: 100, unit: .mebibytes)
 
     private let store: SQLiteKVCache
     private let cachePolicy: EditorCachePolicy
@@ -22,7 +22,7 @@ public struct EditorURLCache: Sendable {
     /// - Parameters:
     ///   - cacheRoot: The directory where cached responses will be stored.
     ///     If `nil`, the system default cache directory is used. The cache has a
-    ///     maximum disk capacity of 100 MB.
+    ///     maximum disk capacity of 100 MiB.
     ///   - cachePolicy: The policy that determines when cached responses are considered valid.
     ///     Use `.ignore` to always fetch fresh data, `.maxAge(_:)` to expire entries after
     ///     a time interval, or `.always` (the default) to use cached data regardless of age.

--- a/ios/Sources/GutenbergKit/Sources/Stores/EditorURLCache.swift
+++ b/ios/Sources/GutenbergKit/Sources/Stores/EditorURLCache.swift
@@ -6,9 +6,13 @@ import OSLog
 /// Responses are stored on disk and survive process termination. Responses are keyed by both URL and HTTP method, so GET and OPTIONS requests to the
 /// same URL are stored independently.
 ///
-/// Backed by `SQLiteKVCache`. The "one instance per backing file" contract from
-/// `SQLiteKVCache` carries over: two `EditorURLCache` instances pointed at the
-/// same `cacheRoot` is undefined behavior.
+/// Backed by `SQLiteKVCache`. The cache directory is built as
+/// `<parentDirectory>/<siteId>/`, so two caches with different `siteId`s are
+/// guaranteed-distinct backing files. The "one instance per backing file"
+/// contract from `SQLiteKVCache` still applies for the same `(siteId,
+/// parentDirectory)` pair, but the typical call pattern (one cache per
+/// `EditorService`, one service per editor view) keeps that contract by
+/// construction.
 public struct EditorURLCache: Sendable {
     /// About enough for 10 sites of cached responses.
     private static let diskCapacity = Measurement<UnitInformationStorage>(value: 100, unit: .mebibytes)
@@ -20,16 +24,23 @@ public struct EditorURLCache: Sendable {
     /// Creates a new URL cache.
     ///
     /// - Parameters:
-    ///   - cacheRoot: The directory where cached responses will be stored.
-    ///     If `nil`, the system default cache directory is used. The cache has a
-    ///     maximum disk capacity of 100 MiB.
+    ///   - siteId: The identifier of the site whose responses are being cached.
+    ///     Appended to `parentDirectory` to produce the final cache directory,
+    ///     so different sites cannot collide on the same backing file.
+    ///   - parentDirectory: The directory under which the per-site cache
+    ///     directory is created. Defaults to `Paths.defaultCacheRoot`. Tests
+    ///     pass a unique temporary directory here for isolation.
     ///   - cachePolicy: The policy that determines when cached responses are considered valid.
     ///     Use `.ignore` to always fetch fresh data, `.maxAge(_:)` to expire entries after
     ///     a time interval, or `.always` (the default) to use cached data regardless of age.
-    public init(cacheRoot: URL? = nil, cachePolicy: EditorCachePolicy = .always) {
+    public init(
+        siteId: String,
+        parentDirectory: URL = Paths.defaultCacheRoot,
+        cachePolicy: EditorCachePolicy = .always
+    ) {
         self.store = SQLiteKVCache(
             handle: "editorurlcache",
-            directory: cacheRoot ?? URL.cachesDirectory,
+            directory: parentDirectory.appending(path: siteId),
             diskCapacity: Self.diskCapacity
         )
         self.cachePolicy = cachePolicy

--- a/ios/Sources/GutenbergKit/Sources/Stores/EditorURLCache.swift
+++ b/ios/Sources/GutenbergKit/Sources/Stores/EditorURLCache.swift
@@ -57,7 +57,7 @@ public struct EditorURLCache: Sendable {
         try self.store.put(
             key: Self.key(url: url, httpMethod: httpMethod),
             storageDate: currentDate,
-            metadata: try JSONEncoder().encode(response.responseHeaders),
+            metadata: response.responseHeaders,
             value: response.data
         )
     }
@@ -91,7 +91,7 @@ public struct EditorURLCache: Sendable {
         try self.store.put(
             key: Self.key(url: url, httpMethod: httpMethod),
             storageDate: currentDate,
-            metadata: try JSONEncoder().encode(headers),
+            metadata: headers,
             value: try Data(contentsOf: path)
         )
     }
@@ -129,13 +129,15 @@ public struct EditorURLCache: Sendable {
     ) throws -> EditorURLResponse? {
         try performanceMonitor.measure { () throws -> EditorURLResponse? in
             guard
-                let entry = try self.store.get(key: Self.key(url: url, httpMethod: httpMethod)),
+                let entry = try self.store.get(
+                    key: Self.key(url: url, httpMethod: httpMethod),
+                    metadataAs: EditorHTTPHeaders.self
+                ),
                 self.cachePolicy.allowsResponseWith(date: entry.storageDate, currentDate: currentDate)
             else {
                 return nil
             }
-            let headers = try JSONDecoder().decode(EditorHTTPHeaders.self, from: entry.metadata)
-            return EditorURLResponse(data: entry.value, responseHeaders: headers)
+            return EditorURLResponse(data: entry.value, responseHeaders: entry.metadata)
         }
     }
 

--- a/ios/Sources/GutenbergKit/Sources/Stores/SQLiteKVCache.swift
+++ b/ios/Sources/GutenbergKit/Sources/Stores/SQLiteKVCache.swift
@@ -692,40 +692,40 @@ extension SQLiteKVCache {
         )
     }
 
-    /// JSON-encodes a `Codable` value and stores it. Metadata stays raw `Data`
-    /// — callers that want a structured metadata payload should encode it
-    /// themselves and use the base `put`. The `value:` argument label here is
-    /// shared with the base `put(_:..., value: Data, ...)`; for `Data` values,
-    /// Swift's overload resolution picks the non-generic original.
-    func put<Value: Encodable>(
+    /// JSON-encodes a `Codable` metadata payload before storing. Cache values
+    /// are already raw `Data` for the typical case (HTTP bodies, downloaded
+    /// blobs) — the boilerplate lives on the metadata side, where callers
+    /// usually want a structured shape (response headers, content-type, etag,
+    /// etc.). The `metadata:` argument label is shared with the base
+    /// `put(_:..., metadata: Data, ...)`; for `Data` metadata, Swift's
+    /// overload resolution picks the non-generic original.
+    func put<Metadata: Encodable>(
         key: String,
         storageDate: Date,
-        metadata: Data = Data(),
-        value: Value,
+        metadata: Metadata,
+        value: Data,
         encoder: JSONEncoder = JSONEncoder()
     ) throws {
         try self.put(
             key: key,
             storageDate: storageDate,
-            metadata: metadata,
-            value: try encoder.encode(value)
+            metadata: try encoder.encode(metadata),
+            value: value
         )
     }
 
-    /// Looks up the entry at `key` and JSON-decodes its `value` blob as
-    /// `Value`. Returns `nil` for a genuine miss; throws `Error.readFailed` if
-    /// SQLite rejects the read, or a `DecodingError` if the stored bytes
-    /// don't decode as `Value`. The original `storageDate` and `metadata`
-    /// from the entry are returned alongside the decoded value so callers
-    /// that need cache-freshness metadata don't have to fall back to the
-    /// base `get`.
-    func get<Value: Decodable>(
+    /// Looks up the entry at `key` and JSON-decodes its `metadata` blob as
+    /// `Metadata`. Returns `nil` for a genuine miss; throws `Error.readFailed`
+    /// if SQLite rejects the read, or a `DecodingError` if the stored bytes
+    /// don't decode as `Metadata`. The raw `value` and original `storageDate`
+    /// are returned alongside the decoded metadata.
+    func get<Metadata: Decodable>(
         key: String,
-        as valueType: Value.Type,
+        metadataAs metadataType: Metadata.Type,
         decoder: JSONDecoder = JSONDecoder()
-    ) throws -> (storageDate: Date, metadata: Data, value: Value)? {
+    ) throws -> (storageDate: Date, metadata: Metadata, value: Data)? {
         guard let entry = try self.get(key: key) else { return nil }
-        let value = try decoder.decode(Value.self, from: entry.value)
-        return (entry.storageDate, entry.metadata, value)
+        let metadata = try decoder.decode(Metadata.self, from: entry.metadata)
+        return (entry.storageDate, metadata, entry.value)
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/Stores/SQLiteKVCache.swift
+++ b/ios/Sources/GutenbergKit/Sources/Stores/SQLiteKVCache.swift
@@ -672,3 +672,60 @@ extension SQLiteKVCache.Error: CustomStringConvertible, LocalizedError {
 
     var errorDescription: String? { description }
 }
+
+extension SQLiteKVCache {
+
+    /// Convenience initializer that accepts the cap as a
+    /// `Measurement<UnitInformationStorage>` so callers can write
+    /// `Measurement(value: 100, unit: .mebibytes)` instead of an opaque
+    /// `100 * 1024 * 1024`. The measurement is converted to bytes (truncated
+    /// to `Int`) and forwarded to the designated initializer.
+    convenience init(
+        handle: StaticString,
+        directory: URL = URL.cachesDirectory,
+        diskCapacity: Measurement<UnitInformationStorage>
+    ) {
+        self.init(
+            handle: handle,
+            directory: directory,
+            diskCapacity: Int(diskCapacity.converted(to: .bytes).value)
+        )
+    }
+
+    /// JSON-encodes a `Codable` value and stores it. Metadata stays raw `Data`
+    /// — callers that want a structured metadata payload should encode it
+    /// themselves and use the base `put`. The `value:` argument label here is
+    /// shared with the base `put(_:..., value: Data, ...)`; for `Data` values,
+    /// Swift's overload resolution picks the non-generic original.
+    func put<Value: Encodable>(
+        key: String,
+        storageDate: Date,
+        metadata: Data = Data(),
+        value: Value,
+        encoder: JSONEncoder = JSONEncoder()
+    ) throws {
+        try self.put(
+            key: key,
+            storageDate: storageDate,
+            metadata: metadata,
+            value: try encoder.encode(value)
+        )
+    }
+
+    /// Looks up the entry at `key` and JSON-decodes its `value` blob as
+    /// `Value`. Returns `nil` for a genuine miss; throws `Error.readFailed` if
+    /// SQLite rejects the read, or a `DecodingError` if the stored bytes
+    /// don't decode as `Value`. The original `storageDate` and `metadata`
+    /// from the entry are returned alongside the decoded value so callers
+    /// that need cache-freshness metadata don't have to fall back to the
+    /// base `get`.
+    func get<Value: Decodable>(
+        key: String,
+        as valueType: Value.Type,
+        decoder: JSONDecoder = JSONDecoder()
+    ) throws -> (storageDate: Date, metadata: Data, value: Value)? {
+        guard let entry = try self.get(key: key) else { return nil }
+        let value = try decoder.decode(Value.self, from: entry.value)
+        return (entry.storageDate, entry.metadata, value)
+    }
+}

--- a/ios/Tests/GutenbergKitTests/Services/RESTAPIRepositoryTests.swift
+++ b/ios/Tests/GutenbergKitTests/Services/RESTAPIRepositoryTests.swift
@@ -69,7 +69,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
         mockClient.urlResponseHandler = { _ in Data(#"{"styles":[]}"#.utf8) }
 
         let configuration = makeConfiguration()
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory)
         let repository = RESTAPIRepository(
             configuration: configuration,
             httpClient: mockClient,
@@ -102,7 +102,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
         mockClient.urlResponseHandler = { _ in Data(rawJSON.utf8) }
 
         let configuration = makeConfiguration()
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory)
         let repository = RESTAPIRepository(
             configuration: configuration,
             httpClient: mockClient,
@@ -139,7 +139,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
         mockClient.urlResponseHandler = { _ in Data(#"{"slug":"post"}"#.utf8) }
 
         let configuration = makeConfiguration()
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory)
         let repository = RESTAPIRepository(
             configuration: configuration,
             httpClient: mockClient,
@@ -171,7 +171,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
         mockClient.urlResponseHandler = { _ in Data(#"[{"stylesheet":"theme"}]"#.utf8) }
 
         let configuration = makeConfiguration()
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory)
         let repository = RESTAPIRepository(
             configuration: configuration,
             httpClient: mockClient,
@@ -218,7 +218,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
         mockClient.urlResponseHandler = { _ in Data(#"{"post":{}}"#.utf8) }
 
         let configuration = makeConfiguration()
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory)
         let repository = RESTAPIRepository(
             configuration: configuration,
             httpClient: mockClient,
@@ -249,7 +249,7 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
         }
 
         let configuration = makeConfiguration()
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory)
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory)
         let repository = RESTAPIRepository(
             configuration: configuration,
             httpClient: capturingClient,

--- a/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
@@ -142,46 +142,25 @@ struct EditorURLCacheTests {
 
     // MARK: - clear()
 
-    @Test("clear removes all entries", .timeLimit(.minutes(1)))
+    @Test("clear removes all entries")
     func clearRemovesAll() throws {
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET)
         let otherURL = URL(string: "https://example.com/other")!
         try cache.store(makeResponse(), for: otherURL, httpMethod: .GET)
         try cache.clear()
 
-        try waitForClearToTakeEffect(cache: cache, url: testURL)
-
         #expect(try cache.response(for: testURL, httpMethod: .GET) == nil)
         #expect(try cache.response(for: otherURL, httpMethod: .GET) == nil)
     }
 
-    @Test("store succeeds after clear", .timeLimit(.minutes(1)))
+    @Test("store succeeds after clear")
     func storeAfterClear() throws {
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET)
         try cache.clear()
 
-        try waitForClearToTakeEffect(cache: cache, url: testURL)
-
         let newResponse = makeResponse(data: Data("after clear"))
         try cache.store(newResponse, for: testURL, httpMethod: .GET)
         #expect(try cache.response(for: testURL, httpMethod: .GET) == newResponse)
-    }
-
-    /// Polls until `URLCache.removeAllCachedResponses()` has taken effect.
-    ///
-    /// Uses exponential backoff (0.05s, 0.1s, 0.2s, 0.4s, ...) with a 5s total timeout.
-    /// `URLCache` clears asynchronously, so the in-memory layer may still serve
-    /// stale entries for a short window after `clear()` returns. CI environments
-    /// with slower I/O may need the longer timeout.
-    private func waitForClearToTakeEffect(cache: EditorURLCache, url: URL) throws {
-        var delay: TimeInterval = 0.05
-        var elapsed: TimeInterval = 0
-        while elapsed < 5.0 {
-            guard try cache.response(for: url, httpMethod: .GET) != nil else { return }
-            Thread.sleep(forTimeInterval: delay)
-            elapsed += delay
-            delay *= 2
-        }
     }
 
     // MARK: - URLs with query parameters

--- a/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/EditorURLCacheTests.swift
@@ -7,7 +7,7 @@ import Testing
 struct EditorURLCacheTests {
     private let testURL = URL(string: "https://example.com/api/posts")!
 
-    let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .always)
+    let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .always)
 
     private func makeResponse(data: Data = .sample, headers: EditorHTTPHeaders = [:])
     -> EditorURLResponse {
@@ -200,7 +200,7 @@ struct EditorURLCacheIgnorePolicyTests {
     private let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
 
     /// A cache configured with the `.ignore` policy, which should never return cached responses.
-    let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .ignore)
+    let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .ignore)
 
     private func makeResponse(data: Data = .sample, headers: EditorHTTPHeaders = [:]) -> EditorURLResponse {
         EditorURLResponse(data: data, responseHeaders: headers)
@@ -257,7 +257,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: fresh response is returned")
     func maxAgePolicy_freshResponseReturned() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
         let response = makeResponse()
 
         // Store at reference date
@@ -269,7 +269,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: response within interval is returned")
     func maxAgePolicy_responseWithinIntervalReturned() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
         let response = makeResponse()
 
         // Store at reference date
@@ -282,7 +282,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: hasData returns true for fresh response")
     func maxAgePolicy_hasDataTrueForFresh() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
 
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET, currentDate: self.referenceDate)
 
@@ -291,7 +291,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: expired response returns nil")
     func maxAgePolicy_expiredResponseReturnsNil() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
         let response = makeResponse()
 
         // Store at reference date
@@ -304,7 +304,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: hasData returns false for expired response")
     func maxAgePolicy_hasDataFalseForExpired() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
 
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET, currentDate: self.referenceDate)
 
@@ -314,7 +314,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: response at exact boundary is expired")
     func maxAgePolicy_responseAtExactBoundaryIsExpired() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
 
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET, currentDate: self.referenceDate)
 
@@ -325,7 +325,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: response just before boundary is fresh")
     func maxAgePolicy_responseJustBeforeBoundaryIsFresh() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
         let response = makeResponse()
 
         try cache.store(response, for: testURL, httpMethod: .GET, currentDate: self.referenceDate)
@@ -337,7 +337,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: zero interval means immediate expiration")
     func maxAgePolicy_zeroIntervalExpiresImmediately() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(0))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(0))
 
         try cache.store(makeResponse(), for: testURL, httpMethod: .GET, currentDate: self.referenceDate)
 
@@ -347,7 +347,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: re-storing refreshes the expiration")
     func maxAgePolicy_restoreRefreshesExpiration() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
 
         // Store initial response at reference date
         try cache.store(makeResponse(data: Data("first")), for: testURL, httpMethod: .GET, currentDate: self.referenceDate)
@@ -364,7 +364,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: different URLs expire independently")
     func maxAgePolicy_urlsExpireIndependently() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
 
         let url1 = URL(string: "https://example.com/posts/1")!
         let url2 = URL(string: "https://example.com/posts/2")!
@@ -389,7 +389,7 @@ struct EditorURLCacheMaxAgePolicyTests {
 
     @Test("maxAge policy: file store respects cache policy")
     func maxAgePolicy_fileStoreRespectsCachePolicy() throws {
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .maxAge(60))
         let filePath = Bundle.module.url(forResource: "post-test-case-1", withExtension: "json")!
         let expectedData = try Data(contentsOf: filePath)
 
@@ -411,7 +411,7 @@ struct EditorURLCacheAlwaysPolicyTests {
     /// A fixed reference date for deterministic testing.
     private let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
 
-    let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .always)
+    let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .always)
 
     private func makeResponse(data: Data = .sample, headers: EditorHTTPHeaders = [:]) -> EditorURLResponse {
         EditorURLResponse(data: data, responseHeaders: headers)

--- a/ios/Tests/GutenbergKitTests/Stores/SQLiteKVCacheTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/SQLiteKVCacheTests.swift
@@ -552,4 +552,104 @@ struct SQLiteKVCacheTests {
         guard total > 0 else { return 0 }
         return Double(freelist) / Double(total)
     }
+
+    // MARK: - UnitInformationStorage convenience init
+
+    @Test("Measurement-based init forwards the byte count to the designated init")
+    func unitInformationStorageInit() throws {
+        // 600-byte cap expressed as a Measurement; same eviction behavior as the
+        // designated init's `evictsOldestOverCapacity` test.
+        let store = SQLiteKVCache(
+            handle: "test",
+            directory: .randomTemporaryDirectory,
+            diskCapacity: Measurement(value: 600, unit: .bytes)
+        )
+        try store.put(key: "oldest", storageDate: referenceDate, metadata: Data(), value: Data(repeating: 0x11, count: 300))
+        try store.put(key: "middle", storageDate: referenceDate.addingTimeInterval(100), metadata: Data(), value: Data(repeating: 0x22, count: 300))
+        try store.put(key: "newest", storageDate: referenceDate.addingTimeInterval(200), metadata: Data(), value: Data(repeating: 0x33, count: 300))
+
+        #expect(try store.get(key: "oldest") == nil)
+        #expect(try store.get(key: "middle") != nil)
+        #expect(try store.get(key: "newest") != nil)
+    }
+
+    @Test("Measurement-based init converts non-byte units to bytes")
+    func unitInformationStorageInitConvertsUnits() throws {
+        // 1 kibibyte == 1024 bytes. A 2000-byte value should be silently dropped
+        // (exceeds cap), a 500-byte one should fit. Same short-circuit contract
+        // as `oversizedEntryNotStored` but exercising the unit conversion path.
+        let store = SQLiteKVCache(
+            handle: "test",
+            directory: .randomTemporaryDirectory,
+            diskCapacity: Measurement(value: 1, unit: .kibibytes)
+        )
+        try store.put(key: "fits", storageDate: referenceDate, metadata: Data(), value: Data(repeating: 0x01, count: 500))
+        try store.put(key: "too-big", storageDate: referenceDate.addingTimeInterval(1), metadata: Data(), value: Data(repeating: 0x02, count: 2000))
+
+        #expect(try store.get(key: "fits")?.value.count == 500)
+        #expect(try store.get(key: "too-big") == nil)
+    }
+
+    // MARK: - Codable convenience put/get
+
+    private struct Sample: Codable, Equatable {
+        let id: Int
+        let name: String
+        let tags: [String]
+    }
+
+    @Test("Codable put/get round-trips a value and preserves storageDate and metadata")
+    func codableRoundTrip() throws {
+        let store = makeStore()
+        let sample = Sample(id: 42, name: "answer", tags: ["meta", "data"])
+        try store.put(key: "k", storageDate: referenceDate, metadata: Data("m"), value: sample)
+
+        let entry = try #require(try store.get(key: "k", as: Sample.self))
+        #expect(entry.value == sample)
+        #expect(entry.storageDate == referenceDate)
+        #expect(entry.metadata == Data("m"))
+    }
+
+    @Test("Codable get returns nil for a missing key")
+    func codableGetMissing() throws {
+        let store = makeStore()
+        #expect(try store.get(key: "missing", as: Sample.self) == nil)
+    }
+
+    @Test("Codable get throws DecodingError when stored bytes don't match the type")
+    func codableGetMismatchedType() throws {
+        // Write raw bytes via the base put, then try to decode them as `Sample`.
+        // The convenience get should surface the JSONDecoder error rather than
+        // silently returning nil.
+        let store = makeStore()
+        try store.put(key: "k", storageDate: referenceDate, metadata: Data(), value: Data("not json"))
+        #expect(throws: DecodingError.self) {
+            try store.get(key: "k", as: Sample.self)
+        }
+    }
+
+    @Test("Codable put with Data value picks the non-generic overload")
+    func codablePutWithDataPrefersNonGeneric() throws {
+        // `Data` conforms to `Encodable`, so the generic overload would also
+        // match. Swift prefers the non-generic original, which stores the raw
+        // bytes — a JSON-encoded `Data` would be a base64 string instead.
+        let store = makeStore()
+        try store.put(key: "k", storageDate: referenceDate, metadata: Data(), value: Data("raw bytes"))
+        let entry = try #require(try store.get(key: "k"))
+        #expect(entry.value == Data("raw bytes"))
+    }
+
+    @Test("Codable put accepts a custom encoder")
+    func codablePutWithCustomEncoder() throws {
+        let store = makeStore()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let sample = Sample(id: 1, name: "x", tags: ["a", "b"])
+        try store.put(key: "k", storageDate: referenceDate, value: sample, encoder: encoder)
+
+        // The bytes should be the deterministically-ordered JSON encoding.
+        let entry = try #require(try store.get(key: "k"))
+        let expected = try encoder.encode(sample)
+        #expect(entry.value == expected)
+    }
 }

--- a/ios/Tests/GutenbergKitTests/Stores/SQLiteKVCacheTests.swift
+++ b/ios/Tests/GutenbergKitTests/Stores/SQLiteKVCacheTests.swift
@@ -590,66 +590,65 @@ struct SQLiteKVCacheTests {
         #expect(try store.get(key: "too-big") == nil)
     }
 
-    // MARK: - Codable convenience put/get
+    // MARK: - Codable metadata convenience put/get
 
-    private struct Sample: Codable, Equatable {
-        let id: Int
-        let name: String
-        let tags: [String]
+    private struct SampleMeta: Codable, Equatable {
+        let etag: String
+        let contentType: String
     }
 
-    @Test("Codable put/get round-trips a value and preserves storageDate and metadata")
-    func codableRoundTrip() throws {
+    @Test("Codable metadata put/get round-trips a value and preserves storageDate and value")
+    func codableMetadataRoundTrip() throws {
         let store = makeStore()
-        let sample = Sample(id: 42, name: "answer", tags: ["meta", "data"])
-        try store.put(key: "k", storageDate: referenceDate, metadata: Data("m"), value: sample)
+        let meta = SampleMeta(etag: "abc123", contentType: "application/json")
+        try store.put(key: "k", storageDate: referenceDate, metadata: meta, value: Data("body"))
 
-        let entry = try #require(try store.get(key: "k", as: Sample.self))
-        #expect(entry.value == sample)
+        let entry = try #require(try store.get(key: "k", metadataAs: SampleMeta.self))
+        #expect(entry.metadata == meta)
+        #expect(entry.value == Data("body"))
         #expect(entry.storageDate == referenceDate)
-        #expect(entry.metadata == Data("m"))
     }
 
-    @Test("Codable get returns nil for a missing key")
-    func codableGetMissing() throws {
+    @Test("Codable metadata get returns nil for a missing key")
+    func codableMetadataGetMissing() throws {
         let store = makeStore()
-        #expect(try store.get(key: "missing", as: Sample.self) == nil)
+        #expect(try store.get(key: "missing", metadataAs: SampleMeta.self) == nil)
     }
 
-    @Test("Codable get throws DecodingError when stored bytes don't match the type")
-    func codableGetMismatchedType() throws {
-        // Write raw bytes via the base put, then try to decode them as `Sample`.
+    @Test("Codable metadata get throws DecodingError when stored bytes don't match the type")
+    func codableMetadataGetMismatchedType() throws {
+        // Write raw bytes via the base put, then try to decode them as `SampleMeta`.
         // The convenience get should surface the JSONDecoder error rather than
         // silently returning nil.
         let store = makeStore()
-        try store.put(key: "k", storageDate: referenceDate, metadata: Data(), value: Data("not json"))
+        try store.put(key: "k", storageDate: referenceDate, metadata: Data("not json"), value: Data())
         #expect(throws: DecodingError.self) {
-            try store.get(key: "k", as: Sample.self)
+            try store.get(key: "k", metadataAs: SampleMeta.self)
         }
     }
 
-    @Test("Codable put with Data value picks the non-generic overload")
-    func codablePutWithDataPrefersNonGeneric() throws {
+    @Test("Codable metadata put with Data metadata picks the non-generic overload")
+    func codableMetadataPutWithDataPrefersNonGeneric() throws {
         // `Data` conforms to `Encodable`, so the generic overload would also
         // match. Swift prefers the non-generic original, which stores the raw
         // bytes — a JSON-encoded `Data` would be a base64 string instead.
         let store = makeStore()
-        try store.put(key: "k", storageDate: referenceDate, metadata: Data(), value: Data("raw bytes"))
+        try store.put(key: "k", storageDate: referenceDate, metadata: Data("raw"), value: Data("v"))
         let entry = try #require(try store.get(key: "k"))
-        #expect(entry.value == Data("raw bytes"))
+        #expect(entry.metadata == Data("raw"))
     }
 
-    @Test("Codable put accepts a custom encoder")
-    func codablePutWithCustomEncoder() throws {
+    @Test("Codable metadata put accepts a custom encoder")
+    func codableMetadataPutWithCustomEncoder() throws {
         let store = makeStore()
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys
-        let sample = Sample(id: 1, name: "x", tags: ["a", "b"])
-        try store.put(key: "k", storageDate: referenceDate, value: sample, encoder: encoder)
+        let meta = SampleMeta(etag: "z", contentType: "text/plain")
+        try store.put(key: "k", storageDate: referenceDate, metadata: meta, value: Data(), encoder: encoder)
 
         // The bytes should be the deterministically-ordered JSON encoding.
         let entry = try #require(try store.get(key: "k"))
-        let expected = try encoder.encode(sample)
-        #expect(entry.value == expected)
+        let expected = try encoder.encode(meta)
+        #expect(entry.metadata == expected)
     }
 }

--- a/ios/Tests/GutenbergKitTests/TestHelpers.swift
+++ b/ios/Tests/GutenbergKitTests/TestHelpers.swift
@@ -84,7 +84,7 @@ extension MakesTestFixtures {
     ) -> RESTAPIRepository {
         let config = configuration ?? makeConfiguration()
         let client = httpClient ?? EditorAssetLibraryMockHTTPClient()
-        let cache = EditorURLCache(cacheRoot: .randomTemporaryDirectory, cachePolicy: .always)
+        let cache = EditorURLCache(siteId: "test", parentDirectory: .randomTemporaryDirectory, cachePolicy: .always)
 
         return RESTAPIRepository(
             configuration: config,


### PR DESCRIPTION
## Summary

- Switches `EditorURLCache`'s backing store from `URLCache` to `SQLiteKVCache` (introduced in #477).
- `EditorURLCache.init` shape changed — `init(cacheRoot:cachePolicy:)` is now `init(siteId:parentDirectory:cachePolicy:)`. `store`/`hasData`/`response`/`clear` are unchanged, as is per-(URL, method) keying and the 100 MB cap. No callers outside this repo construct `EditorURLCache` directly (verified via `gh api search/code`).
- Drops the `Thread.sleep(...)` settling hacks after `store` and `clear`, and the `__fixEmptyDataBug{Encode,Decode}` empty-`Data` sentinel — both were workarounds for `URLCache` quirks that `SQLiteKVCache` doesn't have.

## What's stored

| field | source |
|---|---|
| key | `"<method> <url.absoluteString>"` — `SQLiteKVCache` SHA-256-hashes it before binding, so length/escaping/encoding aren't concerns |
| storageDate | passed through to `SQLiteKVCache.Entry.storageDate` instead of being stuffed into `URLCache`'s `userInfo` dict |
| metadata | `JSONEncoder().encode(EditorHTTPHeaders)` — small JSON blob |
| value | `response.data` — raw bytes, no base64 overhead |

## Notes

- Cache policy filtering (`.ignore` / `.maxAge(_:)` / `.always`) still happens on read, against `Entry.storageDate`. The internal testing overloads that take `currentDate: Date` are preserved.
- **Eviction policy changed** — `URLCache` evicts least-recently-used; `SQLiteKVCache` evicts oldest-by-`storage_date` (insert/refresh order). Under cap pressure, a frequently-read old entry is now evicted before a recently-stored unread one. The cap isn't approached in practice — typical entry count is small (editor settings, theme, post type list) — but the policy is different.
- `SQLiteKVCache.clear()` is synchronous, so the `waitForClearToTakeEffect` polling helper in the tests is gone.
- **Migration:** pre-existing `URLCache` files in `cacheRoot` (a `Cache.db` and `fsCachedData/`) are left in place — dead weight until the OS reclaims the cache directory. Existing entries cache-miss on first read after upgrade and refetch from the network. Acceptable for a cache; a one-shot cleanup on init is possible but not worth the complexity.
- **One instance per backing file** carries over from `SQLiteKVCache`: two `EditorURLCache` instances pointed at the same `(siteId, parentDirectory)` is undefined behavior. `EditorService` creates one cache per service instance, so the typical app flow is fine.

## Test plan

- [x] All 36 `EditorURLCacheTests` pass (covers round-trip, overwrite, empty data, file-store, header round-trip, query-parameter independence, all three cache policies, and clear).
- [x] Full `swift test` suite passes (891 tests / 46 suites).
- [ ] CI runs the package against iOS via `make test-swift-package`.