### PR TITLE
ci(ios): publish tagged releases as binary targets via Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,15 +15,26 @@ steps:
           - $CI_TOOLKIT_PLUGIN
           - $NVM_PLUGIN
 
+    - label: ':white_check_mark: Validate Swift release ${NEW_VERSION:-(no version)}'
+      key: validate-release
+      if: build.env("NEW_VERSION") != null && build.branch == "trunk" && build.pull_request.id == null
+      command: |
+          install_gems
+          bundle exec fastlane validate "version:$NEW_VERSION"
+      plugins: *plugins
+
     - label: ':eslint: Lint React App'
+      key: lint-js
       command: make lint-js
       plugins: *plugins
 
     - label: ':javascript: Test JavaScript'
+      key: test-js
       command: make test-js
       plugins: *plugins
 
     - label: ':performing_arts: Test Web E2E'
+      key: test-web-e2e
       depends_on: build-react
       command: |
           buildkite-agent artifact download dist.tar.gz .
@@ -97,15 +108,15 @@ steps:
 
     - label: ':s3: Publish XCFramework to S3'
       depends_on: build-xcframework
-      if: build.pull_request.id == null
+      # The `:rocket: Publish Swift release` step handles uploads when
+      # `NEW_VERSION` is set, so this step only covers per-commit trunk
+      # uploads keyed by the commit SHA.
+      if: build.pull_request.id == null && build.env("NEW_VERSION") == null
       command: |
           buildkite-agent artifact download '*.xcframework.zip' .
           buildkite-agent artifact download '*.xcframework.zip.checksum.txt' .
           install_gems
-          # Version precedence: explicit `NEW_VERSION` override wins, then a
-          # tag build publishes under the tag, otherwise fall back to the
-          # commit SHA so every push gets a stable artifact URL.
-          bundle exec fastlane publish_to_s3 version:${NEW_VERSION:-${BUILDKITE_TAG:-$BUILDKITE_COMMIT}}
+          bundle exec fastlane publish_to_s3 version:${BUILDKITE_TAG:-$BUILDKITE_COMMIT}
       plugins: *plugins
 
     - label: ':swift: :package: Publish PR XCFramework'
@@ -114,7 +125,21 @@ steps:
       command: .buildkite/publish-pr-xcframework.sh
       plugins: *plugins
 
+    - label: ':rocket: Publish Swift release ${NEW_VERSION:-(no version)}'
+      depends_on:
+          - validate-release
+          - build-xcframework
+          - swift-test-swift-package
+          - lint-js
+          - test-js
+          - test-web-e2e
+          - test-ios-e2e
+      if: build.env("NEW_VERSION") != null && build.branch == "trunk" && build.pull_request.id == null
+      command: .buildkite/release.sh
+      plugins: *plugins
+
     - label: ':ios: Test iOS E2E'
+      key: test-ios-e2e
       depends_on: build-react
       command: |
           buildkite-agent artifact download dist.tar.gz .

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,7 +115,7 @@ steps:
       # the `build.tag == null` clause skips it. Android publish on tag
       # builds is still load-bearing (produces the `vX.Y.Z` Maven artifact)
       # and intentionally not gated here.
-      if: build.pull_request.id == null && build.env("NEW_VERSION") == null && build.tag == null
+      if: build.env("NEW_VERSION") == null && build.tag == null && build.pull_request.id == null
       command: |
           buildkite-agent artifact download '*.xcframework.zip' .
           buildkite-agent artifact download '*.xcframework.zip.checksum.txt' .
@@ -129,7 +129,7 @@ steps:
       command: .buildkite/publish-pr-xcframework.sh
       plugins: *plugins
 
-    - label: ':rocket: Publish Swift release ${NEW_VERSION:-(no version)}'
+    - label: ':rocket: Publish Swift release ${NEW_VERSION:-(Error: No version found!)}'
       depends_on:
           - validate-release
           - build-xcframework

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,15 +108,19 @@ steps:
 
     - label: ':s3: Publish XCFramework to S3'
       depends_on: build-xcframework
-      # The `:rocket: Publish Swift release` step handles uploads when
-      # `NEW_VERSION` is set, so this step only covers per-commit trunk
-      # uploads keyed by the commit SHA.
-      if: build.pull_request.id == null && build.env("NEW_VERSION") == null
+      # This step only covers per-commit trunk uploads keyed by the commit
+      # SHA. Releases are handled by `:rocket: Publish Swift release` (gated
+      # on `NEW_VERSION`), and tag pushes from that step trigger a separate
+      # tag build whose iOS upload would just duplicate the rocket step's —
+      # the `build.tag == null` clause skips it. Android publish on tag
+      # builds is still load-bearing (produces the `vX.Y.Z` Maven artifact)
+      # and intentionally not gated here.
+      if: build.pull_request.id == null && build.env("NEW_VERSION") == null && build.tag == null
       command: |
           buildkite-agent artifact download '*.xcframework.zip' .
           buildkite-agent artifact download '*.xcframework.zip.checksum.txt' .
           install_gems
-          bundle exec fastlane publish_to_s3 version:${BUILDKITE_TAG:-$BUILDKITE_COMMIT}
+          bundle exec fastlane publish_to_s3 version:$BUILDKITE_COMMIT
       plugins: *plugins
 
     - label: ':swift: :package: Publish PR XCFramework'

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -z "${NEW_VERSION:-}" ]]; then
+    echo "ERROR: NEW_VERSION is not set or empty." >&2
+    echo "Set NEW_VERSION=vX.Y.Z when triggering this build." >&2
+    exit 1
+fi
+
+echo '--- :robot_face: Use bot for Git operations'
+source use-bot-for-git
+
+echo '--- :arrow_down: Downloading XCFramework artifacts'
+buildkite-agent artifact download '*.xcframework.zip' . --step "build-xcframework"
+buildkite-agent artifact download '*.xcframework.zip.checksum.txt' . --step "build-xcframework"
+
+echo '--- :rubygems: Setting up Gems'
+install_gems
+
+echo "--- :rocket: Publishing Swift release $NEW_VERSION"
+bundle exec fastlane release "version:$NEW_VERSION"

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+
 set -euo pipefail
 
 if [[ -z "${NEW_VERSION:-}" ]]; then
-    echo "ERROR: NEW_VERSION is not set or empty." >&2
+    echo "ERROR: NEW_VERSION is not set or is empty." >&2
     echo "Set NEW_VERSION=vX.Y.Z when triggering this build." >&2
     exit 1
 fi

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -79,10 +79,6 @@ check_working_directory() {
 check_dependencies() {
     local missing_deps=()
 
-    if ! command -v gh &> /dev/null; then
-        missing_deps+=("gh (GitHub CLI)")
-    fi
-
     if ! command -v npm &> /dev/null; then
         missing_deps+=("npm")
     fi
@@ -130,20 +126,6 @@ calculate_new_version() {
             echo "$version_type"
             ;;
     esac
-}
-
-# Function to check if a version is a prerelease
-is_prerelease() {
-    local version=$1
-
-    # Use semver to check if the version has prerelease identifiers
-    local result=$(node -p "require('semver').prerelease('$version') !== null")
-
-    if [ "$result" = "true" ]; then
-        return 0  # It is a prerelease
-    else
-        return 1  # It is not a prerelease
-    fi
 }
 
 # Function to validate version type
@@ -262,20 +244,6 @@ commit_changes() {
     print_success "Changes committed with message: chore(release): $version"
 }
 
-# Function to create git tag
-create_tag() {
-    local version=$1
-
-    print_status "Creating git tag: v$version"
-
-    if [ "$DRY_RUN" = "true" ]; then
-        return
-    fi
-
-    git tag "v$version"
-    print_success "Tag created: v$version"
-}
-
 # Function to push changes
 push_changes() {
     local version=$1
@@ -286,22 +254,33 @@ push_changes() {
         return
     fi
 
-    git push origin trunk --tags
+    git push origin trunk
     print_success "Changes pushed successfully"
 }
 
-# Function to create GitHub release
-create_github_release() {
+# Function to print the post-push instructions for kicking off the
+# Buildkite publish build. CI creates the tag and the GitHub release —
+# this script just bumps the version files on trunk.
+print_publish_instructions() {
     local version=$1
+    local sha=$2
+    local tag="v$version"
 
-    print_status "Creating GitHub release: v$version"
-
-    if [ "$DRY_RUN" = "true" ]; then
-        return
-    fi
-
-    gh release create "v$version" --generate-notes --title "$version"
-    print_success "GitHub release created: v$version"
+    echo
+    print_status "Next: trigger the Buildkite publish build."
+    echo
+    echo "  1. Open https://buildkite.com/automattic/gutenbergkit/builds/new"
+    echo "  2. Branch: trunk"
+    echo "  3. Commit: $sha"
+    echo "  4. Environment Variables: NEW_VERSION=$tag"
+    echo
+    echo "Pin the Commit field to the SHA above — otherwise Buildkite resolves"
+    echo "'trunk' to whatever HEAD is at trigger time, and a concurrent merge"
+    echo "would tag the wrong commit."
+    echo
+    echo "The :rocket: 'Publish Swift release' step will build + sign the"
+    echo "XCFramework, upload it to S3, and publish the GitHub Release —"
+    echo "which also creates the $tag tag."
 }
 
 # Main function
@@ -381,34 +360,28 @@ main() {
     commit_changes "$new_version"
     echo
 
-    create_tag "$new_version"
-    echo
-
     push_changes "$new_version"
     echo
 
-    # Only create GitHub release for non-prerelease versions
-    if is_prerelease "$new_version"; then
-        print_status "Skipping GitHub release creation for prerelease version"
+    # Capture the SHA of the just-pushed release commit so the operator can
+    # pin it when triggering the Buildkite publish build (avoids drift if
+    # trunk moves between this push and the build trigger).
+    local pushed_sha
+    if [ "$DRY_RUN" = "true" ]; then
+        pushed_sha="<sha-of-pushed-commit>"
     else
-        create_github_release "$new_version"
+        pushed_sha=$(git rev-parse HEAD)
     fi
-    echo
 
     # Summary
-    print_success "Release process completed successfully!"
+    print_success "Version bump completed successfully!"
     print_status "Version: $current_version -> $new_version"
 
     if [ "$DRY_RUN" = "true" ]; then
         print_warning "This was a dry run. No actual changes were made."
         print_status "To perform the actual release, run: make release VERSION_TYPE=$version_type"
     else
-        if is_prerelease "$new_version"; then
-            print_status "Prerelease tag v$new_version has been created and pushed."
-            print_status "No GitHub release was created for this prerelease version."
-        else
-            print_status "The release is ready for integration into the WordPress app."
-        fi
+        print_publish_instructions "$new_version" "$pushed_sha"
     fi
 }
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -265,9 +265,14 @@ print_publish_instructions() {
     local version=$1
     local sha=$2
     local tag="v$version"
+    local prefix=""
+
+    if [ "$DRY_RUN" = "true" ]; then
+        prefix="[DRY RUN] "
+    fi
 
     echo
-    print_status "Next: trigger the Buildkite publish build."
+    print_status "${prefix}Next: trigger the Buildkite publish build."
     echo
     echo "  1. Open https://buildkite.com/automattic/gutenbergkit/builds/new"
     echo "  2. Branch: trunk"
@@ -380,9 +385,9 @@ main() {
     if [ "$DRY_RUN" = "true" ]; then
         print_warning "This was a dry run. No actual changes were made."
         print_status "To perform the actual release, run: make release VERSION_TYPE=$version_type"
-    else
-        print_publish_instructions "$new_version" "$pushed_sha"
     fi
+
+    print_publish_instructions "$new_version" "$pushed_sha"
 }
 
 # Run main function with all arguments

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -64,22 +64,18 @@ The build runs a `:white_check_mark: Validate Swift release` step early on (gate
 
 1. Rewrites `Package.swift` to consume the binary target via `.release(version:, checksum:)`
 1. Uploads the XCFramework to `s3://a8c-apps-public-artifacts/gutenbergkit/vX.Y.Z/`
-1. Commits the rewrite on a `release-staging/vX.Y.Z` branch, pushes it to origin
-1. Creates the GitHub Release **as a draft**, uploading the XCFramework + checksum as assets — at this point no tag exists yet
-1. Flips the release out of draft state, which atomically creates the `vX.Y.Z` tag pointing at the staging-branch commit
-1. Deletes the staging branch (best-effort)
+1. Commits the rewrite on a local `release/vX.Y.Z` branch (never pushed to origin), tags `vX.Y.Z`, and pushes **only the tag** — `git push <tag>` carries the commit along with the tag ref, so the commit becomes reachable on origin via the tag alone
+1. Creates the GitHub Release against the now-existing tag, uploading the XCFramework + checksum as assets (adds `--prerelease` when the version contains `-`)
 
-The two-phase publish means the tag is the last thing created. If anything fails before the draft is flipped — S3 upload, asset upload, staging push — no tag exists and consumers see nothing.
+The tag is pushed before the GitHub Release is created. Once the tag is on origin, SPM consumers pinning `vX.Y.Z` can resolve a `Package.swift` that fetches the prebuilt XCFramework from CDN — the GH Release is metadata and an asset mirror on top of that.
 
-The tag's commit lives off `trunk`'s history (parented on `trunk` but only reachable via the tag), so SPM consumers pinning `vX.Y.Z` resolve a `Package.swift` that fetches the prebuilt XCFramework from CDN rather than rebuilding from local sources.
+The tag's commit lives off `trunk`'s history (parented on `trunk` but only reachable via the tag ref), matching the `pr-build/<n>` snapshot-branch shape but published under a tag instead of a branch.
 
 ### Recovering from a partial publish
 
-The flow is designed so that the tag's existence is the only signal of completion: if `vX.Y.Z` exists, the release is real.
+If the build fails before the tag is pushed (validate, Package.swift rewrite, S3 upload, or local commit/tag), no tag exists and no consumer can resolve `vX.Y.Z`. Re-run Step 2 with the same `NEW_VERSION` once the underlying issue is fixed — `validate` will pass (no tag, no release), and S3 uploads are idempotent (`if_exists: :replace`).
 
-If the build fails before the draft-flip step, no tag was created and no consumer can resolve `vX.Y.Z`. Re-run Step 2 with the same `NEW_VERSION` once the underlying issue is fixed — `validate` will pass (no tag, no release), and S3 uploads are idempotent (`if_exists: :replace`). You may need to manually delete the leftover draft release in the GitHub UI before re-running.
-
-If the build fails specifically on the cleanup step (`git push origin --delete release-staging/vX.Y.Z`), the release is fine — the tag exists and is valid — but the staging branch is left behind. Delete it manually with `git push origin --delete release-staging/vX.Y.Z`.
+If the build fails specifically on `gh release create` (tag pushed, but GH Release missing), the tag is the source of truth: SPM consumers resolving `vX.Y.Z` already work. To create the missing Release page, re-run `gh release create vX.Y.Z --title vX.Y.Z --generate-notes [--prerelease] <xcframework.zip> <checksum.txt>` manually against the existing tag — re-running the full Buildkite step would fail at `validate` because the tag now exists.
 
 ## Release Notes
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,6 +1,19 @@
 # GutenbergKit Release Process
 
-Use the provided release script to automate the entire process:
+## How publishing works
+
+Every push to `trunk` publishes both platforms automatically:
+
+-   **Android**: the `:android: Publish Android Library` step pushes a Maven artifact keyed by the commit (consumable via Git revision pins).
+-   **iOS**: the `:s3: Publish XCFramework to S3` step uploads the signed XCFramework under `gutenbergkit/<commit-sha>/`, and `Publish PR XCFramework` does the same on PR builds under a `pr-build/<n>` snapshot branch.
+
+A **tagged release** is a separate, manually-triggered publish flow on top of that: it produces a stable `vX.Y.Z` tag whose `Package.swift` points at the prebuilt XCFramework on CDN, plus a GitHub Release with the XCFramework attached. SPM consumers pin the tag; everything else can pin a commit/branch.
+
+The tagged release happens in two steps: a local script bumps the version on `trunk`, then a CI build creates the tag and the GitHub release.
+
+## Step 1 — Bump versions on trunk
+
+Run the release script:
 
 ```bash
 # Standard version increments
@@ -31,13 +44,42 @@ The script:
 1. Ensures required dependencies are installed
 1. Increments the version number[^1]
 1. Builds the project[^2]
-1. Commits changes
-1. Creates a Git tag
-1. Pushes to `origin/trunk` with tags
-1. Creates a GitHub release
-1. Creates a new release on GitHub: `gh release create vX.X.X --generate-notes --title "X.X.X"`
+1. Commits the version bump as `chore(release): X.Y.Z`
+1. Pushes to `origin/trunk`
 
-After the release is created, it is ready for integration into the WordPress app.
+It does **not** create the git tag or the GitHub release — that's Step 2.
+
+## Step 2 — Publish via Buildkite
+
+Step 1 prints the SHA of the version-bump commit it just pushed. Trigger a new Buildkite build with that SHA pinned:
+
+1. Open <https://buildkite.com/automattic/gutenbergkit/builds/new>
+2. **Branch**: `trunk`
+3. **Commit**: the SHA printed by Step 1
+4. **Environment Variables**: `NEW_VERSION=vX.Y.Z`
+
+Pinning the commit matters — if you leave it blank, Buildkite resolves `trunk` to HEAD at trigger time, and a concurrent merge would tag the wrong commit.
+
+The build runs a `:white_check_mark: Validate Swift release` step early on (gated on `NEW_VERSION`) that fast-fails if the tag name is malformed, or if the tag or GitHub Release already exists. After that, the `:rocket: Publish Swift release` step:
+
+1. Rewrites `Package.swift` to consume the binary target via `.release(version:, checksum:)`
+1. Uploads the XCFramework to `s3://a8c-apps-public-artifacts/gutenbergkit/vX.Y.Z/`
+1. Commits the rewrite on a `release-staging/vX.Y.Z` branch, pushes it to origin
+1. Creates the GitHub Release **as a draft**, uploading the XCFramework + checksum as assets — at this point no tag exists yet
+1. Flips the release out of draft state, which atomically creates the `vX.Y.Z` tag pointing at the staging-branch commit
+1. Deletes the staging branch (best-effort)
+
+The two-phase publish means the tag is the last thing created. If anything fails before the draft is flipped — S3 upload, asset upload, staging push — no tag exists and consumers see nothing.
+
+The tag's commit lives off `trunk`'s history (parented on `trunk` but only reachable via the tag), so SPM consumers pinning `vX.Y.Z` resolve a `Package.swift` that fetches the prebuilt XCFramework from CDN rather than rebuilding from local sources.
+
+### Recovering from a partial publish
+
+The flow is designed so that the tag's existence is the only signal of completion: if `vX.Y.Z` exists, the release is real.
+
+If the build fails before the draft-flip step, no tag was created and no consumer can resolve `vX.Y.Z`. Re-run Step 2 with the same `NEW_VERSION` once the underlying issue is fixed — `validate` will pass (no tag, no release), and S3 uploads are idempotent (`if_exists: :replace`). You may need to manually delete the leftover draft release in the GitHub UI before re-running.
+
+If the build fails specifically on the cleanup step (`git push origin --delete release-staging/vX.Y.Z`), the release is fine — the tag exists and is valid — but the staging branch is left behind. Delete it manually with `git push origin --delete release-staging/vX.Y.Z`.
 
 ## Release Notes
 

--- a/docs/wordpress-app-integration.md
+++ b/docs/wordpress-app-integration.md
@@ -31,9 +31,9 @@ Make sure the path points to your local GutenbergKit clone relative to your Word
 
 1. Copy `local-builds.gradle-example` to `local-builds.gradle`
 2. Uncomment the `localGutenbergKitPath` line and set it to your local GutenbergKit path:
-   ```groovy
-   localGutenbergKitPath = "../GutenbergKit"
-   ```
+    ```groovy
+    localGutenbergKitPath = "../GutenbergKit"
+    ```
 3. Run Gradle sync — this substitutes the Maven dependency with the local project
 
 ### Git Revision
@@ -72,7 +72,7 @@ CI (Buildkite) publishes builds for PRs to the Maven repository automatically.
 
 **Use case**: Integrating GutenbergKit work into WordPress app trunk before a formal release.
 
-Pre-releases create alpha version tags without creating a GitHub Release. They're useful for getting changes into the WordPress apps' main branches early.
+Pre-releases create alpha version tags with a GitHub Release marked `--prerelease`. They're useful for getting changes into the WordPress apps' main branches early.
 
 #### Creating a Pre-release
 
@@ -89,7 +89,7 @@ Available version types:
 -   `premajor` — increments major and adds alpha suffix (0.13.2 → 1.0.0-alpha.0)
 -   `prerelease` — increments the alpha number (0.13.3-alpha.0 → 0.13.3-alpha.1)
 
-This pushes a git tag (e.g., `v0.13.3-alpha.0`) and CI publishes the Android build to the Maven repository.
+Every trunk push already publishes per-commit artifacts (Android → Maven, iOS → S3 keyed by commit SHA). This bumps the version on `trunk` so the next per-commit publish carries that version, and the follow-up Buildkite build triggered with `NEW_VERSION=v0.13.3-alpha.0` adds the `vX.Y.Z` tag, the binary-target `Package.swift`, and the GitHub prerelease. See [Release Process](./releases.md) for the full flow.
 
 #### iOS
 
@@ -127,7 +127,7 @@ Available version types:
 -   `minor` — new features, backwards compatible (0.13.2 → 0.14.0)
 -   `major` — breaking changes (0.13.2 → 1.0.0)
 
-This creates a GitHub Release with auto-generated notes and CI publishes the Android build to the Maven repository.
+Every trunk push already publishes per-commit artifacts (Android → Maven, iOS → S3 keyed by commit SHA). This bumps the version on `trunk` so the next per-commit publish carries that version, and the follow-up Buildkite build triggered with `NEW_VERSION=v0.13.3` adds the `vX.Y.Z` tag, the binary-target `Package.swift`, and the GitHub Release. See [Release Process](./releases.md) for the full flow.
 
 #### iOS
 
@@ -147,12 +147,12 @@ gutenberg-kit = '0.13.3'
 
 ## Workflow Recommendations
 
-| Scenario                          | Recommended Method |
-| --------------------------------- | ------------------ |
-| Active feature development        | Local Development  |
-| PR review / testing               | Git Revision       |
-| Merging to WordPress app trunk    | Pre-release        |
-| WordPress app release             | Formal Release     |
+| Scenario                       | Recommended Method |
+| ------------------------------ | ------------------ |
+| Active feature development     | Local Development  |
+| PR review / testing            | Git Revision       |
+| Merging to WordPress app trunk | Pre-release        |
+| WordPress app release          | Formal Release     |
 
 ## Platform-Specific Notes
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -71,21 +71,32 @@ lane :publish_pr_xcframework do
   post_buildkite_annotation(body: body)
 end
 
+# CI orchestrator — invoked by `.buildkite/release.sh` when a build is
+# triggered with `NEW_VERSION` set. **Don't run this locally**: it pushes a
+# tag to origin, uploads to the public S3 bucket, and creates a real GitHub
+# Release. For local diagnosis, invoke `validate`, `update_swift_package`,
+# `publish_to_s3`, or `publish_release_to_github` individually.
 lane :release do |options|
   version = required_version!(options)
+  token = github_token!(options)
 
-  # Order matters: do every step that can fail BEFORE the tag is cut, so that
-  # if anything blows up the tag never gets created. Consumers only see the
-  # tag, so "tag exists" == "release is real and complete". The validate lane
-  # runs as an earlier Buildkite step (`validate-release`); it's intentionally
-  # not re-invoked here.
+  # Defense in depth: re-run validate so a misconfigured pipeline (e.g. a
+  # future edit that drops the `validate-release` dep) still fast-fails on
+  # bad input. Cheap no-op when the earlier Buildkite step already passed.
+  validate(version: version, github_token: token)
+
+  # Upload the XCFramework before the tag is pushed: the tag's `Package.swift`
+  # references the S3 URL, so consumers resolving the tag need the artifact
+  # already in place. If S3 upload fails, no tag exists and recovery is a
+  # clean re-run.
   update_swift_package(version: version)
   publish_to_s3(version: version)
-  publish_release_to_github(version: version)
+  publish_release_to_github(version: version, github_token: token)
 end
 
 lane :validate do |options|
   version = required_version!(options)
+  token = github_token!(options)
 
   UI.user_error!("Version #{version.inspect} is not a valid tag name (expected `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-PRERELEASE`).") \
     unless version =~ /\Av\d+\.\d+\.\d+(-.+)?\z/
@@ -93,11 +104,21 @@ lane :validate do |options|
   UI.user_error!("Tag #{version} already exists on the remote.") \
     if git_tag_exists(tag: version, remote: true, remote_name: 'origin')
 
-  UI.user_error!("Release #{version} already exists on GitHub.") \
-    unless get_github_release(url: GITHUB_REPO, version: version).nil?
+  release = get_github_release(url: GITHUB_REPO, version: version, api_token: token)
 
-  # `get_github_release` populates these lane-context values; clear them so a
-  # later action doesn't see stale state from this probe call.
+  # `get_github_release` returns nil for both "no such release" (200 with no
+  # matching tag in the response) AND for any API failure (401, 404, network,
+  # etc.). Check the status code populated in lane context to distinguish
+  # the two — otherwise an auth-misconfigured probe silently green-lights a
+  # publish.
+  status = lane_context[SharedValues::GITHUB_API_STATUS_CODE]
+  UI.user_error!("GitHub API returned status #{status.inspect} probing for release #{version}; cannot determine whether it exists.") \
+    unless status == 200
+
+  UI.user_error!("Release #{version} already exists on GitHub.") unless release.nil?
+
+  # Clear lane-context values populated by `get_github_release` so a later
+  # action doesn't see stale state from this probe call.
   remove_lane_context_values [
     SharedValues::GITHUB_API_RESPONSE,
     SharedValues::GITHUB_API_STATUS_CODE,
@@ -117,46 +138,35 @@ end
 
 lane :publish_release_to_github do |options|
   version = required_version!(options)
-  staging_branch = "release-staging/#{version}"
+  token = github_token!(options)
 
-  # Commit the rewritten Package.swift on a staging branch and push it.
-  # The branch only exists to make the commit reachable on origin so that
-  # `gh release create --target` can resolve it — we delete the branch at
-  # the end, leaving only the tag ref as the published handle on this
-  # commit (matches the `pr-build/<n>` snapshot-branch shape).
-  sh('git', 'checkout', '-B', staging_branch)
+  # Stage the rewritten Package.swift on a local branch — never pushed to
+  # origin — then tag the commit and push only the tag. `git push <tag>`
+  # uploads the commit along with the tag ref, so the tag's commit becomes
+  # reachable on origin via the tag alone (no branch required). Mirrors the
+  # wordpress-rs release flow.
+  sh('git', 'checkout', '-B', "release/#{version}")
   git_commit(
     path: File.join(PROJECT_ROOT, 'Package.swift'),
     message: "Update Package.swift to use version #{version}"
   )
-  sh('git', 'push', 'origin', staging_branch)
+  add_git_tag(tag: version)
+  push_git_tags(remote: 'origin', tag: version)
 
-  # Two-phase publish so the tag is the very last thing created:
-  #   1. Create the release as a draft — uploads the XCFramework + checksum
-  #      assets, but does NOT create the tag yet (GitHub semantics).
-  #   2. Flip `draft=false` — atomic with tag creation. Until this call
-  #      succeeds, no consumer can resolve `version`, so a failure in
-  #      step 1 (or anything earlier) leaves nothing for them to see.
-  create_args = ['gh', 'release', 'create', version,
-                 '--draft',
-                 '--title', version,
-                 '--generate-notes',
-                 '--target', staging_branch]
-  create_args << '--prerelease' if version.include?('-')
-  create_args.push(xcframework_file_path, xcframework_checksum_file_path)
-  sh(*create_args)
-
-  sh('gh', 'release', 'edit', version, '--draft=false')
-
-  # Cleanup is best-effort. The tag ref now holds the commit alive; the
-  # staging branch has done its job. If this fails (network blip), the
-  # branch is harmless — operators can `git push origin --delete` it
-  # later.
-  begin
-    sh('git', 'push', 'origin', '--delete', staging_branch)
-  rescue StandardError
-    UI.important("Failed to delete staging branch #{staging_branch}; clean up manually with `git push origin --delete #{staging_branch}`.")
-  end
+  # The tag is now live on origin and SPM consumers can resolve `version`
+  # against the prebuilt XCFramework already on S3. The GH Release page is
+  # metadata + an asset mirror — if this call fails the tag is unaffected
+  # and an operator can recreate the Release manually against the existing
+  # tag (see docs/releases.md).
+  set_github_release(
+    api_token: token,
+    repository_name: GITHUB_REPO,
+    name: version,
+    tag_name: version,
+    is_generate_release_notes: true,
+    is_prerelease: version.include?('-'),
+    upload_assets: [xcframework_file_path, xcframework_checksum_file_path]
+  )
 end
 
 lane :xcframework_sign do
@@ -232,6 +242,12 @@ def required_version!(options)
   version = options[:version].to_s
   UI.user_error!('version is required') if version.empty?
   version
+end
+
+def github_token!(options = {})
+  options[:github_token] || ENV.fetch('GITHUB_TOKEN') do
+    UI.user_error!('GITHUB_TOKEN must be set in the environment (or pass `github_token:` to the lane).')
+  end
 end
 
 def require_env_vars!(*keys)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -71,6 +71,94 @@ lane :publish_pr_xcframework do
   post_buildkite_annotation(body: body)
 end
 
+lane :release do |options|
+  version = required_version!(options)
+
+  # Order matters: do every step that can fail BEFORE the tag is cut, so that
+  # if anything blows up the tag never gets created. Consumers only see the
+  # tag, so "tag exists" == "release is real and complete". The validate lane
+  # runs as an earlier Buildkite step (`validate-release`); it's intentionally
+  # not re-invoked here.
+  update_swift_package(version: version)
+  publish_to_s3(version: version)
+  publish_release_to_github(version: version)
+end
+
+lane :validate do |options|
+  version = required_version!(options)
+
+  UI.user_error!("Version #{version.inspect} is not a valid tag name (expected `vMAJOR.MINOR.PATCH` or `vMAJOR.MINOR.PATCH-PRERELEASE`).") \
+    unless version =~ /\Av\d+\.\d+\.\d+(-.+)?\z/
+
+  UI.user_error!("Tag #{version} already exists on the remote.") \
+    if git_tag_exists(tag: version, remote: true, remote_name: 'origin')
+
+  UI.user_error!("Release #{version} already exists on GitHub.") \
+    unless get_github_release(url: GITHUB_REPO, version: version).nil?
+
+  # `get_github_release` populates these lane-context values; clear them so a
+  # later action doesn't see stale state from this probe call.
+  remove_lane_context_values [
+    SharedValues::GITHUB_API_RESPONSE,
+    SharedValues::GITHUB_API_STATUS_CODE,
+    SharedValues::GITHUB_API_JSON
+  ]
+end
+
+lane :update_swift_package do |options|
+  version = required_version!(options)
+
+  rewrite_resources_mode!(
+    File.join(PROJECT_ROOT, 'Package.swift'),
+    version: version,
+    checksum: xcframework_checksum
+  )
+end
+
+lane :publish_release_to_github do |options|
+  version = required_version!(options)
+  staging_branch = "release-staging/#{version}"
+
+  # Commit the rewritten Package.swift on a staging branch and push it.
+  # The branch only exists to make the commit reachable on origin so that
+  # `gh release create --target` can resolve it — we delete the branch at
+  # the end, leaving only the tag ref as the published handle on this
+  # commit (matches the `pr-build/<n>` snapshot-branch shape).
+  sh('git', 'checkout', '-B', staging_branch)
+  git_commit(
+    path: File.join(PROJECT_ROOT, 'Package.swift'),
+    message: "Update Package.swift to use version #{version}"
+  )
+  sh('git', 'push', 'origin', staging_branch)
+
+  # Two-phase publish so the tag is the very last thing created:
+  #   1. Create the release as a draft — uploads the XCFramework + checksum
+  #      assets, but does NOT create the tag yet (GitHub semantics).
+  #   2. Flip `draft=false` — atomic with tag creation. Until this call
+  #      succeeds, no consumer can resolve `version`, so a failure in
+  #      step 1 (or anything earlier) leaves nothing for them to see.
+  create_args = ['gh', 'release', 'create', version,
+                 '--draft',
+                 '--title', version,
+                 '--generate-notes',
+                 '--target', staging_branch]
+  create_args << '--prerelease' if version.include?('-')
+  create_args.push(xcframework_file_path, xcframework_checksum_file_path)
+  sh(*create_args)
+
+  sh('gh', 'release', 'edit', version, '--draft=false')
+
+  # Cleanup is best-effort. The tag ref now holds the commit alive; the
+  # staging branch has done its job. If this fails (network blip), the
+  # branch is harmless — operators can `git push origin --delete` it
+  # later.
+  begin
+    sh('git', 'push', 'origin', '--delete', staging_branch)
+  rescue StandardError
+    UI.important("Failed to delete staging branch #{staging_branch}; clean up manually with `git push origin --delete #{staging_branch}`.")
+  end
+end
+
 lane :xcframework_sign do
   sh(
     'codesign',


### PR DESCRIPTION
## Summary

- `bin/release.sh` stops at "bump versions on trunk and push" — no more `git tag`, no more `gh release create`.
- A new `:rocket: Publish Swift release $NEW_VERSION` Buildkite step, gated on `build.env("NEW_VERSION") != null`, takes over: builds + signs the XCFramework, uploads to S3, rewrites `Package.swift` to `.release(version:, checksum:)`, tags, and creates the GitHub Release.
- Mirrors the [wordpress-rs tag-release flow](https://github.com/Automattic/wordpress-rs/blob/trunk/fastlane/Fastfile) (`release`/`validate`/`update_swift_package`/`publish_release_to_github` lanes; tag's commit lives off `trunk`, only the tag ref is pushed).

There's a bit of awkward duplication/mess in this PR – once we can remove the committed JS/HTML files, we can delete a bunch of release code – I'll probably move most of it to Fastlane to align with our other projects, which will iron out a lot of the oddities this PR introduces (like pretending Android doesn't exist...). I wanted to keep this PR small and focused, which resulted in some oddities.

## Why

Tagged releases currently ship `Package.swift` in `.local` mode, so SPM consumers (WordPress-iOS pins `v0.15.0`) resolve the JS bundle from `ios/Sources/GutenbergKitResources/Gutenberg/` — which is why those 61 files are still committed despite [#495](https://github.com/wordpress-mobile/GutenbergKit/pull/495) wiring up XCFramework distribution for PR builds.

Once a tag's `Package.swift` points at the prebuilt XCFramework on CDN (this PR), and WordPress-iOS bumps to a tag cut under the new flow, the committed iOS bundle and the two commented-out lines at `.gitignore:200-202` can finally be dropped.

## How a release works after this

**Step 1 — local** (same as today, minus the tag/release):

\`\`\`bash
make release VERSION_TYPE=patch
\`\`\`

Bumps `package.json` / `GutenbergKitVersion.swift` / `GutenbergKitVersion.kt`, runs `make build`, commits as `chore(release): X.Y.Z`, pushes to `trunk`. Done. The script prints the SHA of the commit it just pushed — pin that SHA when triggering the Buildkite build below.

**Step 2 — Buildkite**:

1. Open <https://buildkite.com/automattic/gutenbergkit/builds/new>
2. **Branch**: `trunk`
3. **Commit**: the SHA printed by Step 1 (pin it — leaving it blank lets a concurrent merge tag the wrong commit)
4. **Environment Variables**: `NEW_VERSION=vX.Y.Z`

The build runs:

1. **`:white_check_mark: Validate Swift release`** — fast-fails on malformed tag names or if the tag/Release already exists. Tag check uses `git_tag_exists(remote: true)`; release check uses `get_github_release` with an explicit `api_token` and asserts the response was a real `200` (not a swallowed 401/404/network error). Runs early so a bad `NEW_VERSION` short-circuits before the XCFramework build.
2. **`:rocket: Publish Swift release`** — gated on `validate-release` + the XCFramework build + lint/test steps. The lane:
    1. Re-invokes `validate` as defense-in-depth — covers a future pipeline edit that drops the `validate-release` dependency. Cheap no-op when the earlier Buildkite step already passed.
    2. Rewrites `Package.swift` to `.release(version: "vX.Y.Z", checksum: ...)` (reusing the `rewrite_resources_mode!` helper from #495).
    3. Uploads the XCFramework to `s3://a8c-apps-public-artifacts/gutenbergkit/vX.Y.Z/`.
    4. Checks out a local `release/vX.Y.Z` branch, commits the rewrite, tags `vX.Y.Z`, and pushes **only the tag** via `push_git_tags`. `git push <tag>` carries the commit along with the tag ref, so the tag's commit becomes reachable on origin via the tag alone — no branch ref ever lives on remote.
    5. Calls `set_github_release` (release-toolkit action) against the just-pushed tag — auto-generated notes, marks as prerelease when the version contains `-`, uploads the XCFramework + checksum as assets. Authenticates with an explicit `GITHUB_TOKEN` so we don't depend on the agent's ambient `gh` auth.

The tag is pushed before the GH Release is created. Once the tag is on origin, SPM consumers can already resolve `vX.Y.Z` against the prebuilt XCFramework on CDN — the GH Release is metadata + an asset mirror on top of that. If `set_github_release` fails, the tag is unaffected and an operator can recreate the Release manually against the existing tag.

The tag's commit is parented on the release commit but unreachable from `trunk`'s history — same shape as the `pr-build/<n>` and (deferred) `trunk-build` snapshot branches, just published under a tag ref instead of a branch ref.

The `release` lane is the CI orchestrator — **don't run it locally**: it pushes the tag, uploads to the public S3 bucket, and creates a real GitHub Release. For local diagnosis, invoke `validate`, `update_swift_package`, `publish_to_s3`, or `publish_release_to_github` individually.

### Tag-triggered builds (Android still relies on these)

Pushing the tag triggers a separate Buildkite build (the pipeline has "Build tags" enabled). For Android, that build is still load-bearing — `prepareToPublishToS3` resolves the version to `vX.Y.Z` from `--tag-name` and produces the canonical `vX.Y.Z` Maven artifact (the trunk branch-build only produces `trunk-<sha>`). The plugin hard-fails if the version is already published, so the trunk vs. tag builds aren't competing.

For iOS, the rocket step already uploads to `gutenbergkit/vX.Y.Z/`, so the tag-build's `:s3:` would just re-upload the same bytes. This PR adds `&& build.tag == null` to the `:s3:` gate to skip it on tag builds. A cleaner future refactor would move Android publish into the rocket step too, then "Build tags" can be turned off entirely — out of scope here.

## Changes

### Fastfile

- **`fastlane/Fastfile`**: Four new lanes — `release` (orchestrator: validate → rewrite → S3 → tag/Release), `validate`, `update_swift_package`, `publish_release_to_github`. The orchestrator re-invokes `validate` at the top so a future pipeline edit dropping the `validate-release` dep can't silently bypass validation. GitHub API calls (`get_github_release`, `set_github_release`) take an explicit `api_token` resolved from `ENV['GITHUB_TOKEN']` — no reliance on `gh` CLI auth (the `use-bot-for-git` script only sets `GIT_SSH_COMMAND`). `validate` checks `lane_context[GITHUB_API_STATUS_CODE]` after the release probe so a swallowed 401/404 doesn't silently green-light the publish. Reuses the existing `rewrite_resources_mode!`, `required_version!`, `xcframework_checksum`, `xcframework_file_path` helpers added in #495.

### Pipeline

- **`.buildkite/pipeline.yml`**: New `:white_check_mark: Validate Swift release` step (gated on `NEW_VERSION`) and `:rocket: Publish Swift release $NEW_VERSION` step (gated on `NEW_VERSION` + trunk + non-PR), with the rocket step depending on validate plus the XCFramework build, swift package tests, lint, JS tests, and the iOS/web E2E suites. Existing `:s3: Publish XCFramework to S3` step now also gated on `NEW_VERSION == null && build.tag == null` so the rocket step owns the `vX.Y.Z/` namespace and the tag-triggered re-build doesn't re-upload the same iOS artifact. Version arg simplified from `${BUILDKITE_TAG:-$BUILDKITE_COMMIT}` to `$BUILDKITE_COMMIT` since the step now never runs on a tag build.
- **`.buildkite/release.sh`** (new): Sources `use-bot-for-git`, downloads the xcframework + checksum artifacts from `build-xcframework`, runs `bundle exec fastlane release version:$NEW_VERSION`. `GITHUB_TOKEN` for the API calls comes from the agent environment.

### Release script

- **`bin/release.sh`**: Dropped `create_tag`, `create_github_release`, `is_prerelease` (unused), and the `gh` dependency check. Push is now `git push origin trunk` (no `--tags`). New `print_publish_instructions` prints the Buildkite trigger steps and the just-pushed SHA after the trunk push. `--dry-run` now prints the same instructions with a `[DRY RUN]` prefix so the operator gets a full preview of a real run.

### Behavior change: prereleases now get a GitHub Release

Previously, `bin/release.sh` skipped `gh release create` for prereleases (anything with a `-` suffix) — the tag was pushed but no GH Release existed. The new `:rocket:` flow **does** create a GH Release for prereleases, marked as prerelease. This is intentional: every tag now has a corresponding Release page with the XCFramework + checksum attached, and consumers who previously pinned prerelease tags via Git revision can keep doing so.

### Docs

- **`docs/releases.md`**: Rewrote into a Step 1 / Step 2 flow with a recovering-from-partial-publish section.
- **`docs/wordpress-app-integration.md`**: Updated two stale "make release creates the tag/GH release" lines.

## Test plan

Most of this can only be exercised end-to-end by cutting an actual release, so most of this would have to be tested post-merge.

### Local validation (no CI run required)

Exercised locally against the PR branch:

- [x] Shell syntax: `bash -n` on `release.sh`, `bin/release.sh`, `publish-pr-xcframework.sh`.
- [x] Fastfile Ruby syntax: `ruby -c fastlane/Fastfile`.
- [x] `pipeline.yml` YAML parses; every `depends_on` reference resolves to a declared `key:`.
- [x] Version regex `/\Av\d+\.\d+\.\d+(-.+)?\z/` — 15 cases (valid `vX.Y.Z`, `vX.Y.Z-prerelease`; rejects bare `0.15.0`, `v0.15`, `v0.15.0.1`, trailing whitespace, trailing `-`).
- [x] `rewrite_resources_mode!` against a copy of `Package.swift` — correct rewrite, idempotent re-rewrite, errors on zero / multiple matches.
- [x] Read-only validate-lane probes: `git ls-remote --tags origin <tag>` and `gh release view <tag>` against `v0.15.0` (exists) and `v999.999.999` (doesn't) — both distinguish correctly.
- [x] `bin/release.sh patch --dry-run` in a throwaway worktree on `trunk` — new flow runs end-to-end: pre-flight → version bump → build → commit → `git push origin trunk` (no `--tags`) → "Version bump completed successfully!" with the new `[DRY RUN]`-prefixed Buildkite trigger instructions. Old `Creating git tag` / `Creating GitHub release` steps confirmed gone.
- [x] `:rocket:` step `if:` gating walked through 6 scenarios in Ruby — trunk + `NEW_VERSION` triggers; PR + `NEW_VERSION` blocked; stale branch + `NEW_VERSION` blocked.

### Pipeline-only checks (pre-merge, require a CI run)

- [ ] A regular trunk push (no `NEW_VERSION`) hits the existing `:s3:` step and uploads under `gutenbergkit/<commit-sha>/`, same as today.
- [ ] A regular trunk push does **not** trigger the new `:rocket:` step.
- [ ] A PR push hits `Publish PR XCFramework`, not the new `:rocket:` step.

### Release dry-run (against a throwaway version)

- [ ] Kick off a Buildkite build on `trunk` with `NEW_VERSION=v0.0.0-test.0`. Confirm:
  - [ ] `:white_check_mark: Validate Swift release v0.0.0-test.0` step runs and passes.
  - [ ] `:rocket: Publish Swift release v0.0.0-test.0` step runs.
  - [ ] S3 has the xcframework at `gutenbergkit/v0.0.0-test.0/`.
  - [ ] Tag `v0.0.0-test.0` is created on the remote.
  - [ ] The tag's `Package.swift:9` reads `.release(version: "v0.0.0-test.0", checksum: ...)`.
  - [ ] GH Release `v0.0.0-test.0` is created, marked as prerelease, with the xcframework + checksum attached as assets.
  - [ ] No `release/v0.0.0-test.0` branch (or any other branch) is pushed to the remote — only the tag ref.
  - [ ] The existing `:s3:` step is skipped on the same build.
- [ ] **Tag-triggered follow-up build**: confirm the auto-triggered build on the new tag skips `:s3:` (gated out by `build.tag == null`) but still runs `:android: Publish Android Library` and produces the `v0.0.0-test.0` Maven artifact. This is the regression test for the new tag-gate.
- [ ] Pull the tag into a scratch SPM consumer. `swift package resolve` downloads the binary artifact from CDN; checksum validates.
- [ ] Re-run the same Buildkite build → `validate` lane fails fast because the tag already exists.
- [ ] Re-run with a deliberately broken `GITHUB_TOKEN` → `validate` errors out with the "GitHub API returned status … cannot determine whether it exists" message rather than silently passing.

### Cleanup after dry-run

- [ ] Delete the test tag, GH Release, and S3 artifacts.

## Related

- Builds on [#495](https://github.com/wordpress-mobile/GutenbergKit/pull/495).
- Mirrors [Automattic/wordpress-rs](https://github.com/Automattic/wordpress-rs)'s `release`/`validate`/`update_swift_package`/`publish_release_to_github` lanes.