### PR TITLE
fix(js): align block-inserter schema with native-inserter producer

### DIFF
--- a/schemas/block-inserter-payload.schema.json
+++ b/schemas/block-inserter-payload.schema.json
@@ -75,6 +75,10 @@
 					"type": [ "string", "null" ],
 					"description": "SVG markup as a string, or null when the block has no renderable icon."
 				},
+				"iconForeground": {
+					"type": [ "string", "null" ],
+					"description": "CSS color (hex or rgba) applied to the SVG icon's foreground, or null when the block uses default tinting."
+				},
 				"frecency": { "type": "number" },
 				"isDisabled": { "type": "boolean" },
 				"isSearchOnly": { "type": "boolean" },

--- a/src/utils/blocks.test.js
+++ b/src/utils/blocks.test.js
@@ -38,8 +38,8 @@ function assertBlockInserterPayloadShape( payload ) {
 	if ( validate( payload ) ) {
 		return;
 	}
-	const { instancePath, message } = validate.errors[ 0 ];
-	throw new Error( `${ instancePath || '/' }: ${ message }` );
+	const { instancePath, dataPath, message } = validate.errors[ 0 ];
+	throw new Error( `${ instancePath || dataPath || '/' }: ${ message }` );
 }
 
 function makeInserterItem( overrides = {} ) {


### PR DESCRIPTION
## Summary

Two small JS fixes that surfaced from CI on #461 / #481 / downstream stacked PRs.

1. **Schema misses `iconForeground`** — #468 added `iconForeground` to the block payload, but the schema (added in #467) declares `additionalProperties: false` on `BlockType` with no `iconForeground` entry. Trunk doesn't emit the field yet so trunk CI is fine, but any branch that carries both pieces (e.g. #461) fails AJV validation. Adds an entry mirroring `icon`: nullable string.

2. **AJV version drift in error reading** — `package.json` declares `ajv ^8.18.0` but the resolved version in `node_modules` is `6.12.6` (pulled in transitively and hoisted). AJV 6 surfaces the failing field path as `dataPath`; AJV 7+ uses `instancePath`. The shape-test helper only read `instancePath`, so error messages came back as `/: should be array` instead of `.patterns[0].blockTypes: should be array`, and the regex matchers in two rejection tests failed to find the field name. Read both, fall back across versions.

Landing this on trunk first lets #461 merge as a clean mechanical replay of already-approved squash commits.

## Test plan

- [x] `npx vitest run src/utils/blocks.test.js` — 17/17 pass
- [x] `make lint-js-fix` — clean