### PR TITLE
feat(android): add photo-permission rationale and recent-photos strip

### DIFF
--- a/android/Gutenberg/src/main/AndroidManifest.xml
+++ b/android/Gutenberg/src/main/AndroidManifest.xml
@@ -3,6 +3,25 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- Used by the block inserter media strip to preview recent device photos.
+         Inherited in the merged manifest, so it shows up in the host's Play
+         Store data-safety disclosure. Hosts that don't render the inserter or
+         already declare these permissions for their own media flows can opt
+         out via the manifest merger:
+
+             <uses-permission
+                 android:name="android.permission.READ_MEDIA_IMAGES"
+                 tools:node="remove" />
+             <uses-permission
+                 android:name="android.permission.READ_EXTERNAL_STORAGE"
+                 tools:node="remove" />
+
+         See docs/integration.md (Android → Manifest Permissions) for details. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
     <application>
         <!-- Exposes a writeable temp-file URI to the camera app so captures can
              come back to us without the host app having to configure its own

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -37,6 +37,8 @@ import kotlinx.coroutines.launch
 import org.json.JSONException
 import org.json.JSONObject
 import org.wordpress.gutenberg.inserter.BlockPickerDialog
+import org.wordpress.gutenberg.inserter.clearPhotoPreferences
+import org.wordpress.gutenberg.inserter.warmupPhotoPrefs
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
@@ -218,6 +220,12 @@ class GutenbergView : FrameLayout {
     constructor(configuration: EditorConfiguration, dependencies: EditorDependencies?, coroutineScope: CoroutineScope, context: Context) : super(context) {
         this.configuration = configuration
         this.coroutineScope = coroutineScope
+
+        // Warm the block-inserter's photo-prefs cache off the main thread now,
+        // well before the user can navigate to the inserter. By the time they
+        // tap `+`, the prefs read in `MediaStrip` is synchronous from the
+        // process-wide cache — no async-load placeholder, no visible flash.
+        warmupPhotoPrefs(context)
 
         // Initialize the asset loader now that context is available
         assetLoader = WebViewAssetLoader.Builder()
@@ -1090,6 +1098,20 @@ class GutenbergView : FrameLayout {
     }
 
     companion object {
+        /**
+         * Clears the block inserter's photo-library preferences (rationale
+         * rejection + first-prompt tracking). Call from a host-app settings
+         * screen if you want users to re-see the rationale after dismissing it.
+         *
+         * The OS-level photo permission itself is not affected — only the
+         * in-app flags. The library's media permissions are declared in the
+         * library's manifest and inherited via manifest merging; see
+         * docs/integration.md (Android → Manifest Permissions) for the opt-out.
+         */
+        fun resetBlockPickerPhotoPreferences(context: Context) {
+            clearPhotoPreferences(context)
+        }
+
         /** Hosts that are safe to serve assets over HTTP (local development only). */
         private val LOCAL_HOSTS = setOf("localhost", "127.0.0.1", "10.0.2.2")
 

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import android.os.Build
 import android.util.Log
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -15,6 +16,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,6 +33,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -47,6 +51,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -62,14 +67,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -99,7 +106,9 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import java.io.File
 import kotlin.math.roundToInt
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.wordpress.gutenberg.R
 import androidx.compose.ui.graphics.Color as ComposeColor
 import org.wordpress.gutenberg.model.BlockInserterPayload
@@ -133,14 +142,30 @@ private const val HEADER_TITLE_LETTER_SPACING_SP = -0.1
 private const val ICON_BUTTON_SIZE_DP = 40
 private const val ICON_SIZE_DP = 20
 
-private const val MEDIA_STRIP_HORIZONTAL_PAD_DP = 20
-private const val MEDIA_STRIP_TOP_PAD_DP = 6
-private const val MEDIA_STRIP_BOTTOM_PAD_DP = 16
+private const val MEDIA_STRIP_TOP_PAD_DP = 4
+private const val MEDIA_STRIP_BOTTOM_PAD_DP = 10
+private const val MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP = 20
+private const val MEDIA_STRIP_CONTENT_TOP_PAD_DP = 2
+private const val MEDIA_STRIP_CONTENT_BOTTOM_PAD_DP = 6
+private const val MEDIA_STRIP_ITEM_GAP_DP = 8
+private const val MEDIA_STACK_WIDTH_DP = 72
+private const val MEDIA_STACK_HEIGHT_DP = 136
 private const val MEDIA_STACK_COMPACT_HEIGHT_DP = 88
 private const val MEDIA_STACK_GAP_DP = 4
 private const val MEDIA_STACK_CORNER_DP = 18
 private const val MEDIA_STACK_ICON_SIZE_DP = 28
 private const val MEDIA_STACK_LABEL_SP = 13
+private const val MEDIA_THUMB_SIZE_DP = 64
+private const val MEDIA_THUMB_CORNER_DP = 16
+private const val RECENT_PHOTO_LIMIT = 64
+
+private const val MEDIA_RATIONALE_PAD_DP = 14
+private const val MEDIA_RATIONALE_FONT_SP = 13
+private const val MEDIA_RATIONALE_LINE_HEIGHT_SP = 18
+private const val MEDIA_RATIONALE_BUTTON_GAP_DP = 6
+private const val MEDIA_RATIONALE_BUTTON_HEIGHT_DP = 32
+private const val MEDIA_RATIONALE_BUTTON_CORNER_DP = 16
+private const val MEDIA_RATIONALE_BUTTON_FONT_SP = 12
 
 // Matches M3's internal `Tab.HorizontalTextPadding` — the horizontal padding
 // applied by `Tab` between its layout bounds and the text label inside.
@@ -180,10 +205,17 @@ private const val EMPTY_STATE_FONT_SP = 14
 private const val DISABLED_ALPHA = 0.5f
 
 /**
+ * Material 3 minimum touch-target. The rationale buttons sit below this for
+ * design reasons; we wrap them in an outer clickable that meets the minimum
+ * without changing the visual size.
+ */
+private const val TOUCH_TARGET_MIN_DP = 48
+
+/**
  * Bottom-sheet block inserter. The outer shell stays a `BottomSheetDialog` so
  * `GutenbergView`'s integration surface is unchanged; everything visible is
- * Compose content matching the Variation B design handoff — header row,
- * scrollable secondary tabs, rounded search, 5-column tonal tile grid.
+ * Compose content matching the Variation B design handoff — header row, recent
+ * media strip, scrollable secondary tabs, rounded search, 5-column tonal tile grid.
  *
  * The sheet background and 28dp top corners are drawn by Compose directly; the
  * dialog's default white pill background is cleared so it doesn't fight the
@@ -196,6 +228,18 @@ internal class BlockPickerDialog(
 ) : BottomSheetDialog(context) {
 
     init {
+        // `STATE_HIDDEN` dismisses any in-flight soft keyboard on dialog open
+        // — without it the sheet renders compressed above the editor's IME and
+        // then visibly resizes when the IME dismisses, looking like a "double
+        // launch". `ADJUST_RESIZE` lets the sheet shrink back to make room when
+        // the user later taps the search field; previously we paired
+        // `STATE_HIDDEN` with `ADJUST_NOTHING`, which fixed the open-time race
+        // but latched in for the dialog's lifetime — the IME then covered the
+        // search field and the results grid below it.
+        window?.setSoftInputMode(
+            WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN or
+                WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+        )
         val composeView = ComposeView(context).apply {
             setContent {
                 BlockPickerSheet(
@@ -426,12 +470,146 @@ private fun CloseButton(onClose: () -> Unit) {
     }
 }
 
-// Photos and Camera tiles. Photos uses the permissionless system photo picker;
-// Camera uses ACTION_IMAGE_CAPTURE against a cache-scoped FileProvider URI.
-// Neither requires READ_MEDIA_IMAGES — the recent-photos thumbnail strip that
-// needs it lands in a follow-up and will sit alongside this row.
 @Composable
+@Suppress("LongMethod")
 private fun MediaStrip() {
+    val contentPadding = PaddingValues(
+        start = MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP.dp,
+        end = MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP.dp,
+        top = MEDIA_STRIP_CONTENT_TOP_PAD_DP.dp,
+        bottom = MEDIA_STRIP_CONTENT_BOTTOM_PAD_DP.dp,
+    )
+    val stripFraming = Modifier
+        .fillMaxWidth()
+        .padding(top = MEDIA_STRIP_TOP_PAD_DP.dp, bottom = MEDIA_STRIP_BOTTOM_PAD_DP.dp)
+    // Pre-Q (Android 7-9, API 24-28): `ContentResolver.loadThumbnail` is
+    // API 29+ and we don't ship a `BitmapFactory.decodeStream` fallback —
+    // full-resolution decodes on the slowest hardware in our minSdk range
+    // would be worse UX than not showing the strip. Skip the permission
+    // prompt entirely and render only the permissionless Photos/Camera
+    // tiles. The user gets a working media-insert path (system picker +
+    // camera) and we don't burn their trust asking for a permission we
+    // can't deliver on.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        Box(modifier = stripFraming) {
+            PhotosCameraTile(
+                horizontal = true,
+                modifier = Modifier.fillMaxWidth().padding(contentPadding),
+            )
+        }
+        return
+    }
+    val context = LocalContext.current
+    // SharedPreferences are read async on `Dispatchers.IO` to keep the main
+    // thread IO-free. While loading we render a same-height placeholder so
+    // the strip's vertical rhythm doesn't shift when the real state arrives
+    // a few ms later. After process-warmup (cache hot) this returns
+    // synchronously and no placeholder shows.
+    val prefs = rememberPhotoPrefs(context)
+    if (prefs == null) {
+        Box(modifier = stripFraming.height(MEDIA_STACK_HEIGHT_DP.dp))
+        return
+    }
+    val access = rememberPhotoAccess(
+        limit = RECENT_PHOTO_LIMIT,
+        initialPromptedBefore = prefs.promptedBefore,
+    )
+    var rejected by remember(prefs) { mutableStateOf(prefs.rejected) }
+    // Clear a prior rejection once the user actually grants the permission.
+    // Without this, a later revocation would leave the user in CompactTiles
+    // with no in-app path back to the rationale.
+    LaunchedEffect(access) {
+        if (access is PhotoAccess.Granted && rejected) {
+            clearRejectedRationale(context)
+            rejected = false
+        }
+    }
+    Box(modifier = stripFraming) {
+        when (resolveMediaStripView(access, rejected)) {
+            MediaStripView.Rationale -> {
+                val needs = access as PhotoAccess.NeedsPermission
+                // Rationale fills the remaining width next to the Photos/Camera
+                // column — no horizontal scroll needed since nothing extends past
+                // the viewport.
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp),
+                    modifier = Modifier.fillMaxWidth().padding(contentPadding),
+                ) {
+                    PhotosCameraTile(horizontal = false)
+                    PhotoAccessRationale(
+                        state = needs.state,
+                        onAllow = needs.request,
+                        onReject = {
+                            markRationaleRejected(context)
+                            rejected = true
+                        },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+            MediaStripView.CompactTiles -> {
+                // Rationale dismissed — keep the Photos/Camera buttons accessible
+                // but flatten them into a single full-width row. Picker and camera
+                // don't need the photo permission; only the recent-photo strip does.
+                PhotosCameraTile(
+                    horizontal = true,
+                    modifier = Modifier.fillMaxWidth().padding(contentPadding),
+                )
+            }
+            MediaStripView.FullStrip -> FullMediaStrip(
+                granted = access as? PhotoAccess.Granted,
+                contentPadding = contentPadding,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FullMediaStrip(granted: PhotoAccess.Granted?, contentPadding: PaddingValues) {
+    // Granted — thumbnail strip extends past the viewport. LazyRow composes
+    // only the visible columns (plus prefetch), so the 64 thumbnails aren't
+    // all decoded into memory upfront. Vertical drags pass through the lazy
+    // list's nested-scroll dispatch up to BottomSheetBehavior; no manual
+    // relay needed.
+    //
+    // When a thumbnail fails to load (deleted-mid-scroll URI, partial-grant
+    // denial, OEM MediaStore quirk, offline + cloud-only stub) we drop the
+    // URI from the displayed set. The strip shrinks gracefully — better
+    // than stranding a grey placeholder where a real thumbnail should be.
+    val sourceUris = granted?.uris.orEmpty()
+    var failed by remember(granted) { mutableStateOf<Set<Uri>>(emptySet()) }
+    val uris = sourceUris.filterNot { it in failed }
+    val columns = (uris.size + 1) / 2
+    val onThumbnailFailed: (Uri) -> Unit = { failed = failed + it }
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp),
+        contentPadding = contentPadding,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        item(key = "actions") { PhotosCameraTile(horizontal = false) }
+        items(columns, key = { uris[it * 2].toString() }) { col ->
+            Column(verticalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp)) {
+                RealThumbnail(uri = uris[col * 2], onLoadFailed = onThumbnailFailed)
+                val secondIndex = col * 2 + 1
+                if (secondIndex < uris.size) {
+                    RealThumbnail(uri = uris[secondIndex], onLoadFailed = onThumbnailFailed)
+                }
+            }
+        }
+    }
+}
+
+// Photos uses the permissionless system photo picker; Camera uses
+// ACTION_IMAGE_CAPTURE against a cache-scoped FileProvider URI — no CAMERA
+// permission required since we delegate to the system camera app. The
+// recent-photos strip (READ_MEDIA_IMAGES-gated) sits alongside this row when
+// granted; otherwise this tile pair is the only media affordance.
+@Composable
+@Suppress("LongMethod")
+private fun PhotosCameraTile(
+    horizontal: Boolean,
+    modifier: Modifier = Modifier,
+) {
     val context = LocalContext.current
     // Hide the Camera tile on devices without any camera hardware (tablets,
     // emulators, e-readers). FEATURE_CAMERA_ANY doesn't require a `<queries>`
@@ -472,35 +650,57 @@ private fun MediaStrip() {
             Toast.makeText(context, cameraUnavailableMessage, Toast.LENGTH_SHORT).show()
         }
     }
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(MEDIA_STACK_GAP_DP.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(
-                start = MEDIA_STRIP_HORIZONTAL_PAD_DP.dp,
-                end = MEDIA_STRIP_HORIZONTAL_PAD_DP.dp,
-                top = MEDIA_STRIP_TOP_PAD_DP.dp,
-                bottom = MEDIA_STRIP_BOTTOM_PAD_DP.dp,
-            )
-            .height(MEDIA_STACK_COMPACT_HEIGHT_DP.dp),
-    ) {
-        MediaActionTile(
-            icon = Icons.Filled.PhotoLibrary,
-            label = stringResource(R.string.gbk_block_inserter_photos),
-            background = MaterialTheme.colorScheme.primaryContainer,
-            foreground = MaterialTheme.colorScheme.onPrimaryContainer,
-            onClick = onPhotosClick,
-            modifier = Modifier.fillMaxHeight().weight(1f),
-        )
-        if (hasCamera) {
+    val photosLabel = stringResource(R.string.gbk_block_inserter_photos)
+    val cameraLabel = stringResource(R.string.gbk_block_inserter_camera)
+    if (horizontal) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(MEDIA_STACK_GAP_DP.dp),
+            modifier = modifier.height(MEDIA_STACK_COMPACT_HEIGHT_DP.dp),
+        ) {
             MediaActionTile(
-                icon = Icons.Filled.PhotoCamera,
-                label = stringResource(R.string.gbk_block_inserter_camera),
-                background = MaterialTheme.colorScheme.tertiary,
-                foreground = MaterialTheme.colorScheme.onTertiary,
-                onClick = onCameraClick,
+                icon = Icons.Filled.PhotoLibrary,
+                label = photosLabel,
+                background = MaterialTheme.colorScheme.primaryContainer,
+                foreground = MaterialTheme.colorScheme.onPrimaryContainer,
+                onClick = onPhotosClick,
                 modifier = Modifier.fillMaxHeight().weight(1f),
             )
+            if (hasCamera) {
+                MediaActionTile(
+                    icon = Icons.Filled.PhotoCamera,
+                    label = cameraLabel,
+                    background = MaterialTheme.colorScheme.tertiary,
+                    foreground = MaterialTheme.colorScheme.onTertiary,
+                    onClick = onCameraClick,
+                    modifier = Modifier.fillMaxHeight().weight(1f),
+                )
+            }
+        }
+    } else {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(MEDIA_STACK_GAP_DP.dp),
+            modifier = modifier
+                .width(MEDIA_STACK_WIDTH_DP.dp)
+                .height(MEDIA_STACK_HEIGHT_DP.dp),
+        ) {
+            MediaActionTile(
+                icon = Icons.Filled.PhotoLibrary,
+                label = photosLabel,
+                background = MaterialTheme.colorScheme.primaryContainer,
+                foreground = MaterialTheme.colorScheme.onPrimaryContainer,
+                onClick = onPhotosClick,
+                modifier = Modifier.fillMaxWidth().weight(1f),
+            )
+            if (hasCamera) {
+                MediaActionTile(
+                    icon = Icons.Filled.PhotoCamera,
+                    label = cameraLabel,
+                    background = MaterialTheme.colorScheme.tertiary,
+                    foreground = MaterialTheme.colorScheme.onTertiary,
+                    onClick = onCameraClick,
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                )
+            }
         }
     }
 }
@@ -551,6 +751,136 @@ private fun MediaActionTile(
             color = foreground,
             fontSize = MEDIA_STACK_LABEL_SP.sp,
             fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun PhotoAccessRationale(
+    state: PromptState,
+    onAllow: () -> Unit,
+    onReject: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val bodyRes = when (state) {
+        PromptState.Unasked -> R.string.gbk_block_inserter_photos_rationale
+        PromptState.Denied -> R.string.gbk_block_inserter_photos_rationale_denied
+        PromptState.PermanentlyDenied -> R.string.gbk_block_inserter_photos_rationale_permanent
+    }
+    val primaryLabelRes = when (state) {
+        PromptState.Unasked -> R.string.gbk_block_inserter_photos_allow
+        PromptState.Denied -> R.string.gbk_block_inserter_photos_try_again
+        PromptState.PermanentlyDenied -> R.string.gbk_block_inserter_photos_open_settings
+    }
+    @Composable
+    fun RationaleButton(label: String, filled: Boolean, onClick: () -> Unit, modifier: Modifier) {
+        val bg = if (filled) MaterialTheme.colorScheme.primary else ComposeColor.Transparent
+        val fg = if (filled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary
+        // Outer wrapper inflates the touch zone to the 48dp minimum; the inner
+        // Box paints the design's 32dp pill. The shared interaction source lets
+        // the outer absorb taps with no indication while the inner draws the
+        // ripple — otherwise a default ripple on the outer would render as a
+        // square halo around the rounded pill.
+        val interactionSource = remember { MutableInteractionSource() }
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = modifier
+                .heightIn(min = TOUCH_TARGET_MIN_DP.dp)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    role = Role.Button,
+                    onClick = onClick,
+                ),
+        ) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(MEDIA_RATIONALE_BUTTON_HEIGHT_DP.dp)
+                    .clip(RoundedCornerShape(MEDIA_RATIONALE_BUTTON_CORNER_DP.dp))
+                    .background(bg)
+                    .indication(interactionSource, ripple()),
+            ) {
+                Text(
+                    text = label,
+                    color = fg,
+                    fontSize = MEDIA_RATIONALE_BUTTON_FONT_SP.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+    }
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier
+            .height(MEDIA_STACK_HEIGHT_DP.dp)
+            .clip(RoundedCornerShape(MEDIA_STACK_CORNER_DP.dp))
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .padding(MEDIA_RATIONALE_PAD_DP.dp),
+    ) {
+        Text(
+            text = stringResource(bodyRes),
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            fontSize = MEDIA_RATIONALE_FONT_SP.sp,
+            lineHeight = MEDIA_RATIONALE_LINE_HEIGHT_SP.sp,
+            fontWeight = FontWeight.Medium,
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(MEDIA_RATIONALE_BUTTON_GAP_DP.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            RationaleButton(
+                label = stringResource(primaryLabelRes),
+                filled = true,
+                onClick = onAllow,
+                modifier = Modifier.weight(1f),
+            )
+            RationaleButton(
+                label = stringResource(R.string.gbk_block_inserter_photos_reject),
+                filled = false,
+                onClick = onReject,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun RealThumbnail(uri: Uri, onLoadFailed: (Uri) -> Unit) {
+    val context = LocalContext.current
+    val sizePx = with(LocalDensity.current) { MEDIA_THUMB_SIZE_DP.dp.roundToPx() }
+    // Seed from the process-wide cache so a scroll-back or dialog-reopen
+    // skips the grey-placeholder flash entirely. On a cache miss the
+    // LaunchedEffect below fetches off-thread and populates the cache;
+    // on a load failure we notify the parent so the URI is dropped from
+    // the displayed set and a pool spare takes its place.
+    var bitmap by remember(uri, sizePx) { mutableStateOf(cachedThumbnail(uri, sizePx)) }
+    LaunchedEffect(uri, sizePx) {
+        if (bitmap == null) {
+            val loaded = withContext(Dispatchers.IO) { loadThumbnail(context, uri, sizePx) }
+            if (loaded == null) onLoadFailed(uri) else bitmap = loaded
+        }
+    }
+    val bmp = bitmap
+    if (bmp != null) {
+        Image(
+            bitmap = bmp,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(MEDIA_THUMB_SIZE_DP.dp)
+                .clip(RoundedCornerShape(MEDIA_THUMB_CORNER_DP.dp)),
+        )
+    } else {
+        // Neutral loading box — avoids flashing colorful mock-photo gradients
+        // between the URI being known and the bitmap finishing async load.
+        Box(
+            modifier = Modifier
+                .size(MEDIA_THUMB_SIZE_DP.dp)
+                .clip(RoundedCornerShape(MEDIA_THUMB_CORNER_DP.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         )
     }
 }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/PhotoAccessState.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/PhotoAccessState.kt
@@ -1,0 +1,60 @@
+package org.wordpress.gutenberg.inserter
+
+import android.net.Uri
+
+/**
+ * Photo-library access state for the inserter's media strip. Distinguishes
+ * "never asked" from "permanently denied" by persisting whether the system
+ * prompt has been shown at least once — Android's
+ * `shouldShowRequestPermissionRationale` alone can't tell those apart.
+ */
+internal sealed interface PhotoAccess {
+    data class Granted(val uris: List<Uri>) : PhotoAccess
+    data class NeedsPermission(
+        val state: PromptState,
+        val request: () -> Unit,
+    ) : PhotoAccess
+}
+
+/**
+ * Three mutually exclusive states the rationale card needs to distinguish:
+ * never asked, denied once (system will re-prompt), or permanently denied
+ * (system prompt is suppressed, user must enable via Settings).
+ */
+internal enum class PromptState { Unasked, Denied, PermanentlyDenied }
+
+/**
+ * Pure mapping from the two Android signals to the rationale's three-way state.
+ * `canReprompt` is `Activity.shouldShowRequestPermissionRationale(...)`'s result;
+ * `promptedBefore` is our SharedPreferences flag set after the first system prompt.
+ */
+internal fun resolvePromptState(
+    promptedBefore: Boolean,
+    canReprompt: Boolean,
+): PromptState = when {
+    !promptedBefore -> PromptState.Unasked
+    canReprompt -> PromptState.Denied
+    else -> PromptState.PermanentlyDenied
+}
+
+/**
+ * Which of the three media-strip layouts the inserter should render. A granted
+ * permission always wins over a sticky rejection so users get the thumbnail
+ * strip back if they grant access via system Settings after dismissing the
+ * rationale.
+ */
+internal sealed class MediaStripView {
+    object Rationale : MediaStripView()
+    object CompactTiles : MediaStripView()
+    object FullStrip : MediaStripView()
+}
+
+internal fun resolveMediaStripView(
+    access: PhotoAccess,
+    rejected: Boolean,
+): MediaStripView = when {
+    access is PhotoAccess.Granted -> MediaStripView.FullStrip
+    rejected -> MediaStripView.CompactTiles
+    access is PhotoAccess.NeedsPermission -> MediaStripView.Rationale
+    else -> MediaStripView.FullStrip
+}

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/RecentImages.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/RecentImages.kt
@@ -1,0 +1,327 @@
+package org.wordpress.gutenberg.inserter
+
+import android.Manifest
+import android.app.Activity
+import android.content.ContentUris
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.provider.Settings
+import android.util.Log
+import android.util.LruCache
+import android.util.Size as AndroidSize
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+// Process-wide thumbnail cache keyed by content URI. Sized for ~half the
+// strip (RECENT_PHOTO_LIMIT / 2) — enough that the user can scroll back
+// and forth without re-fetching the leading items, and bounded so the
+// memory footprint stays predictable (32 entries * ~200KB ARGB_8888 at
+// 64dp/3.5x density ≈ 6MB worst case). Bitmaps are immutable, so cache
+// hits are safe to share across composables.
+//
+// Without this cache, `LazyRow`'s offscreen disposal forced every
+// scroll-back into view to re-run `RealThumbnail`'s `LaunchedEffect`,
+// re-hitting `ContentResolver.loadThumbnail` via binder for a thumbnail
+// the user just saw — and every dialog reopen re-decoded the same 64
+// URIs from scratch.
+private const val THUMBNAIL_CACHE_SIZE = 32
+// Key includes `sizePx` so a density or `MEDIA_THUMB_SIZE_DP` change doesn't
+// serve a bitmap decoded for a different render size.
+private val thumbnailCache = LruCache<Pair<Uri, Int>, ImageBitmap>(THUMBNAIL_CACHE_SIZE)
+
+private const val TAG = "RecentImages"
+
+private const val PHOTO_PREFS = "gbk_inserter"
+private const val KEY_PHOTOS_PROMPTED = "photos_prompted"
+private const val KEY_RATIONALE_REJECTED = "rationale_rejected"
+
+/**
+ * Immutable snapshot of the inserter's photo prefs. Two booleans:
+ *  - `promptedBefore`: have we shown the system permission prompt at least once.
+ *  - `rejected`: has the user dismissed the rationale card.
+ */
+internal data class PhotoPrefs(
+    val promptedBefore: Boolean = false,
+    val rejected: Boolean = false,
+)
+
+// Process-wide cache populated on first async load. SharedPreferences reads
+// and writes are dispatched off the main thread — composables read from the
+// cache (synchronous, no IO) and writers update the cache atomically before
+// queuing a disk `.apply()` on `photoPrefsScope`.
+@Volatile
+private var cachedPhotoPrefs: PhotoPrefs? = null
+private val photoPrefsScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+internal suspend fun ensurePhotoPrefsLoaded(context: Context): PhotoPrefs {
+    cachedPhotoPrefs?.let { return it }
+    return withContext(Dispatchers.IO) {
+        cachedPhotoPrefs ?: run {
+            val sp = context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+            PhotoPrefs(
+                promptedBefore = sp.getBoolean(KEY_PHOTOS_PROMPTED, false),
+                rejected = sp.getBoolean(KEY_RATIONALE_REJECTED, false),
+            ).also { cachedPhotoPrefs = it }
+        }
+    }
+}
+
+/**
+ * Returns the cached prefs synchronously if already loaded; otherwise kicks
+ * off an async load and returns `null` until the load completes. In practice
+ * the cache is warmed by `warmupPhotoPrefs` during `GutenbergView` construction,
+ * so by the time the inserter is openable the prefs are loaded and this
+ * returns synchronously. The async path is a defensive fallback that should
+ * never render visibly under normal use.
+ */
+@Composable
+internal fun rememberPhotoPrefs(context: Context): PhotoPrefs? {
+    var prefs by remember { mutableStateOf(cachedPhotoPrefs) }
+    LaunchedEffect(Unit) {
+        if (prefs == null) prefs = ensurePhotoPrefsLoaded(context)
+    }
+    return prefs
+}
+
+/**
+ * Fire-and-forget warmup that loads the photo prefs into the process-wide
+ * cache. Called from `GutenbergView`'s constructor so that by the time the
+ * user can navigate to and open the inserter, the cache is hot and the
+ * inserter's prefs read is synchronous — no async-load placeholder flashes.
+ */
+internal fun warmupPhotoPrefs(context: Context) {
+    if (cachedPhotoPrefs != null) return
+    val appContext = context.applicationContext
+    photoPrefsScope.launch { ensurePhotoPrefsLoaded(appContext) }
+}
+
+@Composable
+internal fun rememberPhotoAccess(limit: Int, initialPromptedBefore: Boolean): PhotoAccess {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findActivity() }
+    var granted by remember { mutableStateOf(hasPhotosPermission(context)) }
+    var promptedBefore by remember { mutableStateOf(initialPromptedBefore) }
+    var uris by remember { mutableStateOf<List<Uri>>(emptyList()) }
+    // `canReprompt` is its own state, recomputed at every permission-relevant
+    // signal (launcher result, lifecycle resume). Compose's snapshot system
+    // can't see the OS-level `shouldShowRequestPermissionRationale` flip from
+    // true → false on the 2nd denial otherwise — `granted` and `promptedBefore`
+    // are already in their post-deny values, so neither would notify Compose
+    // and the rationale would stay stuck on "Try Again".
+    var canReprompt by remember {
+        mutableStateOf(activity?.let { shouldShowRationale(it) } ?: true)
+    }
+    val refreshAccessState = {
+        granted = hasPhotosPermission(context)
+        canReprompt = activity?.let { shouldShowRationale(it) } ?: true
+    }
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { _ ->
+        markPromptedForPhotos(context)
+        promptedBefore = true
+        refreshAccessState()
+    }
+    // Re-read permission on every RESUME so we notice grants made via system
+    // Settings (which happen outside the Compose result-callback path).
+    // Important: observe the host Activity's lifecycle, not the Compose-default
+    // LocalLifecycleOwner. Inside a BottomSheetDialog the latter resolves to the
+    // dialog's own LifecycleRegistry (per ComponentDialog), which only dispatches
+    // ON_RESUME from `show()` and never refires when the user leaves to system
+    // Settings and returns. The Activity's lifecycle does refire ON_RESUME.
+    val activityLifecycle = (activity as? LifecycleOwner)?.lifecycle
+    DisposableEffect(activityLifecycle) {
+        if (activityLifecycle == null) return@DisposableEffect onDispose { }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) refreshAccessState()
+        }
+        activityLifecycle.addObserver(observer)
+        onDispose { activityLifecycle.removeObserver(observer) }
+    }
+    LaunchedEffect(granted, limit) {
+        uris = if (granted) {
+            withContext(Dispatchers.IO) { queryRecentImages(context, limit) }
+        } else {
+            emptyList()
+        }
+    }
+    if (granted) return PhotoAccess.Granted(uris)
+    val state = resolvePromptState(promptedBefore = promptedBefore, canReprompt = canReprompt)
+    return PhotoAccess.NeedsPermission(
+        state = state,
+        request = {
+            if (state == PromptState.PermanentlyDenied) openAppSettings(context)
+            else launcher.launch(photosPermission())
+        },
+    )
+}
+
+internal fun cachedThumbnail(uri: Uri, sizePx: Int): ImageBitmap? =
+    thumbnailCache.get(uri to sizePx)
+
+internal fun loadThumbnail(context: Context, uri: Uri, sizePx: Int): ImageBitmap? {
+    val key = uri to sizePx
+    thumbnailCache.get(key)?.let { return it }
+    // MediaStore failures here are expected (deleted-mid-scroll URIs,
+    // partial-grant SecurityExceptions on Android 14+, OEM-specific
+    // FileNotFoundException). Log at warn so the failure isn't silent
+    // for engineers watching logcat, but don't crash — the strip
+    // gracefully falls back to the neutral placeholder for this tile.
+    val decoded = runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            context.contentResolver.loadThumbnail(uri, AndroidSize(sizePx, sizePx), null)
+                .asImageBitmap()
+        } else {
+            null
+        }
+    }.onFailure { Log.w(TAG, "Failed to load thumbnail: $uri", it) }.getOrNull()
+    decoded?.let { thumbnailCache.put(key, it) }
+    return decoded
+}
+
+private fun photosPermission(): String =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+
+private fun hasPhotosPermission(context: Context): Boolean {
+    if (ContextCompat.checkSelfPermission(context, photosPermission()) ==
+        PackageManager.PERMISSION_GRANTED
+    ) {
+        return true
+    }
+    // Android 14+ shows a three-option dialog ("Allow all" / "Select photos" /
+    // "Don't allow") whenever an app at targetSdk >= 34 requests
+    // `READ_MEDIA_IMAGES` — regardless of whether the manifest opts in to
+    // `READ_MEDIA_VISUAL_USER_SELECTED`. If the user picks "Select photos",
+    // `READ_MEDIA_IMAGES` stays denied but `READ_MEDIA_VISUAL_USER_SELECTED`
+    // is granted, and MediaStore automatically scopes our query to the
+    // user-selected items. Treat that as granted so we don't tell the user
+    // they have no access when they actually granted partial access.
+    //
+    // Declaring `READ_MEDIA_VISUAL_USER_SELECTED` in the library manifest
+    // (which would unlock the "Select more photos" re-prompt affordance)
+    // is the follow-up PR.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+    return false
+}
+
+private fun shouldShowRationale(activity: Activity): Boolean =
+    ActivityCompat.shouldShowRequestPermissionRationale(activity, photosPermission())
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
+
+private fun openAppSettings(context: Context) {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", context.packageName, null)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(intent)
+}
+
+// Cache update is synchronous so subsequent composition reads see the new
+// value immediately; the disk `.apply()` runs on `photoPrefsScope` so the
+// caller never blocks on IO (including `SharedPreferences.edit()` itself,
+// which can block waiting for the file's background load to complete).
+private fun markPromptedForPhotos(context: Context) {
+    cachedPhotoPrefs = (cachedPhotoPrefs ?: PhotoPrefs()).copy(promptedBefore = true)
+    val appContext = context.applicationContext
+    photoPrefsScope.launch {
+        appContext.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_PHOTOS_PROMPTED, true).apply()
+    }
+}
+
+internal fun markRationaleRejected(context: Context) {
+    cachedPhotoPrefs = (cachedPhotoPrefs ?: PhotoPrefs()).copy(rejected = true)
+    val appContext = context.applicationContext
+    photoPrefsScope.launch {
+        appContext.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_RATIONALE_REJECTED, true).apply()
+    }
+}
+
+/**
+ * Clears just the rationale-rejected flag (leaving the prompted-before flag
+ * alone). Called when we observe the photo permission becoming granted, so a
+ * subsequent revocation surfaces the rationale again instead of stranding the
+ * user in CompactTiles with no in-app affordance to re-engage.
+ */
+internal fun clearRejectedRationale(context: Context) {
+    cachedPhotoPrefs = (cachedPhotoPrefs ?: PhotoPrefs()).copy(rejected = false)
+    val appContext = context.applicationContext
+    photoPrefsScope.launch {
+        appContext.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+            .edit().remove(KEY_RATIONALE_REJECTED).apply()
+    }
+}
+
+internal fun clearPhotoPreferences(context: Context) {
+    cachedPhotoPrefs = PhotoPrefs()
+    val appContext = context.applicationContext
+    photoPrefsScope.launch {
+        appContext.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+            .edit().clear().apply()
+    }
+}
+
+private fun queryRecentImages(context: Context, limit: Int): List<Uri> {
+    val collection = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL)
+    } else {
+        @Suppress("DEPRECATION")
+        MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+    }
+    val projection = arrayOf(MediaStore.Images.Media._ID)
+    val sortOrder = "${MediaStore.Images.Media.DATE_ADDED} DESC"
+    val result = mutableListOf<Uri>()
+    // Query failures here strand the user with an empty strip rather
+    // than a crash — surface to logcat so engineers see when a real
+    // permission/cursor problem (vs. genuinely no photos) is the cause.
+    runCatching {
+        context.contentResolver.query(collection, projection, null, null, sortOrder)?.use { cursor ->
+            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+            while (cursor.moveToNext() && result.size < limit) {
+                val id = cursor.getLong(idColumn)
+                result.add(ContentUris.withAppendedId(collection, id))
+            }
+        }
+    }.onFailure { Log.w(TAG, "Failed to query recent images from MediaStore", it) }
+    return result
+}

--- a/android/Gutenberg/src/main/res/values/strings.xml
+++ b/android/Gutenberg/src/main/res/values/strings.xml
@@ -19,4 +19,11 @@
     <string name="gbk_block_inserter_photos">Photos</string>
     <string name="gbk_block_inserter_camera">Camera</string>
     <string name="gbk_block_inserter_camera_unavailable">Camera not available on this device</string>
+    <string name="gbk_block_inserter_photos_rationale">Show your photo library here to quickly insert an image</string>
+    <string name="gbk_block_inserter_photos_rationale_denied">Allow access to show your photo library here</string>
+    <string name="gbk_block_inserter_photos_rationale_permanent">Enable photo access in Settings to show your library here</string>
+    <string name="gbk_block_inserter_photos_allow">Allow</string>
+    <string name="gbk_block_inserter_photos_try_again">Try Again</string>
+    <string name="gbk_block_inserter_photos_reject">Reject</string>
+    <string name="gbk_block_inserter_photos_open_settings">Open Settings</string>
 </resources>

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/PhotoAccessStateTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/PhotoAccessStateTest.kt
@@ -1,0 +1,72 @@
+package org.wordpress.gutenberg.inserter
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PhotoAccessStateTest {
+
+    // resolvePromptState
+
+    @Test
+    fun `unasked when never prompted, regardless of canReprompt`() {
+        assertEquals(
+            PromptState.Unasked,
+            resolvePromptState(promptedBefore = false, canReprompt = true),
+        )
+        assertEquals(
+            PromptState.Unasked,
+            resolvePromptState(promptedBefore = false, canReprompt = false),
+        )
+    }
+
+    @Test
+    fun `denied when prompted before and system can re-prompt`() {
+        assertEquals(
+            PromptState.Denied,
+            resolvePromptState(promptedBefore = true, canReprompt = true),
+        )
+    }
+
+    @Test
+    fun `permanently denied when prompted before and system cannot re-prompt`() {
+        assertEquals(
+            PromptState.PermanentlyDenied,
+            resolvePromptState(promptedBefore = true, canReprompt = false),
+        )
+    }
+
+    // resolveMediaStripView
+
+    @Test
+    fun `granted access always shows full strip even after rejection`() {
+        val granted = PhotoAccess.Granted(uris = emptyList())
+        assertEquals(MediaStripView.FullStrip, resolveMediaStripView(granted, rejected = false))
+        assertEquals(MediaStripView.FullStrip, resolveMediaStripView(granted, rejected = true))
+    }
+
+    @Test
+    fun `needs-permission shows rationale when not rejected`() {
+        val needs = needsPermission(PromptState.Denied)
+        assertEquals(MediaStripView.Rationale, resolveMediaStripView(needs, rejected = false))
+    }
+
+    @Test
+    fun `needs-permission shows compact tiles when rejected`() {
+        val needs = needsPermission(PromptState.PermanentlyDenied)
+        assertEquals(MediaStripView.CompactTiles, resolveMediaStripView(needs, rejected = true))
+    }
+
+    @Test
+    fun `rationale shows for every prompt state when not rejected`() {
+        for (state in PromptState.entries) {
+            assertEquals(
+                "state=$state",
+                MediaStripView.Rationale,
+                resolveMediaStripView(needsPermission(state), rejected = false),
+            )
+        }
+    }
+
+    private fun needsPermission(state: PromptState) =
+        PhotoAccess.NeedsPermission(state = state, request = {})
+}

--- a/android/app/src/androidTest/java/com/example/gutenbergkit/EditorTestHelpers.kt
+++ b/android/app/src/androidTest/java/com/example/gutenbergkit/EditorTestHelpers.kt
@@ -58,8 +58,12 @@ object EditorTestHelpers {
         rule.waitForNodeWithText("Standalone editor")
         rule.onNodeWithText("Standalone editor").performClick()
 
-        // Wait for and tap the "Start" button on the configuration screen.
+        // Wait for the configuration screen to render. The native inserter
+        // toggle defaults to on; turn it off so "Add block" opens the web
+        // Gutenberg dialog (which the WebView-side helpers below assert on)
+        // rather than the native BlockPickerDialog bottom sheet.
         rule.waitForNodeWithText("Start")
+        rule.onNodeWithContentDescription("Enable Native Inserter").performClick()
         rule.onNodeWithText("Start").performClick()
 
         // Block until the editor JS has booted and the bridge API is live.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -58,6 +58,9 @@
         <activity
             android:name=".MediaProxyServerActivity"
             android:exported="true" />
+        <activity
+            android:name=".ManagePermissionsActivity"
+            android:exported="false" />
     </application>
     <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -113,6 +113,9 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
                     onMediaProxyServer = {
                         startActivity(Intent(this, MediaProxyServerActivity::class.java))
                     },
+                    onManagePermissions = {
+                        startActivity(Intent(this, ManagePermissionsActivity::class.java))
+                    },
                     isDiscoveringSite = isDiscoveringSite.value,
                     onDismissDiscovering = { isDiscoveringSite.value = false },
                     isLoadingCapabilities = isLoadingCapabilities.value,
@@ -150,6 +153,7 @@ private fun isDevServerRunning(): Boolean {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongParameterList", "LongMethod")
 fun MainScreen(
     configurations: List<ConfigurationItem>,
     onConfigurationClick: (ConfigurationItem) -> Unit,
@@ -157,6 +161,7 @@ fun MainScreen(
     onAddConfiguration: (String) -> Unit,
     onDeleteConfiguration: (ConfigurationItem) -> Unit,
     onMediaProxyServer: () -> Unit = {},
+    onManagePermissions: () -> Unit = {},
     isDiscoveringSite: Boolean = false,
     onDismissDiscovering: () -> Unit = {},
     isLoadingCapabilities: Boolean = false,
@@ -189,6 +194,13 @@ fun MainScreen(
                             onClick = {
                                 showOverflowMenu.value = false
                                 onMediaProxyServer()
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Manage Permissions") },
+                            onClick = {
+                                showOverflowMenu.value = false
+                                onManagePermissions()
                             }
                         )
                     }

--- a/android/app/src/main/java/com/example/gutenbergkit/ManagePermissionsActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/ManagePermissionsActivity.kt
@@ -1,0 +1,236 @@
+package com.example.gutenbergkit
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.example.gutenbergkit.ui.theme.AppTheme
+import org.wordpress.gutenberg.GutenbergView
+
+class ManagePermissionsActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            AppTheme {
+                ManagePermissionsScreen(onBack = { finish() })
+            }
+        }
+    }
+}
+
+private enum class OsPermissionState {
+    Granted,
+    DeniedCanReprompt,
+    DeniedSuppressed,
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ManagePermissionsScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findActivity() }
+    var state by remember { mutableStateOf(readPermissionState(context, activity)) }
+    val refresh = { state = readPermissionState(context, activity) }
+
+    // Re-read on RESUME so revokes/grants made via system Settings are reflected
+    // when the user returns to this screen. Observes the host Activity directly
+    // (it implements LifecycleOwner) — avoids the deprecated compose-ui
+    // `LocalLifecycleOwner` without pulling in `lifecycle-runtime-compose`.
+    val lifecycle = (activity as? LifecycleOwner)?.lifecycle
+    DisposableEffect(lifecycle) {
+        if (lifecycle == null) return@DisposableEffect onDispose { }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) refresh()
+        }
+        lifecycle.addObserver(observer)
+        onDispose { lifecycle.removeObserver(observer) }
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Manage Permissions") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(PaddingValues(16.dp)),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            CurrentStateCard(state)
+            ResetFlagsCard(onReset = {
+                GutenbergView.resetBlockPickerPhotoPreferences(context)
+                refresh()
+            })
+            OpenSettingsCard(
+                state = state,
+                onOpen = { openAppSettings(context) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun CurrentStateCard(state: OsPermissionState) {
+    val (label, detail) = when (state) {
+        OsPermissionState.Granted ->
+            "Granted" to "The library can read MediaStore images; the inserter renders the thumbnail strip."
+        OsPermissionState.DeniedCanReprompt ->
+            "Denied (system will re-prompt)" to "The next Allow tap in the rationale will show the system prompt."
+        OsPermissionState.DeniedSuppressed ->
+            "Denied (system prompt suppressed)" to
+                "The OS has stopped offering the system prompt for this permission. Re-enable via Settings."
+    }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text("READ_MEDIA_IMAGES", style = MaterialTheme.typography.labelMedium)
+            Text(label, style = MaterialTheme.typography.titleMedium)
+            Text(
+                detail,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ResetFlagsCard(onReset: () -> Unit) {
+    ActionCard(
+        title = "Reset App Rationale Flags",
+        body = "Clears the in-app rationale-rejection and first-prompt flags. Does not touch the OS-level permission grant.",
+        action = {
+            OutlinedButton(onClick = onReset) { Text("Reset flags") }
+        },
+    )
+}
+
+// Settings hand-off rather than `revokeSelfPermissionOnKill` + self-kill:
+//   - The API is API 33+ only and the demo's minSdk is 24, so we'd need
+//     two code paths regardless.
+//   - Settings gives the user an OS-owned confirmation surface — they
+//     see exactly which permission flipped and when.
+//   - No lifecycle race between an async self-kill and the user landing
+//     back in the demo to verify the new state.
+@Composable
+private fun OpenSettingsCard(state: OsPermissionState, onOpen: () -> Unit) {
+    val body = when (state) {
+        OsPermissionState.Granted ->
+            "Open the system permission settings to revoke photo access. Return to the demo to see the rationale flow restart."
+        OsPermissionState.DeniedCanReprompt ->
+            "Open the system permission settings if you want to inspect or change the OS-level photo permission."
+        OsPermissionState.DeniedSuppressed ->
+            "The system has suppressed the permission prompt for this app. " +
+                "Toggle photos access from system Settings to test the granted path."
+    }
+    ActionCard(
+        title = "Open Permission Settings",
+        body = body,
+        action = {
+            OutlinedButton(onClick = onOpen) { Text("Open Settings") }
+        },
+    )
+}
+
+@Composable
+private fun ActionCard(title: String, body: String, action: @Composable () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(title, style = MaterialTheme.typography.titleMedium)
+            Text(
+                body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            action()
+        }
+    }
+}
+
+private fun readPermissionState(context: Context, activity: Activity?): OsPermissionState {
+    val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+    val granted = ContextCompat.checkSelfPermission(context, permission) ==
+        PackageManager.PERMISSION_GRANTED
+    if (granted) return OsPermissionState.Granted
+    val canReprompt = activity?.let {
+        ActivityCompat.shouldShowRequestPermissionRationale(it, permission)
+    } ?: false
+    return if (canReprompt) OsPermissionState.DeniedCanReprompt else OsPermissionState.DeniedSuppressed
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is android.content.ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
+
+private fun openAppSettings(context: Context) {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", context.packageName, null)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(intent)
+}

--- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationActivity.kt
@@ -51,6 +51,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelProvider
 import com.example.gutenbergkit.ui.theme.AppTheme
@@ -408,7 +410,10 @@ private fun FeatureConfigurationCard(
                 Text("Enable Native Inserter")
                 Switch(
                     checked = enableNativeInserter,
-                    onCheckedChange = onEnableNativeInserterChange
+                    onCheckedChange = onEnableNativeInserterChange,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Enable Native Inserter"
+                    },
                 )
             }
 

--- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
@@ -19,7 +19,7 @@ import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.PostType as WpPostType
 
 data class SitePreparationUiState(
-    val enableNativeInserter: Boolean = false,
+    val enableNativeInserter: Boolean = true,
     val enableNetworkLogging: Boolean = false,
     /** All viewable post types fetched from the site, or empty while loading. */
     val postTypes: List<PostTypeDetails> = emptyList(),

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -154,6 +154,33 @@ dependencies {
 
 Include the `android/Gutenberg/` module directly in your project.
 
+### Manifest Permissions
+
+GutenbergKit's `AndroidManifest.xml` declares the following permissions, which are merged into the host app's manifest:
+
+| Permission              | SDK range | Why                                                    |
+| ----------------------- | --------- | ------------------------------------------------------ |
+| `ACCESS_NETWORK_STATE`  | all       | Detects offline state so the editor can react.         |
+| `READ_MEDIA_IMAGES`     | 33+       | Powers the block inserter's recent-photos strip.       |
+| `READ_EXTERNAL_STORAGE` | ≤32       | Pre-Android-13 fallback for the same recent-photos UI. |
+
+The two media permissions show up in your app's Play Store data-safety disclosure and in the OS app-info screen. Hosts that don't render the inserter, don't want the recent-photos strip, or already declare these permissions for their own media flows can opt out via the manifest merger:
+
+```xml
+<uses-permission
+    android:name="android.permission.READ_MEDIA_IMAGES"
+    tools:node="remove" />
+<uses-permission
+    android:name="android.permission.READ_EXTERNAL_STORAGE"
+    tools:node="remove" />
+```
+
+The `tools:node` attribute requires the `tools` XML namespace on your `<manifest>` root element: `xmlns:tools="http://schemas.android.com/tools"`. Android Studio's project wizard generates this by default, so most host manifests already have it.
+
+With the media permissions removed, the inserter's Photos and Camera tiles still work (both are permissionless — Photos uses the system photo picker, Camera uses `ACTION_IMAGE_CAPTURE`). Only the recent-photos preview strip is suppressed.
+
+The recent-photos strip itself requires Android 10+ (API 29). On Android 7–9, the inserter automatically falls back to the Photos and Camera tiles and never requests the media permission, regardless of what the merged manifest declares.
+
 ### Basic Setup
 
 Create a `GutenbergView` and start the editor:


### PR DESCRIPTION
## Summary

Layers on top of #509 with the photo-permission state machine, the rationale card, and the recent-photos thumbnail strip.

Three media-strip states resolved at runtime by `resolveMediaStripView` in `PhotoAccessState.kt`:

1. **Rationale card** — shown when `READ_MEDIA_IMAGES` isn't granted and the user hasn't dismissed it. Body copy and primary-button label swap across three sub-states (`Unasked` / `Denied` / `PermanentlyDenied`); SharedPreferences tracks the first-prompt flag because `shouldShowRequestPermissionRationale` alone can't tell "never asked" from "permanently denied".
2. **Compact tiles** — once the rationale is rejected, the Photos / Camera column flattens into a full-width 88dp row. The rejection auto-clears when permission is later granted via `clearRejectedRationale`, so a future revocation surfaces the rationale again instead of stranding the user in CompactTiles with no in-app affordance to re-engage.
3. **Full strip** — once granted, queries MediaStore for the 64 most recent images and renders them as a horizontally-scrolling 2-row thumbnail grid. `LazyRow` keeps off-screen thumbnails out of memory.

Sorry, this one is a little bigger, but I couldn't find a meaningful way to split it up.

## Lifecycle observer

The strip observes the **host Activity's** lifecycle (via `LocalContext.findActivity()` walking the `ContextWrapper` chain), not the `BottomSheetDialog`'s own `LifecycleRegistry`. The dialog's lifecycle only dispatches `ON_RESUME` from `show()` and never refires when the user leaves to system Settings and returns; the Activity's does. This is what makes the "grant via Settings → strip updates on return" path work even when the inserter sheet stays open through the round-trip.

## `canReprompt` state

Modelled as its own `mutableStateOf`, explicitly recomputed at every permission-relevant signal (launcher result, lifecycle resume) via the `refreshAccessState` helper. Compose's snapshot system can't see the OS-level `shouldShowRequestPermissionRationale` flip from `true → false` on the 2nd denial otherwise — `granted` and `promptedBefore` are already in their post-deny values, so neither would notify Compose and the rationale would stay stuck on "Try Again".

## Manifest permissions

This PR adds two host-visible `<uses-permission>` declarations to the library manifest:

| Permission              | SDK range | Purpose                                         |
| ----------------------- | --------- | ----------------------------------------------- |
| `READ_MEDIA_IMAGES`     | 33+       | Read MediaStore images for the thumbnail strip. |
| `READ_EXTERNAL_STORAGE` | ≤32       | Pre-Android-13 fallback for the same read.      |

Android 14+'s three-option permission dialog ("Allow all" / "Select photos" / "Don't allow") is surfaced by the system whenever an app at targetSdk ≥ 34 requests `READ_MEDIA_IMAGES`, regardless of whether the manifest opts in to `READ_MEDIA_VISUAL_USER_SELECTED` (verified empirically on Pixel 9 Pro XL / Android 16). `hasPhotosPermission` checks both permissions, so a "Select photos" choice is treated as granted and MediaStore scopes the strip to the user-selected items. Declaring `READ_MEDIA_VISUAL_USER_SELECTED` in the library manifest to unlock the "Select more photos" re-prompt UX is #511.

Hosts that don't ship the media strip can opt out:

```xml
<uses-permission
    android:name="android.permission.READ_MEDIA_IMAGES"
    tools:node="remove" />
<uses-permission
    android:name="android.permission.READ_EXTERNAL_STORAGE"
    tools:node="remove" />
```

With the permissions removed, `hasPhotosPermission` returns `false`, the rationale is unreachable (the launcher request hits the merged-manifest check and resolves to denied), and the strip falls back to the **CompactTiles** layout from the parent PR. The Photos tile (system picker) and Camera tile continue to work — they're permissionless.

## Host integration

`GutenbergView.resetBlockPickerPhotoPreferences(context)` is exposed for host apps that want to clear the rationale-rejection / first-prompt flags from a settings screen.

The demo's `⋮` menu now has a **Manage Permissions** screen for replaying the rationale flow during review: it shows the current OS state for `READ_MEDIA_IMAGES`, lets reviewers reset the in-app flags via the library API above, and hands off to the system permission settings for OS-level revokes. `revokeSelfPermissionOnKill` was the obvious path for the OS-revoke side but requires API 33+; the demo's `minSdk = 24`, so a Settings hand-off code path is needed regardless. Settings also gives the user an OS-owned confirmation surface and avoids the lifecycle race of an async self-kill. The screen refreshes on `ON_RESUME` so returning from Settings reflects the new state immediately.

The demo's "Enable Native Inserter" toggle now defaults to **on** so reviewers see the new strip without flipping a setting.

## Test plan

> _Note: the **Photos** and **Camera** tiles open the system picker / camera app, but the picked URI / capture is not yet handed off to the JS editor for block insertion — that round-trip lands in a follow-up PR. The launchers firing and the permission/rationale flow are the parts under test here._

- [ ] Open the inserter on first launch. Rationale card shows **Allow** + **Reject** alongside the Photos/Camera column.
- [ ] Tap **Allow** → system prompt → grant → strip flips to recent photos, behind the same Photos/Camera column.
- [ ] Deny system prompt once → rationale switches to **Try Again**.
- [ ] Deny system prompt twice → rationale switches to **Open Settings** (system suppresses the prompt).
- [ ] Tap **Reject** in rationale → rationale hides, Photos/Camera reflow into a 88dp full-width row; preference persists across dialog dismiss/relaunch and app cold-start.
- [ ] After Reject, grant permission via system Settings → return to the app → strip flips to thumbnails (lifecycle resume picks up the new grant).
- [ ] After grant, revoke via system Settings → return to the app → rationale card returns (sticky rejected flag was cleared on grant).
- [ ] Tap **Photos** tile → system photo picker opens (works in all three states).
- [ ] Tap **Camera** tile → camera app opens with a cache-scoped output URI (works in all three states).
- [ ] Vertical drag on the photo strip still drags the bottom sheet (LazyRow's nested-scroll dispatch).
- [ ] Demo `⋮` → **Manage Permissions** shows current OS state (`Granted` / `Denied (system will re-prompt)` / `Denied (system prompt suppressed)`).
- [ ] **Reset flags** clears the SharedPreferences; reopening the inserter shows the rationale fresh.
- [ ] **Open Settings** hands off to the system permission detail; toggling there and returning refreshes the state card via the `ON_RESUME` observer.
- [ ] Rationale buttons feel comfortably tappable despite their 32dp visual.
- [ ] `./gradlew :Gutenberg:detekt :Gutenberg:assembleDebug :Gutenberg:testDebugUnitTest` passes (includes `PhotoAccessStateTest`).



