### PR TITLE
fix(js): skip redux toggle when opening native block inserter

### DIFF
--- a/src/components/native-inserter/index.jsx
+++ b/src/components/native-inserter/index.jsx
@@ -424,7 +424,11 @@ export default function NativeBlockInserterButton( { open, onToggle } ) {
 			title={ __( 'Add block' ) }
 			icon={ plus }
 			onClick={ () => {
-				onToggle( true );
+				// Skip the redux toggle and present the native inserter
+				// directly. Flipping `isInserterOpened` in editorStore would
+				// briefly render Gutenberg's web inserter behind the native
+				// dialog before it covers, causing a visible flash.
+				prepareAndShowInserter();
 			} }
 			onMouseDown={ ( e ) => {
 				e.preventDefault();


### PR DESCRIPTION
## Summary

Tapping the `+` button currently calls `setIsInserterOpened(true)` on the editor store, which momentarily renders Gutenberg's web inserter UI before the native dialog covers it — a visible flash on slower devices. Call `prepareAndShowInserter()` directly instead; the redux flag isn't useful when the inserter is rendered natively.

## Test plan

- [x] On Android (or iOS), with `enableNativeBlockInserter` on, tap the `+` toolbar button
- [x] Native inserter dialog appears immediately, no flash of the web inserter behind it
- [x] The dialog still closes correctly via the X button (still goes through `onToggle(false)` from `window.blockInserter.onClose`)