### PR TITLE
refactor(ios): back HTMLPreviewManager with SQLiteKVCache

### DIFF
--- a/ios/Demo-iOS/Sources/Views/DebugSettingsView.swift
+++ b/ios/Demo-iOS/Sources/Views/DebugSettingsView.swift
@@ -76,10 +76,10 @@ struct DebugSettingsView: View {
     }
 
     private func clearCache() {
-        Task {
-            await HTMLPreviewManager.clearCache()
-            cacheCleared = true
+        HTMLPreviewManager.clearCache()
+        cacheCleared = true
 
+        Task {
             // Reset the checkmark after 2 seconds
             try? await Task.sleep(nanoseconds: 2_000_000_000)
             cacheCleared = false

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -351,10 +351,31 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         return WKUserScript(source: jsCode, injectionTime: .atDocumentStart, forMainFrameOnly: true)
     }
 
-    /// Deletes all cached editor data for all sites
+    /// Deletes all cached editor data for all sites.
+    ///
+    /// `HTMLPreviewManager` keeps a process-wide `SQLiteKVCache` connection
+    /// open against `htmlpreview.sqlite` + its WAL/SHM sidecars. Removing
+    /// those files out from under the live handle would leave the static
+    /// cache writing to an unlinked inode for the rest of the process. So we
+    /// clear the rows through the live handle and skip the underlying files
+    /// when sweeping `defaultCacheRoot`; everything else in the directory
+    /// (per-site `EditorURLCache` subdirs, etc.) is removed normally.
     public static func deleteAllData() throws {
+        HTMLPreviewManager.clearCache()
+
         if FileManager.default.directoryExists(at: Paths.defaultCacheRoot) {
-            try FileManager.default.removeItem(at: Paths.defaultCacheRoot)
+            let preserved: Set<String> = [
+                "htmlpreview.sqlite",
+                "htmlpreview.sqlite-wal",
+                "htmlpreview.sqlite-shm",
+            ]
+            let contents = try FileManager.default.contentsOfDirectory(
+                at: Paths.defaultCacheRoot,
+                includingPropertiesForKeys: nil
+            )
+            for url in contents where !preserved.contains(url.lastPathComponent) {
+                try FileManager.default.removeItem(at: url)
+            }
         }
 
         if FileManager.default.directoryExists(at: Paths.defaultStorageRoot) {

--- a/ios/Sources/GutenbergKit/Sources/Views/HTMLPreview/HTMLPreviewManager.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/HTMLPreview/HTMLPreviewManager.swift
@@ -3,9 +3,29 @@ import UIKit
 import WebKit
 import CryptoKit
 import ImageIO
+import OSLog
 import UniformTypeIdentifiers
 import SwiftUI
 import GutenbergKitResources
+
+// MARK: - Process-wide cache
+
+/// Roughly 600–1000 cached previews depending on rendered size.
+private let previewDiskCapacity = Measurement<UnitInformationStorage>(value: 16, unit: .mebibytes)
+
+/// Process-wide preview cache. `SQLiteKVCache` requires one owning instance
+/// per backing file, and `HTMLPreviewManager` is created lazily per
+/// `EditorViewController` — so the store lives at file scope rather than
+/// being owned by any one manager. Per-template isolation still holds
+/// because the cache key folds in `templateHash`, so different themes can't
+/// see each other's entries.
+private let previewCache = SQLiteKVCache(
+    handle: "htmlpreview",
+    directory: Paths.defaultCacheRoot,
+    diskCapacity: previewDiskCapacity
+)
+
+private let previewLogger = Logger(subsystem: "GutenbergKit", category: "html-preview")
 
 /// Renders HTML content to images using a pool of WKWebView instances.
 ///
@@ -29,8 +49,6 @@ public final class HTMLPreviewManager: ObservableObject {
     // All requests (both queued and executing)
     private var requests: [RenderRequest] = []
     private var executingTaskCount: Int = 0
-
-    private let urlCache: URLCache
 
     private let editorStyles: String
     private let themeStyles: String?
@@ -64,8 +82,6 @@ public final class HTMLPreviewManager: ObservableObject {
         // it will automatically invaliate the previous caches.
         let template = makePatternHTML(content: "", viewportWidth: 0, editorStyles: gutenbergCSS, themeStyles: themeStyles)
         self.templateHash = template.sha1
-
-        self.urlCache = HTMLPreviewManager.makeCache()
     }
 
     // MARK: - Public API
@@ -126,58 +142,44 @@ public final class HTMLPreviewManager: ObservableObject {
         }
     }
 
-    // MARK: - URLCache
+    // MARK: - Cache
 
-    /// Clears the disk cache for all HTMLPreviewManager instances
-    public static func clearCache() async {
-        makeCache().removeAllCachedResponses()
+    /// Clears the disk cache. Backing store is process-wide, so this affects
+    /// every `HTMLPreviewManager` instance. `nonisolated` so non-MainActor
+    /// callers don't have to hop through the main actor just to flush a
+    /// SQLite table.
+    public nonisolated static func clearCache() {
+        try? previewCache.clear()
     }
 
-    private static func makeCache() -> URLCache {
-        let cacheDirectory = URL.cachesDirectory.appendingPathComponent("gbk-html-preview-cache", isDirectory: true)
-        do {
-            try FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
-        } catch {
-            assertionFailure("failed to create cache directory: \(error)")
-        }
-        return URLCache(
-            memoryCapacity: 0,
-            diskCapacity: 16 * 1024 * 1024,
-            directory: cacheDirectory
-        )
-    }
-
-    /// Clears the disk cache for this instance
-    public func clearCache() async {
-        urlCache.removeAllCachedResponses()
-    }
-
-    /// Load image from URLCache
     private func loadImageFromCache(forKey key: String) -> UIImage? {
-        let url = URL(string: "preview://\(key)")!
-        let request = URLRequest(url: url)
-
-        guard let cachedResponse = urlCache.cachedResponse(for: request),
-              let image = UIImage(data: cachedResponse.data) else {
+        let entry: SQLiteKVCache.Entry?
+        do {
+            entry = try previewCache.get(key: key)
+        } catch {
+            previewLogger.error("Failed to read preview from cache: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        guard let entry, let image = UIImage(data: entry.value) else {
             return nil
         }
         return image
     }
 
-    /// Save image to URLCache
     private func saveImageToCache(_ image: UIImage, forKey key: String) {
-        guard let data = encode(image) else { return }
-
-        let url = URL(string: "preview://\(key)")!
-        let request = URLRequest(url: url)
-        let response = URLResponse(
-            url: url,
-            mimeType: "image/heic",
-            expectedContentLength: data.count,
-            textEncodingName: nil
-        )
-        let cachedResponse = CachedURLResponse(response: response, data: data)
-        urlCache.storeCachedResponse(cachedResponse, for: request)
+        // Encode on main because `UIImage` isn't `Sendable`; ship the
+        // resulting `Data` + `key` to a detached task for the SQLite write.
+        guard let data = encode(image) else {
+            previewLogger.error("Failed to encode preview image to HEIC")
+            return
+        }
+        Task.detached {
+            do {
+                try previewCache.put(key: key, storageDate: .now, metadata: Data(), value: data)
+            } catch {
+                previewLogger.error("Failed to write preview to cache: \(error.localizedDescription, privacy: .public)")
+            }
+        }
     }
 
     // MARK: - Private Methods
@@ -232,7 +234,7 @@ public final class HTMLPreviewManager: ObservableObject {
 // MARK: - Private Helper Functions
 
 private func makeDiskCacheKey(content: String, viewportWidth: Int, templateHash: String) -> String {
-    "\(content)-\(viewportWidth)-\(templateHash)".sha1
+    "\(content)-\(viewportWidth)-\(templateHash)"
 }
 
 /// Creates the HTML for rendering the pattern preview.


### PR DESCRIPTION
## Summary

- Swaps `HTMLPreviewManager`'s backing store from `URLCache` to `SQLiteKVCache` (introduced in #477, also used by `EditorURLCache` in #483).
- Moves the SQLite write off the main actor — see "Off-main writes" below.
- Reworks `EditorViewController.deleteAllData()` so it doesn't unlink `htmlpreview.sqlite` under the live SQLite handle — see "deleteAllData() interaction" below.
- Removes the public per-instance `clearCache()` and makes the static one `nonisolated` + sync — see "One process-wide instance" below.
- Drops `makeCache()`, the `preview://` synthetic-URL key wrapping, and the `CachedURLResponse` round-trip — all `URLCache` ceremony that `SQLiteKVCache` doesn't need.

## What's stored

| field | source |
|---|---|
| key | raw `"content-viewportWidth-templateHash"` string — `SQLiteKVCache` hashes keys with SHA-256 internally before binding, so wrapping in another digest at the call site is redundant |
| storageDate | `.now` at write time — used by `SQLiteKVCache` for oldest-first eviction |
| metadata | empty `Data()` — preview entries don't need side-channel state |
| value | HEIC-encoded image bytes (unchanged from the prior `URLCache` path) |

The backing file lives at `~/Library/Caches/GutenbergKit/htmlpreview.sqlite`, sibling to the per-site `EditorURLCache` directories (`<siteId>/editorurlcache.sqlite`) under the same root — the layout makes the global-vs-per-site distinction visible at the filesystem level.

## One process-wide instance

`SQLiteKVCache` requires one owning instance per backing file. `HTMLPreviewManager` is created lazily per `EditorViewController`, so two coexisting instances would have shared a single backing directory under the old `URLCache` design (and silently raced); under `SQLiteKVCache` that's undefined behavior.

Fixed by holding the store at **file scope** rather than per-instance — `private let previewCache = SQLiteKVCache(...)` lives outside the class. Reads more honestly than a class-scope `static let` would: the cache is process-wide singleton state, not a property of any one manager. Per-template isolation still holds because the cache key folds in `templateHash` — different themes never collide.

Side effect: the per-instance `clearCache()` becomes redundant. With one shared backing store, `instance.clearCache()` and `Self.clearCache()` had identical semantics — calling either nukes every instance's cached previews. `gh search code` across the `wordpress-mobile` org confirmed the only call site for either form is `Demo-iOS/Sources/Views/DebugSettingsView.swift`, which already uses the static API. Dropped the instance method entirely rather than leave behind a signature that implies per-instance scoping.

The static `clearCache()` is also now `nonisolated` and synchronous (was `async`). Its body just calls `previewCache.clear()`, which has no actor requirement; the `async` was vestigial. The demo's only call site is updated accordingly.

## Off-main writes

`HTMLPreviewManager` is `@MainActor`; the old `URLCache.storeCachedResponse` ran synchronously on the main thread, and the naive `SQLiteKVCache` swap inherited the same property. Fixed by:

- Putting the cache at file scope so it has no actor isolation — the detached task can reach it directly.
- Wrapping the `cache.put` in `Task.detached` — the closure runs on the cooperative pool, not main.

The HEIC encode stays on main because `UIImage` isn't `Sendable` — only the resulting `Data` + `key` cross into the detached task. Cache reads stay on main as the cache-hit fast path; SQLite reads on flash are sub-millisecond and going async would add a continuation hop on every render.

Write failures, read failures, and HEIC-encode failures are logged via OSLog (`subsystem: "GutenbergKit", category: "html-preview"`) instead of being swallowed by `try?`. The lower-level `SQLiteKVCache` already logs the SQLite-level error code; these add the call-site context.

Minor side effect: a render arriving immediately after another identical render completes can now race the detached write and re-render. The window is small (the time to encode HEIC + commit one SQLite row), and pattern previews aren't typically requested back-to-back. Not worth defending against with an in-memory shadow.

## `deleteAllData()` interaction

`previewCache` keeps a SQLite connection (and its WAL/SHM file handles) open for the lifetime of the process. The previous `deleteAllData()` did `removeItem(at: defaultCacheRoot)`, which used to be a no-op against the preview cache (the old path was outside `defaultCacheRoot`) but **would now unlink `htmlpreview.sqlite` under the live handle**, leaving the process writing to an orphaned inode until termination.

Fixed by:

- Clearing the preview cache rows through the live handle (`HTMLPreviewManager.clearCache()`) before any file removal.
- Sweeping `defaultCacheRoot` selectively, preserving `htmlpreview.sqlite`, `htmlpreview.sqlite-wal`, and `htmlpreview.sqlite-shm`.

Per-site `EditorURLCache` subdirectories are still removed wholesale. Their open-handle issue is the existing #483 surface — separate concern, out of scope here.

## Migration

Pre-existing `URLCache` files at `~/Library/Caches/gbk-html-preview-cache/` are left in place — dead weight until the OS reclaims the cache directory. Existing entries cache-miss on first read after upgrade and re-render. Same trade-off #483 makes; a one-shot cleanup on init is possible but not worth the complexity.

## Test plan

- [x] `make build-swift-package` succeeds (iOS Simulator target compiles the `#if canImport(UIKit)`-gated file).
- [x] `make test-swift-package` passes (full iOS Simulator suite).
- [x] `make test-swift-library` passes on macOS host (898 tests / 46 suites — `HTMLPreviewManager` itself is UIKit-gated and not exercised here).
- [ ] Manual: open the demo app's debug menu → "Clear Preview Cache" — confirm pattern previews regenerate on next render.
- [ ] Manual: open the demo app's debug menu → "Clear Editor Data" — confirm preview cache rebuilds correctly afterward and no SQLite errors appear in OSLog.