### PR TITLE
ci: prune `pr-build/*` branches for closed PRs on trunk pushes

### DIFF
--- a/.buildkite/cleanup-pr-build-branches.sh
+++ b/.buildkite/cleanup-pr-build-branches.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Deletes `pr-build/<n>` branches whose PR is closed (merged or rejected).
+# Runs on trunk pushes so the just-merged PR's branch gets cleaned up
+# immediately, and any orphans accumulated from prior failures get swept too.
+
+if [[ "${BUILDKITE_BRANCH:-}" != "trunk" ]]; then
+    echo "Not a trunk build (branch=${BUILDKITE_BRANCH:-unset}), skipping"
+    exit 0
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "GITHUB_TOKEN not set, cannot query PR state" >&2
+    exit 1
+fi
+
+GITHUB_REPO="wordpress-mobile/GutenbergKit"
+
+echo '--- :robot_face: Use bot for Git operations'
+source use-bot-for-git
+
+echo "--- :mag: Listing pr-build/* branches on origin"
+mapfile -t branches < <(
+    git ls-remote --heads origin 'refs/heads/pr-build/*' \
+        | awk '{print $2}' \
+        | sed 's|^refs/heads/||'
+)
+
+echo "Found ${#branches[@]} pr-build branches"
+
+if [[ ${#branches[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+echo "--- :github: Checking PR state for each branch"
+to_delete=()
+for branch in "${branches[@]}"; do
+    pr_number="${branch#pr-build/}"
+    if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+        echo "Skipping $branch (unexpected suffix)"
+        continue
+    fi
+
+    response=$(
+        curl --silent --show-error \
+            --write-out $'\n%{http_code}' \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPO}/pulls/${pr_number}"
+    )
+    http_code=$(printf '%s' "$response" | tail -n1)
+    body=$(printf '%s' "$response" | sed '$d')
+
+    if [[ "$http_code" != "200" ]]; then
+        echo "Skipping $branch (HTTP $http_code from GitHub)"
+        continue
+    fi
+
+    state=$(printf '%s' "$body" | jq -r '.state')
+
+    if [[ "$state" == "closed" ]]; then
+        echo "Marking $branch for deletion (PR #$pr_number is closed)"
+        to_delete+=("$branch")
+    else
+        echo "Keeping $branch (PR #$pr_number is $state)"
+    fi
+done
+
+if [[ ${#to_delete[@]} -eq 0 ]]; then
+    echo "No closed PR branches to delete"
+    exit 0
+fi
+
+echo "--- :wastebasket: Deleting ${#to_delete[@]} stale branches"
+chunk_size=50
+for ((i=0; i<${#to_delete[@]}; i+=chunk_size)); do
+    chunk=("${to_delete[@]:i:chunk_size}")
+    refspecs=()
+    for branch in "${chunk[@]}"; do
+        refspecs+=(":refs/heads/${branch}")
+    done
+    git push origin "${refspecs[@]}"
+done

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -80,8 +80,8 @@ steps:
     - label: ':xcode: Build XCFramework'
       key: build-xcframework
       depends_on:
-        - build-react
-        - swift-test-library
+          - build-react
+          - swift-test-library
       command: |
           buildkite-agent artifact download dist.tar.gz .
           tar -xzf dist.tar.gz
@@ -149,3 +149,8 @@ steps:
           - 'android/Gutenberg/build/outputs/androidTest-results/connected/**/*'
           - 'android/Gutenberg/build/outputs/buildkite-logs/**/*'
           - 'android/Gutenberg/build/outputs/connected_android_test_additional_output/**/*'
+
+    - label: ':wastebasket: Clean up `pr-build/*` branches for closed PRs'
+      if: build.branch == "trunk"
+      command: .buildkite/cleanup-pr-build-branches.sh
+      plugins: *plugins


### PR DESCRIPTION
## Summary

- Each PR build force-pushes a `pr-build/<n>` snapshot branch (#495). Nothing prunes them, so they accumulate.
- Adds a Buildkite step on every trunk push that lists `pr-build/*` refs, queries each PR's state via the GitHub API, and deletes the refs whose PR is `closed` (covers both merged and rejected — GitHub collapses them).
- Mirrors [Automattic/wordpress-rs#1321](https://github.com/Automattic/wordpress-rs/pull/1321), which paired with the equivalent publish PR there.

## Changes

- **`.buildkite/cleanup-pr-build-branches.sh`** (new): Guards on `BUILDKITE_BRANCH == "trunk"`, sources `use-bot-for-git`, enumerates via `git ls-remote --heads origin 'refs/heads/pr-build/*'`, queries `GET /repos/wordpress-mobile/GutenbergKit/pulls/<n>` with `GITHUB_TOKEN`, and deletes closed-PR refs with batched `git push origin :refs/heads/...` (chunks of 50). Skips on non-200 responses so we never delete a ref we couldn't verify.
- **`.buildkite/pipeline.yml`**: New step gated to `build.branch == "trunk"`, sharing the standard `*plugins` anchor (CI toolkit + NVM).

## Test plan

- [ ] First trunk merge after this lands sweeps any orphan `pr-build/*` branches accumulated from #495 testing.
- [ ] Subsequent trunk merges delete the just-merged PR's `pr-build/<n>` branch.
- [ ] Step is skipped on PR builds.
- [ ] Open-PR `pr-build/*` branches are left alone.
- [ ] If GitHub returns non-200 for a PR (deleted, rate-limited, transient), the corresponding branch is preserved and the step continues.

## Related

- Depends on #495 to define what `pr-build/*` branches exist in the first place.