### PR TITLE
ci(ios): publish + prune per-PR XCFramework snapshot branches

### DIFF
--- a/.buildkite/cleanup-pr-build-branches.sh
+++ b/.buildkite/cleanup-pr-build-branches.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Deletes `pr-build/<n>` branches whose PR is closed (merged or rejected).
+# Runs on trunk pushes so the just-merged PR's branch gets cleaned up
+# immediately, and any orphans accumulated from prior failures get swept too.
+
+if [[ "${BUILDKITE_BRANCH:-}" != "trunk" ]]; then
+    echo "Not a trunk build (branch=${BUILDKITE_BRANCH:-unset}), skipping"
+    exit 0
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "GITHUB_TOKEN not set, cannot query PR state" >&2
+    exit 1
+fi
+
+GITHUB_REPO="wordpress-mobile/GutenbergKit"
+
+echo '--- :robot_face: Use bot for Git operations'
+source use-bot-for-git
+
+echo "--- :mag: Listing pr-build/* branches on origin"
+mapfile -t branches < <(
+    git ls-remote --heads origin 'refs/heads/pr-build/*' \
+        | awk '{print $2}' \
+        | sed 's|^refs/heads/||'
+)
+
+echo "Found ${#branches[@]} pr-build branches"
+
+if [[ ${#branches[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+echo "--- :github: Checking PR state for each branch"
+to_delete=()
+for branch in "${branches[@]}"; do
+    pr_number="${branch#pr-build/}"
+    if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+        echo "Skipping $branch (unexpected suffix)"
+        continue
+    fi
+
+    response=$(
+        curl --silent --show-error \
+            --write-out $'\n%{http_code}' \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPO}/pulls/${pr_number}"
+    )
+    http_code=$(printf '%s' "$response" | tail -n1)
+    body=$(printf '%s' "$response" | sed '$d')
+
+    if [[ "$http_code" != "200" ]]; then
+        echo "Skipping $branch (HTTP $http_code from GitHub)"
+        continue
+    fi
+
+    state=$(printf '%s' "$body" | jq -r '.state')
+
+    if [[ "$state" == "closed" ]]; then
+        echo "Marking $branch for deletion (PR #$pr_number is closed)"
+        to_delete+=("$branch")
+    else
+        echo "Keeping $branch (PR #$pr_number is $state)"
+    fi
+done
+
+if [[ ${#to_delete[@]} -eq 0 ]]; then
+    echo "No closed PR branches to delete"
+    exit 0
+fi
+
+echo "--- :wastebasket: Deleting ${#to_delete[@]} stale branches"
+chunk_size=50
+for ((i=0; i<${#to_delete[@]}; i+=chunk_size)); do
+    chunk=("${to_delete[@]:i:chunk_size}")
+    refspecs=()
+    for branch in "${chunk[@]}"; do
+        refspecs+=(":refs/heads/${branch}")
+    done
+    git push origin "${refspecs[@]}"
+done

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -156,3 +156,8 @@ steps:
           - 'android/Gutenberg/build/outputs/androidTest-results/connected/**/*'
           - 'android/Gutenberg/build/outputs/buildkite-logs/**/*'
           - 'android/Gutenberg/build/outputs/connected_android_test_additional_output/**/*'
+
+    - label: ':wastebasket: Clean up `pr-build/*` branches for closed PRs'
+      if: build.branch == "trunk"
+      command: .buildkite/cleanup-pr-build-branches.sh
+      plugins: *plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -80,8 +80,8 @@ steps:
     - label: ':xcode: Build XCFramework'
       key: build-xcframework
       depends_on:
-        - build-react
-        - swift-test-library
+          - build-react
+          - swift-test-library
       command: |
           buildkite-agent artifact download dist.tar.gz .
           tar -xzf dist.tar.gz
@@ -97,6 +97,7 @@ steps:
 
     - label: ':s3: Publish XCFramework to S3'
       depends_on: build-xcframework
+      if: build.pull_request.id == null
       command: |
           buildkite-agent artifact download '*.xcframework.zip' .
           buildkite-agent artifact download '*.xcframework.zip.checksum.txt' .
@@ -105,6 +106,12 @@ steps:
           # tag build publishes under the tag, otherwise fall back to the
           # commit SHA so every push gets a stable artifact URL.
           bundle exec fastlane publish_to_s3 version:${NEW_VERSION:-${BUILDKITE_TAG:-$BUILDKITE_COMMIT}}
+      plugins: *plugins
+
+    - label: ':swift: :package: Publish PR XCFramework'
+      depends_on: build-xcframework
+      if: build.pull_request.id != null
+      command: .buildkite/publish-pr-xcframework.sh
       plugins: *plugins
 
     - label: ':ios: Test iOS E2E'

--- a/.buildkite/publish-pr-xcframework.sh
+++ b/.buildkite/publish-pr-xcframework.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
+    echo "Not a PR build, skipping PR XCFramework publish"
+    exit 0
+fi
+
+# Skip on fork PRs: bot credentials and S3 secrets aren't available, and we
+# couldn't push the snapshot branch back to the canonical repo anyway.
+if [[ -n "${BUILDKITE_PULL_REQUEST_REPO:-}" ]] \
+    && [[ "$BUILDKITE_PULL_REQUEST_REPO" != *"wordpress-mobile/GutenbergKit"* ]]; then
+    echo "PR is from a fork (${BUILDKITE_PULL_REQUEST_REPO}), skipping XCFramework publish"
+    exit 0
+fi
+
+PR_NUMBER="$BUILDKITE_PULL_REQUEST"
+
+echo '--- :robot_face: Use bot for Git operations'
+source use-bot-for-git
+
+echo '--- :arrow_down: Downloading XCFramework artifacts'
+buildkite-agent artifact download '*.xcframework.zip' . --step "build-xcframework"
+buildkite-agent artifact download '*.xcframework.zip.checksum.txt' . --step "build-xcframework"
+
+echo '--- :rubygems: Setting up Gems'
+install_gems
+
+echo "--- :rocket: Publishing PR build for PR #${PR_NUMBER}"
+bundle exec fastlane publish_pr_xcframework pr_number:"$PR_NUMBER"

--- a/.buildkite/publish-pr-xcframework.sh
+++ b/.buildkite/publish-pr-xcframework.sh
@@ -25,4 +25,4 @@ echo '--- :rubygems: Setting up Gems'
 install_gems
 
 echo "--- :rocket: Publishing PR build for PR #${BUILDKITE_PULL_REQUEST}"
-bundle exec fastlane publish_pr_xcframework pr_number:"$BUILDKITE_PULL_REQUEST"
+bundle exec fastlane publish_pr_xcframework

--- a/.buildkite/publish-pr-xcframework.sh
+++ b/.buildkite/publish-pr-xcframework.sh
@@ -14,8 +14,6 @@ if [[ -n "${BUILDKITE_PULL_REQUEST_REPO:-}" ]] \
     exit 0
 fi
 
-PR_NUMBER="$BUILDKITE_PULL_REQUEST"
-
 echo '--- :robot_face: Use bot for Git operations'
 source use-bot-for-git
 
@@ -26,5 +24,5 @@ buildkite-agent artifact download '*.xcframework.zip.checksum.txt' . --step "bui
 echo '--- :rubygems: Setting up Gems'
 install_gems
 
-echo "--- :rocket: Publishing PR build for PR #${PR_NUMBER}"
-bundle exec fastlane publish_pr_xcframework pr_number:"$PR_NUMBER"
+echo "--- :rocket: Publishing PR build for PR #${BUILDKITE_PULL_REQUEST}"
+bundle exec fastlane publish_pr_xcframework pr_number:"$BUILDKITE_PULL_REQUEST"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -169,7 +169,7 @@ def xcframework_comment_body(branch_name:, commit_sha:)
     #{XCFRAMEWORK_COMMENT_MARKER}
     ## XCFramework Build
 
-    This PR's XCFramework is available for testing. Add to your `Package.swift`:
+    This PR's XCFramework is available for testing. Add the following to your `Package.swift`:
 
     ```swift
     .package(url: "https://github.com/#{GITHUB_REPO}", branch: "#{branch_name}")
@@ -229,7 +229,5 @@ end
 def post_buildkite_annotation(body:)
   return unless ENV['BUILDKITE_AGENT_ACCESS_TOKEN']
 
-  IO.popen(['buildkite-agent', 'annotate', '--context', 'xcframework', '--style', 'info'], 'w') do |io|
-    io.write(body)
-  end
+  buildkite_annotate(context: 'xcframework', style: 'info', message: body)
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,7 +5,7 @@ PROJECT_ROOT = File.expand_path('..', __dir__)
 APPLE_TEAM_ID = 'PZYM8XX95Q'
 
 GITHUB_REPO = 'wordpress-mobile/GutenbergKit'
-XCFRAMEWORK_COMMENT_MARKER = '<!-- gutenbergkit-xcframework-build -->'
+XCFRAMEWORK_COMMENT_REUSE_ID = 'gutenbergkit-xcframework-build'
 
 ASC_API_KEY_ENV_VARS = %w[
   APP_STORE_CONNECT_API_KEY_KEY_ID
@@ -42,8 +42,10 @@ lane :publish_to_s3 do |options|
   )
 end
 
-lane :publish_pr_xcframework do |options|
-  pr_number = Integer(options[:pr_number].to_s, 10)
+lane :publish_pr_xcframework do
+  pr_num_str = ENV.fetch('BUILDKITE_PULL_REQUEST', 'false')
+  UI.user_error!('publish_pr_xcframework requires BUILDKITE_PULL_REQUEST to be a PR number') if pr_num_str == 'false'
+  pr_number = Integer(pr_num_str, 10)
 
   branch_name = "pr-build/#{pr_number}"
   version = "pr-builds/#{pr_number}"
@@ -52,7 +54,12 @@ lane :publish_pr_xcframework do |options|
   push_xcframework_snapshot_branch(branch_name: branch_name, version: version, checksum: xcframework_checksum)
 
   body = xcframework_comment_body(branch_name: branch_name, commit_sha: ENV.fetch('BUILDKITE_COMMIT', nil))
-  upsert_pr_xcframework_comment(pr_number: pr_number, body: body)
+  comment_on_pr(
+    project: GITHUB_REPO,
+    pr_number: pr_number,
+    body: body,
+    reuse_identifier: XCFRAMEWORK_COMMENT_REUSE_ID
+  )
   post_buildkite_annotation(body: body)
 end
 
@@ -165,7 +172,6 @@ end
 def xcframework_comment_body(branch_name:, commit_sha:)
   short_sha = (commit_sha || 'unknown')[0, 8]
   <<~MARKDOWN
-    #{XCFRAMEWORK_COMMENT_MARKER}
     ## XCFramework Build
 
     This PR's XCFramework is available for testing. Add the following to your `Package.swift`:
@@ -176,53 +182,6 @@ def xcframework_comment_body(branch_name:, commit_sha:)
 
     <sub>Built from #{short_sha}</sub>
   MARKDOWN
-end
-
-def upsert_pr_xcframework_comment(pr_number:, body:)
-  github_token = ENV.fetch('GITHUB_TOKEN', nil)
-  unless github_token
-    UI.important('GITHUB_TOKEN not set, skipping PR comment')
-    return
-  end
-
-  existing = find_existing_xcframework_comment(github_token: github_token, pr_number: pr_number)
-  if existing
-    github_api(
-      server_url: 'https://api.github.com',
-      api_token: github_token,
-      http_method: 'PATCH',
-      path: "/repos/#{GITHUB_REPO}/issues/comments/#{existing['id']}",
-      body: { body: body }
-    )
-  else
-    github_api(
-      server_url: 'https://api.github.com',
-      api_token: github_token,
-      http_method: 'POST',
-      path: "/repos/#{GITHUB_REPO}/issues/#{pr_number}/comments",
-      body: { body: body }
-    )
-  end
-end
-
-def find_existing_xcframework_comment(github_token:, pr_number:)
-  page = 1
-  loop do
-    result = github_api(
-      server_url: 'https://api.github.com',
-      api_token: github_token,
-      http_method: 'GET',
-      path: "/repos/#{GITHUB_REPO}/issues/#{pr_number}/comments?per_page=100&page=#{page}"
-    )
-    comments = result[:json] || []
-    return nil if comments.empty?
-
-    found = comments.find { |c| c['body']&.include?(XCFRAMEWORK_COMMENT_MARKER) }
-    return found if found
-    return nil if comments.length < 100
-
-    page += 1
-  end
 end
 
 def post_buildkite_annotation(body:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,6 +4,9 @@ PROJECT_ROOT = File.expand_path('..', __dir__)
 
 APPLE_TEAM_ID = 'PZYM8XX95Q'
 
+GITHUB_REPO = 'wordpress-mobile/GutenbergKit'
+XCFRAMEWORK_COMMENT_MARKER = '<!-- gutenbergkit-xcframework-build -->'
+
 ASC_API_KEY_ENV_VARS = %w[
   APP_STORE_CONNECT_API_KEY_KEY_ID
   APP_STORE_CONNECT_API_KEY_ISSUER_ID
@@ -37,6 +40,21 @@ lane :publish_to_s3 do |options|
     auto_prefix: false,
     if_exists: :replace
   )
+end
+
+lane :publish_pr_xcframework do |options|
+  pr_number = options[:pr_number].to_s
+  UI.user_error!('pr_number is required') if pr_number.empty?
+
+  branch_name = "pr-build/#{pr_number}"
+  version = "pr-builds/#{pr_number}"
+
+  publish_to_s3(version: version)
+  push_xcframework_snapshot_branch(branch_name: branch_name, version: version, checksum: xcframework_checksum)
+
+  body = xcframework_comment_body(branch_name: branch_name, commit_sha: ENV.fetch('BUILDKITE_COMMIT', nil))
+  upsert_pr_xcframework_comment(pr_number: pr_number, body: body)
+  post_buildkite_annotation(body: body)
 end
 
 lane :xcframework_sign do
@@ -122,4 +140,96 @@ def get_required_env!(key)
   return ENV.fetch(key) if ENV.key?(key)
 
   UI.user_error!("Environment variable `#{key}` is not set.")
+end
+
+def push_xcframework_snapshot_branch(branch_name:, version:, checksum:)
+  package_swift = File.join(PROJECT_ROOT, 'Package.swift')
+  rewrite_resources_mode!(package_swift, version: version, checksum: checksum)
+
+  sh("git checkout -B #{branch_name}")
+  git_commit(path: package_swift, message: "Update Package.swift for #{version}")
+  sh("git push -f origin #{branch_name}")
+end
+
+def rewrite_resources_mode!(package_swift, version:, checksum:)
+  prefix = 'let resourcesMode: DependencyMode ='
+  replacement = %(#{prefix} .release(version: "#{version}", checksum: "#{checksum}")\n)
+
+  lines = File.readlines(package_swift)
+  matches = lines.count { |line| line.start_with?(prefix) }
+  UI.user_error!("Expected exactly one `#{prefix}` line in Package.swift, found #{matches}") unless matches == 1
+
+  rewritten = lines.map { |line| line.start_with?(prefix) ? replacement : line }
+  File.write(package_swift, rewritten.join)
+end
+
+def xcframework_comment_body(branch_name:, commit_sha:)
+  short_sha = (commit_sha || 'unknown')[0, 8]
+  <<~MARKDOWN
+    #{XCFRAMEWORK_COMMENT_MARKER}
+    ## XCFramework Build
+
+    This PR's XCFramework is available for testing. Add to your `Package.swift`:
+
+    ```swift
+    .package(url: "https://github.com/#{GITHUB_REPO}", branch: "#{branch_name}")
+    ```
+
+    <sub>Built from #{short_sha}</sub>
+  MARKDOWN
+end
+
+def upsert_pr_xcframework_comment(pr_number:, body:)
+  github_token = ENV.fetch('GITHUB_TOKEN', nil)
+  unless github_token
+    UI.important('GITHUB_TOKEN not set, skipping PR comment')
+    return
+  end
+
+  existing = find_existing_xcframework_comment(github_token: github_token, pr_number: pr_number)
+  if existing
+    github_api(
+      server_url: 'https://api.github.com',
+      api_token: github_token,
+      http_method: 'PATCH',
+      path: "/repos/#{GITHUB_REPO}/issues/comments/#{existing['id']}",
+      body: { body: body }
+    )
+  else
+    github_api(
+      server_url: 'https://api.github.com',
+      api_token: github_token,
+      http_method: 'POST',
+      path: "/repos/#{GITHUB_REPO}/issues/#{pr_number}/comments",
+      body: { body: body }
+    )
+  end
+end
+
+def find_existing_xcframework_comment(github_token:, pr_number:)
+  page = 1
+  loop do
+    result = github_api(
+      server_url: 'https://api.github.com',
+      api_token: github_token,
+      http_method: 'GET',
+      path: "/repos/#{GITHUB_REPO}/issues/#{pr_number}/comments?per_page=100&page=#{page}"
+    )
+    comments = result[:json] || []
+    return nil if comments.empty?
+
+    found = comments.find { |c| c['body']&.include?(XCFRAMEWORK_COMMENT_MARKER) }
+    return found if found
+    return nil if comments.length < 100
+
+    page += 1
+  end
+end
+
+def post_buildkite_annotation(body:)
+  return unless ENV['BUILDKITE_AGENT_ACCESS_TOKEN']
+
+  IO.popen(['buildkite-agent', 'annotate', '--context', 'xcframework', '--style', 'info'], 'w') do |io|
+    io.write(body)
+  end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fastlane/plugin/wpmreleasetoolkit'
+
 PROJECT_ROOT = File.expand_path('..', __dir__)
 
 APPLE_TEAM_ID = 'PZYM8XX95Q'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,8 +43,7 @@ lane :publish_to_s3 do |options|
 end
 
 lane :publish_pr_xcframework do |options|
-  pr_number = options[:pr_number].to_s
-  UI.user_error!('pr_number is required') if pr_number.empty?
+  pr_number = Integer(options[:pr_number].to_s, 10)
 
   branch_name = "pr-build/#{pr_number}"
   version = "pr-builds/#{pr_number}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,12 @@ CODE_SIGNING_STORAGE_ENV_VARS = %w[
   MATCH_S3_SECRET_ACCESS_KEY
 ].freeze
 
+# Set up the release-toolkit env manager so lanes can read CI metadata
+# (`pull_request_number`, `commit_hash`, etc.) via a single canonical helper.
+# We don't ship a `.env` file; on CI the values come straight from the process
+# environment, and off-CI the manager will warn (not fail) about the missing file.
+Fastlane::Wpmreleasetoolkit::EnvManager.set_up(env_file_name: 'gutenbergkit.env')
+
 before_all do
   setup_ci
 end
@@ -43,9 +49,9 @@ lane :publish_to_s3 do |options|
 end
 
 lane :publish_pr_xcframework do
-  pr_num_str = ENV.fetch('BUILDKITE_PULL_REQUEST', 'false')
-  UI.user_error!('publish_pr_xcframework requires BUILDKITE_PULL_REQUEST to be a PR number') if pr_num_str == 'false'
-  pr_number = Integer(pr_num_str, 10)
+  env = Fastlane::Wpmreleasetoolkit::EnvManager.default!
+  pr_number = env.pull_request_number
+  UI.user_error!('publish_pr_xcframework must run on a PR build (BUILDKITE_PULL_REQUEST is unset or "false")') if pr_number.nil?
 
   branch_name = "pr-build/#{pr_number}"
   version = "pr-builds/#{pr_number}"
@@ -53,7 +59,7 @@ lane :publish_pr_xcframework do
   publish_to_s3(version: version)
   push_xcframework_snapshot_branch(branch_name: branch_name, version: version, checksum: xcframework_checksum)
 
-  body = xcframework_comment_body(branch_name: branch_name, commit_sha: ENV.fetch('BUILDKITE_COMMIT', nil))
+  body = xcframework_comment_body(branch_name: branch_name, commit_sha: env.commit_hash)
   comment_on_pr(
     project: GITHUB_REPO,
     pr_number: pr_number,


### PR DESCRIPTION
## Summary

- For each PR commit, upload the signed XCFramework to `s3://a8c-apps-public-artifacts/gutenbergkit/pr-builds/<n>/`, force-push a `pr-build/<n>` branch with `Package.swift` rewritten to consume the binary target, and post a sticky PR comment + Buildkite annotation pointing consumers at the branch.
- On every trunk push, sweep `pr-build/*` refs whose PR is closed (merged or rejected) so the branches don't accumulate.
- Existing trunk/tag publish step (`Fastfile:25–43`) gated on `build.pull_request.id == null` so PRs don't double-upload to the commit-SHA prefix.
- Mirrors [Automattic/wordpress-rs#1291](https://github.com/Automattic/wordpress-rs/pull/1291#issuecomment-4275192022) (publish) and [#1321](https://github.com/Automattic/wordpress-rs/pull/1321) (cleanup) — same comment marker pattern (`<!-- gutenbergkit-xcframework-build -->`), same lane structure, same sweep approach.

## How a consumer uses it

The PR comment will look like:

> ## XCFramework Build
>
> This PR's XCFramework is available for testing. Add to your `Package.swift`:
>
> ```swift
> .package(url: "https://github.com/wordpress-mobile/GutenbergKit", branch: "pr-build/<n>")
> ```
>
> <sub>Built from `<short-sha>`</sub>

The `pr-build/<n>` branch points at the PR's HEAD commit with `Package.swift:9` rewritten from `.local` to `.release(version: "pr-builds/<n>", checksum: "<sha>")`, so SPM resolves the resources via the binary target on CDN.

## Changes

### Publish

- **`.buildkite/pipeline.yml`**: Gate the existing `:s3: Publish XCFramework to S3` step on non-PR builds; add a `:swift: :package: Publish PR XCFramework` step that runs only when `build.pull_request.id != null`.
- **`.buildkite/publish-pr-xcframework.sh`** (new): Skip fork PRs (no bot creds), `source use-bot-for-git`, download the build artifacts, and invoke the new fastlane lane.
- **`fastlane/Fastfile`**: Add `publish_pr_xcframework` lane that uploads to S3, rewrites `Package.swift`, force-pushes `pr-build/<n>`, posts/updates the sticky PR comment, and writes a Buildkite annotation. Helpers paginate the comments lookup so the marker isn't missed on PRs with >100 comments — small fix relative to the wordpress-rs prior art.

### Cleanup

- **`.buildkite/cleanup-pr-build-branches.sh`** (new): Guards on `BUILDKITE_BRANCH == "trunk"`, sources `use-bot-for-git`, enumerates via `git ls-remote --heads origin 'refs/heads/pr-build/*'`, queries `GET /repos/wordpress-mobile/GutenbergKit/pulls/<n>` with `GITHUB_TOKEN`, and deletes closed-PR refs with batched `git push origin :refs/heads/...` (chunks of 50). Skips on non-200 responses so we never delete a ref we couldn't verify.
- **`.buildkite/pipeline.yml`**: New trunk-only `:wastebasket: Clean up pr-build/*` step.

## What we explored

- **Generated-source equivalent.** wordpress-rs commits its Swift FFI bindings onto the snapshot branch because they're gitignored Swift source consumed by a regular `.target`. GutenbergKit's equivalent is the .html/.js bundle, but on the snapshot branch we're switching `GutenbergKitResources` from a source target with `resources: [.copy("Gutenberg")]` to a `.binaryTarget` — the resources live inside the XCFramework on that path, so we don't need to commit them. Simpler than wordpress-rs.
- **Trunk snapshot branch.** wordpress-rs also publishes a `trunk-build` branch keyed by SHA. Deferred to a follow-up — the existing trunk `gutenbergkit/<commit-sha>/` upload still runs unchanged, and the use case (downstream apps consuming a known-good trunk binary via SPM branch) isn't load-bearing yet.
- **Dropping the local resource files.** `.gitignore:200–202` has a comment saying the `ios/Sources/GutenbergKitResources/Gutenberg/{assets,index.html}` files are checked in temporarily until "this is published like Android in CI." Once consumers migrate to `.release(...)`, those 61 files can finally be ignored — separate follow-up so consumers can flip first.

## Test plan

### Publish

This PR exercises its own publish path, so several items are confirmed against [build #2235](https://buildkite.com/automattic/gutenbergkit/builds/2235).

- [x] `Publish PR XCFramework` step runs and succeeds — confirmed: `swift-package-publish-pr-xcframework` SUCCESS in build #2235.
- [x] `pr-build/<n>` branch appears on the remote with `Package.swift:9` rewritten to `.release(version: "pr-builds/<n>", checksum: "...")` — confirmed: [`pr-build/495`](https://github.com/wordpress-mobile/GutenbergKit/blob/pr-build/495/Package.swift#L9) has `.release(version: "pr-builds/495", checksum: "d2d8a91c...")`.
- [x] `<!-- gutenbergkit-xcframework-build -->` comment posted with correct branch URL and short SHA — confirmed: [comment by `wpmobilebot`](https://github.com/wordpress-mobile/GutenbergKit/pull/495#issuecomment-4383914413).
- [x] Push another commit to the same PR; verify the existing comment is updated (PATCHed), not duplicated — confirmed: the cherry-pick force-push triggered a second build, and the GH API shows a single comment with `created_at: 23:26:54Z` / `updated_at: 23:42:30Z` and the latest short SHA `8027996c` in the body.
- [x] Buildkite annotation appears in the build summary with the same body — confirmed via the Buildkite API (`context: xcframework`, `style: info`).
- [x] `s3://a8c-apps-public-artifacts/gutenbergkit/pr-builds/<n>/` has the zip + checksum — confirmed: `cdn.a8c-ci.services/gutenbergkit/pr-builds/495/...zip` returns HTTP 200 (18.6 MB) and the `.checksum.txt` returns 200.
- [x] Pull the `pr-build/<n>` branch into a consumer and confirm SPM resolves the XCFramework — confirmed in a scratch SPM consumer: `swift package resolve` resolved `pr-build/495 (51a9bb6)`, downloaded the binary artifact from CDN, checksum validated, and `swift build --triple arm64-apple-ios17.0-simulator` linked successfully. The framework contains both `ios-arm64` and `ios-arm64_x86_64-simulator` slices, each with `GutenbergKitResources` (Mach-O dylib), a Swift module (`module.modulemap` + `.swiftinterface`), and a `GutenbergKit_GutenbergKitResources.bundle` carrying `Gutenberg/index.html` + 59 web assets.
- [ ] Verify a non-PR push (trunk) still hits the original `:s3:` step and uploads under `gutenbergkit/<commit-sha>/` — verifiable on first trunk push after merge.
- [ ] Confirm a fork PR (or a simulated `BUILDKITE_PULL_REQUEST_REPO` mismatch) skips cleanly rather than failing on `git push` — not exercised; covered by the early-exit guard in `publish-pr-xcframework.sh`.

### Cleanup

These all require trunk pushes; not verifiable pre-merge.

- [ ] First trunk merge after this lands sweeps any orphan `pr-build/*` branches accumulated from publish-side testing.
- [ ] Subsequent trunk merges delete the just-merged PR's `pr-build/<n>` branch.
- [ ] Step is skipped on PR builds.
- [ ] Open-PR `pr-build/*` branches are left alone.
- [ ] If GitHub returns non-200 for a PR (deleted, rate-limited, transient), the corresponding branch is preserved and the step continues.