### PR TITLE
ci: have Dependabot watch the Bundler ecosystem too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
             update-types: ['version-update:semver-major']
           - dependency-name: 'eslint-plugin-react-refresh' # eslint-plugin-react-refresh@>=0.5.x requires eslint@>=9.x.x, blocked by https://github.com/WordPress/gutenberg/issues/64782
             update-types: ['version-update:semver-minor']
+
+    - package-ecosystem: 'bundler'
+      directory: '/'
+      schedule:
+          interval: 'weekly'


### PR DESCRIPTION
## Summary

- #498 has since landed and brought us up to `fastlane-plugin-wpmreleasetoolkit ~> 14.4` manually. Had this dependabot entry already existed, that bump would have surfaced as an automatic PR and we would not have needed the manual catch-up — which is exactly the gap this PR closes for next time.

## Changes

- **`.github/dependabot.yml`**: add a second `updates:` entry for `package-ecosystem: 'bundler'`, weekly cadence, no ignores. The existing `npm` block is unchanged.

## Test plan

- [ ] After merge, Dependabot's next scan posts a PR for any outstanding `bundler` updates (release-toolkit is now current at 14.4.1 thanks to #498; `fastlane` is still at 2.232.2 vs latest 2.234.0).
- [ ] Weekly schedule kicks in on the standard Dependabot day; no further intervention needed.