### PR TITLE
feat(android): support Android 14 partial photo access

### DIFF
--- a/android/Gutenberg/build.gradle.kts
+++ b/android/Gutenberg/build.gradle.kts
@@ -171,6 +171,7 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.activity.compose)
 
     testImplementation(libs.junit)
     testImplementation(kotlin("test"))

--- a/android/Gutenberg/src/main/AndroidManifest.xml
+++ b/android/Gutenberg/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <!-- Used by the block inserter media strip to preview recent device photos.
          Host apps that don't need this can opt out via tools:node="remove". -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <!-- Android 14+ partial-access opt-in. Declaring this lets the system offer
+         "Select photos and videos" alongside the all/none choice and lets us
+         detect partial grants so we can surface a "Manage selection" affordance. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/android/Gutenberg/src/main/AndroidManifest.xml
+++ b/android/Gutenberg/src/main/AndroidManifest.xml
@@ -3,4 +3,20 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <application>
+        <!-- Exposes a writeable temp-file URI to the camera app so captures can
+             come back to us without the host app having to configure its own
+             FileProvider. Authority is keyed off the host app's applicationId
+             so it won't collide with one a host app already declares. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.gutenberg.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/gbk_file_paths" />
+        </provider>
+    </application>
+
 </manifest>

--- a/android/Gutenberg/src/main/AndroidManifest.xml
+++ b/android/Gutenberg/src/main/AndroidManifest.xml
@@ -2,6 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- Used by the block inserter media strip to preview recent device photos.
+         Host apps that don't need this can opt out via tools:node="remove". -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
 
     <application>
         <!-- Exposes a writeable temp-file URI to the camera app so captures can

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.launch
 import org.json.JSONException
 import org.json.JSONObject
 import org.wordpress.gutenberg.inserter.BlockPickerDialog
+import org.wordpress.gutenberg.inserter.clearPhotoPreferences
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
@@ -1090,6 +1091,15 @@ class GutenbergView : FrameLayout {
     }
 
     companion object {
+        /**
+         * Clears the block inserter's photo-library preferences (rationale
+         * rejection + first-prompt tracking). Call from a host-app settings
+         * screen if you want users to re-see the rationale after dismissing it.
+         */
+        fun resetBlockPickerPhotoPreferences(context: Context) {
+            clearPhotoPreferences(context)
+        }
+
         /** Hosts that are safe to serve assets over HTTP (local development only). */
         private val LOCAL_HOSTS = setOf("localhost", "127.0.0.1", "10.0.2.2")
 

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Build
 import android.view.ViewGroup
+import android.view.WindowManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -12,6 +13,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.rememberScrollableState
 import androidx.compose.foundation.gestures.scrollable
@@ -31,6 +34,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.rememberScrollState
@@ -46,6 +50,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -60,14 +65,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -75,6 +82,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
+import androidx.core.content.FileProvider
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
@@ -84,12 +92,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.content.FileProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import java.io.File
 import kotlin.math.roundToInt
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.wordpress.gutenberg.R
 import androidx.compose.ui.graphics.Color as ComposeColor
 import org.wordpress.gutenberg.model.BlockInserterPayload
@@ -128,11 +137,25 @@ private const val MEDIA_STRIP_BOTTOM_PAD_DP = 10
 private const val MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP = 20
 private const val MEDIA_STRIP_CONTENT_TOP_PAD_DP = 2
 private const val MEDIA_STRIP_CONTENT_BOTTOM_PAD_DP = 6
+private const val MEDIA_STRIP_ITEM_GAP_DP = 8
+private const val MEDIA_STACK_WIDTH_DP = 72
+private const val MEDIA_STACK_HEIGHT_DP = 136
 private const val MEDIA_STACK_COMPACT_HEIGHT_DP = 88
 private const val MEDIA_STACK_GAP_DP = 4
 private const val MEDIA_STACK_CORNER_DP = 18
 private const val MEDIA_STACK_ICON_SIZE_DP = 28
 private const val MEDIA_STACK_LABEL_SP = 13
+private const val MEDIA_THUMB_SIZE_DP = 64
+private const val MEDIA_THUMB_CORNER_DP = 16
+private const val RECENT_PHOTO_LIMIT = 64
+
+private const val MEDIA_RATIONALE_PAD_DP = 14
+private const val MEDIA_RATIONALE_FONT_SP = 13
+private const val MEDIA_RATIONALE_LINE_HEIGHT_SP = 18
+private const val MEDIA_RATIONALE_BUTTON_GAP_DP = 6
+private const val MEDIA_RATIONALE_BUTTON_HEIGHT_DP = 32
+private const val MEDIA_RATIONALE_BUTTON_CORNER_DP = 16
+private const val MEDIA_RATIONALE_BUTTON_FONT_SP = 12
 
 private const val TABS_VERTICAL_PAD_DP = 4
 private const val TABS_BOTTOM_PAD_DP = 6
@@ -179,10 +202,17 @@ private const val EMPTY_STATE_FONT_SP = 14
 private const val DISABLED_ALPHA = 0.5f
 
 /**
+ * Material 3 minimum touch-target. Several visual elements here (rationale
+ * buttons, category chips) sit below this for design reasons; we wrap them in
+ * an outer clickable that meets the minimum without changing the visual size.
+ */
+private const val TOUCH_TARGET_MIN_DP = 48
+
+/**
  * Bottom-sheet block inserter. The outer shell stays a `BottomSheetDialog` so
  * `GutenbergView`'s integration surface is unchanged; everything visible is
- * Compose content matching the Variation B design handoff — header row,
- * pill category tabs, rounded search, 5-column tonal tile grid.
+ * Compose content matching the Variation B design handoff — header row, recent
+ * media strip, pill category tabs, rounded search, 5-column tonal tile grid.
  *
  * The sheet background and 28dp top corners are drawn by Compose directly; the
  * dialog's default white pill background is cleared so it doesn't fight the
@@ -195,6 +225,13 @@ internal class BlockPickerDialog(
 ) : BottomSheetDialog(context) {
 
     init {
+        // Render at full size regardless of the IME — without this the dialog
+        // opens compressed above an in-flight soft keyboard, then visibly
+        // resizes once the IME dismisses, looking like a "double launch".
+        window?.setSoftInputMode(
+            WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN or
+                WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
+        )
         val composeView = ComposeView(context).apply {
             setContent {
                 BlockPickerSheet(
@@ -425,6 +462,18 @@ private fun CloseButton(onClose: () -> Unit) {
 
 @Composable
 private fun MediaStrip() {
+    val access = rememberPhotoAccess(limit = RECENT_PHOTO_LIMIT)
+    val context = LocalContext.current
+    var rejected by remember { mutableStateOf(hasRejectedRationale(context)) }
+    // Clear a prior rejection once the user actually grants the permission.
+    // Without this, a later revocation would leave the user in CompactTiles
+    // with no in-app path back to the rationale.
+    LaunchedEffect(access) {
+        if (access is PhotoAccess.Granted && rejected) {
+            clearRejectedRationale(context)
+            rejected = false
+        }
+    }
     val contentPadding = PaddingValues(
         start = MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP.dp,
         end = MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP.dp,
@@ -436,17 +485,82 @@ private fun MediaStrip() {
             .fillMaxWidth()
             .padding(top = MEDIA_STRIP_TOP_PAD_DP.dp, bottom = MEDIA_STRIP_BOTTOM_PAD_DP.dp),
     ) {
-        // Photos and Camera tiles. Photos uses the permissionless system photo
-        // picker; Camera uses ACTION_IMAGE_CAPTURE against a cache-scoped
-        // FileProvider URI. Neither requires READ_MEDIA_IMAGES — the recent-
-        // photos thumbnail strip that needs it lands in a follow-up.
-        PhotosCameraTile(modifier = Modifier.fillMaxWidth().padding(contentPadding))
+        when (resolveMediaStripView(access, rejected)) {
+            MediaStripView.Rationale -> {
+                val needs = access as PhotoAccess.NeedsPermission
+                // Rationale fills the remaining width next to the Photos/Camera
+                // column — no horizontal scroll needed since nothing extends past
+                // the viewport.
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp),
+                    modifier = Modifier.fillMaxWidth().padding(contentPadding),
+                ) {
+                    PhotosCameraTile(horizontal = false)
+                    PhotoAccessRationale(
+                        state = needs.state,
+                        onAllow = needs.request,
+                        onReject = {
+                            markRationaleRejected(context)
+                            rejected = true
+                        },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+            MediaStripView.CompactTiles -> {
+                // Rationale dismissed — keep the Photos/Camera buttons accessible
+                // but flatten them into a single full-width row. Picker and camera
+                // don't need the photo permission; only the recent-photo strip does.
+                PhotosCameraTile(
+                    horizontal = true,
+                    modifier = Modifier.fillMaxWidth().padding(contentPadding),
+                )
+            }
+            MediaStripView.FullStrip -> FullMediaStrip(
+                granted = access as? PhotoAccess.Granted,
+                contentPadding = contentPadding,
+            )
+        }
     }
 }
 
 @Composable
-private fun PhotosCameraTile(modifier: Modifier = Modifier) {
+private fun FullMediaStrip(granted: PhotoAccess.Granted?, contentPadding: PaddingValues) {
+    // Granted — thumbnail strip extends past the viewport. LazyRow composes
+    // only the visible columns (plus prefetch), so the 64 thumbnails aren't
+    // all decoded into memory upfront. Vertical drags pass through the lazy
+    // list's nested-scroll dispatch up to BottomSheetBehavior; no manual
+    // relay needed.
+    val uris = granted?.uris.orEmpty()
+    val columns = (uris.size + 1) / 2
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp),
+        contentPadding = contentPadding,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        item(key = "actions") { PhotosCameraTile(horizontal = false) }
+        items(columns, key = { uris[it * 2].toString() }) { col ->
+            Column(verticalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp)) {
+                RealThumbnail(uri = uris[col * 2])
+                val secondIndex = col * 2 + 1
+                if (secondIndex < uris.size) {
+                    RealThumbnail(uri = uris[secondIndex])
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod")
+private fun PhotosCameraTile(
+    horizontal: Boolean,
+    modifier: Modifier = Modifier,
+) {
     val context = LocalContext.current
+    // System photo picker is permissionless — our READ_MEDIA_IMAGES permission
+    // only gates the recent-photos strip, not this launch path.
+    //
     // The result callbacks below are intentionally inert: the picked URI / camera
     // capture needs to round-trip through `WebViewAssetLoader` so the JS editor
     // can `fetch()` it, which is a follow-up. Until that lands, this whole sheet
@@ -455,6 +569,9 @@ private fun PhotosCameraTile(modifier: Modifier = Modifier) {
     val photoPicker = rememberLauncherForActivityResult(
         ActivityResultContracts.PickVisualMedia()
     ) { /* picked uri — hand-off to editor insertion is a follow-up */ }
+    // Camera writes into a cache-scoped temp file exposed by the library's
+    // FileProvider; no CAMERA permission needed since we delegate to the
+    // system camera app via ACTION_IMAGE_CAPTURE.
     var pendingCameraUri by remember { mutableStateOf<Uri?>(null) }
     val cameraLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.TakePicture()
@@ -469,26 +586,54 @@ private fun PhotosCameraTile(modifier: Modifier = Modifier) {
         pendingCameraUri = uri
         cameraLauncher.launch(uri)
     }
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(MEDIA_STACK_GAP_DP.dp),
-        modifier = modifier.height(MEDIA_STACK_COMPACT_HEIGHT_DP.dp),
-    ) {
-        MediaActionTile(
-            iconVector = Icons.Filled.PhotoLibrary,
-            label = stringResource(R.string.gbk_block_inserter_photos),
-            background = MaterialTheme.colorScheme.primaryContainer,
-            foreground = MaterialTheme.colorScheme.onPrimaryContainer,
-            onClick = onPhotosClick,
-            modifier = Modifier.fillMaxHeight().weight(1f),
-        )
-        MediaActionTile(
-            iconVector = Icons.Filled.PhotoCamera,
-            label = stringResource(R.string.gbk_block_inserter_camera),
-            background = MaterialTheme.colorScheme.tertiary,
-            foreground = MaterialTheme.colorScheme.onTertiary,
-            onClick = onCameraClick,
-            modifier = Modifier.fillMaxHeight().weight(1f),
-        )
+    val photosLabel = stringResource(R.string.gbk_block_inserter_photos)
+    val cameraLabel = stringResource(R.string.gbk_block_inserter_camera)
+    if (horizontal) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(MEDIA_STACK_GAP_DP.dp),
+            modifier = modifier.height(MEDIA_STACK_COMPACT_HEIGHT_DP.dp),
+        ) {
+            MediaActionTile(
+                iconVector = Icons.Filled.PhotoLibrary,
+                label = photosLabel,
+                background = MaterialTheme.colorScheme.primaryContainer,
+                foreground = MaterialTheme.colorScheme.onPrimaryContainer,
+                onClick = onPhotosClick,
+                modifier = Modifier.fillMaxHeight().weight(1f),
+            )
+            MediaActionTile(
+                iconVector = Icons.Filled.PhotoCamera,
+                label = cameraLabel,
+                background = MaterialTheme.colorScheme.tertiary,
+                foreground = MaterialTheme.colorScheme.onTertiary,
+                onClick = onCameraClick,
+                modifier = Modifier.fillMaxHeight().weight(1f),
+            )
+        }
+    } else {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(MEDIA_STACK_GAP_DP.dp),
+            modifier = modifier
+                .width(MEDIA_STACK_WIDTH_DP.dp)
+                .height(MEDIA_STACK_HEIGHT_DP.dp),
+        ) {
+            MediaActionTile(
+                iconVector = Icons.Filled.PhotoLibrary,
+                label = photosLabel,
+                background = MaterialTheme.colorScheme.primaryContainer,
+                foreground = MaterialTheme.colorScheme.onPrimaryContainer,
+                onClick = onPhotosClick,
+                modifier = Modifier.fillMaxWidth().weight(1f),
+            )
+            MediaActionTile(
+                iconVector = Icons.Filled.PhotoCamera,
+                label = cameraLabel,
+                background = MaterialTheme.colorScheme.tertiary,
+                foreground = MaterialTheme.colorScheme.onTertiary,
+                onClick = onCameraClick,
+                modifier = Modifier.fillMaxWidth().weight(1f),
+            )
+        }
     }
 }
 
@@ -534,6 +679,127 @@ private fun MediaActionTile(
             color = foreground,
             fontSize = MEDIA_STACK_LABEL_SP.sp,
             fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun PhotoAccessRationale(
+    state: PromptState,
+    onAllow: () -> Unit,
+    onReject: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val bodyRes = when (state) {
+        PromptState.Unasked -> R.string.gbk_block_inserter_photos_rationale
+        PromptState.Denied -> R.string.gbk_block_inserter_photos_rationale_denied
+        PromptState.PermanentlyDenied -> R.string.gbk_block_inserter_photos_rationale_permanent
+    }
+    val primaryLabelRes = when (state) {
+        PromptState.Unasked -> R.string.gbk_block_inserter_photos_allow
+        PromptState.Denied -> R.string.gbk_block_inserter_photos_try_again
+        PromptState.PermanentlyDenied -> R.string.gbk_block_inserter_photos_open_settings
+    }
+    @Composable
+    fun RationaleButton(label: String, filled: Boolean, onClick: () -> Unit, modifier: Modifier) {
+        val bg = if (filled) MaterialTheme.colorScheme.primary else ComposeColor.Transparent
+        val fg = if (filled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary
+        // Outer wrapper inflates the touch zone to the 48dp minimum; the inner
+        // Box paints the design's 32dp pill. The shared interaction source lets
+        // the outer absorb taps with no indication while the inner draws the
+        // ripple — otherwise a default ripple on the outer would render as a
+        // square halo around the rounded pill.
+        val interactionSource = remember { MutableInteractionSource() }
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = modifier
+                .heightIn(min = TOUCH_TARGET_MIN_DP.dp)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onClick,
+                ),
+        ) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(MEDIA_RATIONALE_BUTTON_HEIGHT_DP.dp)
+                    .clip(RoundedCornerShape(MEDIA_RATIONALE_BUTTON_CORNER_DP.dp))
+                    .background(bg)
+                    .indication(interactionSource, ripple()),
+            ) {
+                Text(
+                    text = label,
+                    color = fg,
+                    fontSize = MEDIA_RATIONALE_BUTTON_FONT_SP.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+    }
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier
+            .height(MEDIA_STACK_HEIGHT_DP.dp)
+            .clip(RoundedCornerShape(MEDIA_STACK_CORNER_DP.dp))
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .padding(MEDIA_RATIONALE_PAD_DP.dp),
+    ) {
+        Text(
+            text = stringResource(bodyRes),
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            fontSize = MEDIA_RATIONALE_FONT_SP.sp,
+            lineHeight = MEDIA_RATIONALE_LINE_HEIGHT_SP.sp,
+            fontWeight = FontWeight.Medium,
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(MEDIA_RATIONALE_BUTTON_GAP_DP.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            RationaleButton(
+                label = stringResource(primaryLabelRes),
+                filled = true,
+                onClick = onAllow,
+                modifier = Modifier.weight(1f),
+            )
+            RationaleButton(
+                label = stringResource(R.string.gbk_block_inserter_photos_reject),
+                filled = false,
+                onClick = onReject,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun RealThumbnail(uri: Uri) {
+    val context = LocalContext.current
+    val sizePx = with(LocalDensity.current) { MEDIA_THUMB_SIZE_DP.dp.roundToPx() }
+    var bitmap by remember(uri) { mutableStateOf<ImageBitmap?>(null) }
+    LaunchedEffect(uri, sizePx) {
+        bitmap = withContext(Dispatchers.IO) { loadThumbnail(context, uri, sizePx) }
+    }
+    val bmp = bitmap
+    if (bmp != null) {
+        Image(
+            bitmap = bmp,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(MEDIA_THUMB_SIZE_DP.dp)
+                .clip(RoundedCornerShape(MEDIA_THUMB_CORNER_DP.dp)),
+        )
+    } else {
+        // Neutral loading box — avoids flashing colorful mock-photo gradients
+        // between the URI being known and the bitmap finishing async load.
+        Box(
+            modifier = Modifier
+                .size(MEDIA_THUMB_SIZE_DP.dp)
+                .clip(RoundedCornerShape(MEDIA_THUMB_CORNER_DP.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         )
     }
 }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -2,8 +2,12 @@ package org.wordpress.gutenberg.inserter
 
 import android.content.Context
 import android.graphics.Color
+import android.net.Uri
 import android.os.Build
 import android.view.ViewGroup
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -19,6 +23,7 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -33,6 +38,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.Icon
@@ -54,6 +61,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.geometry.Offset
@@ -76,8 +84,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.FileProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import java.io.File
 import kotlin.math.roundToInt
 import kotlinx.coroutines.delay
 import org.wordpress.gutenberg.R
@@ -112,6 +122,17 @@ private const val HEADER_TITLE_LETTER_SPACING_SP = -0.1
 
 private const val ICON_BUTTON_SIZE_DP = 40
 private const val ICON_SIZE_DP = 20
+
+private const val MEDIA_STRIP_TOP_PAD_DP = 4
+private const val MEDIA_STRIP_BOTTOM_PAD_DP = 10
+private const val MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP = 20
+private const val MEDIA_STRIP_CONTENT_TOP_PAD_DP = 2
+private const val MEDIA_STRIP_CONTENT_BOTTOM_PAD_DP = 6
+private const val MEDIA_STACK_COMPACT_HEIGHT_DP = 88
+private const val MEDIA_STACK_GAP_DP = 4
+private const val MEDIA_STACK_CORNER_DP = 18
+private const val MEDIA_STACK_ICON_SIZE_DP = 28
+private const val MEDIA_STACK_LABEL_SP = 13
 
 private const val TABS_VERTICAL_PAD_DP = 4
 private const val TABS_BOTTOM_PAD_DP = 6
@@ -269,6 +290,7 @@ private fun SheetContent(
     ) {
         DragHandle()
         Header(onClose = onClose)
+        MediaStrip()
         CategoryTabs(selected = selectedTab, onSelect = onSelectTab)
         SearchField(query = query, onQueryChange = onQueryChange)
         BlockGridContent(
@@ -397,6 +419,121 @@ private fun CloseButton(onClose: () -> Unit) {
             contentDescription = stringResource(R.string.gbk_block_inserter_close),
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.size(ICON_SIZE_DP.dp),
+        )
+    }
+}
+
+@Composable
+private fun MediaStrip() {
+    val contentPadding = PaddingValues(
+        start = MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP.dp,
+        end = MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP.dp,
+        top = MEDIA_STRIP_CONTENT_TOP_PAD_DP.dp,
+        bottom = MEDIA_STRIP_CONTENT_BOTTOM_PAD_DP.dp,
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = MEDIA_STRIP_TOP_PAD_DP.dp, bottom = MEDIA_STRIP_BOTTOM_PAD_DP.dp),
+    ) {
+        // Photos and Camera tiles. Photos uses the permissionless system photo
+        // picker; Camera uses ACTION_IMAGE_CAPTURE against a cache-scoped
+        // FileProvider URI. Neither requires READ_MEDIA_IMAGES — the recent-
+        // photos thumbnail strip that needs it lands in a follow-up.
+        PhotosCameraTile(modifier = Modifier.fillMaxWidth().padding(contentPadding))
+    }
+}
+
+@Composable
+private fun PhotosCameraTile(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    // The result callbacks below are intentionally inert: the picked URI / camera
+    // capture needs to round-trip through `WebViewAssetLoader` so the JS editor
+    // can `fetch()` it, which is a follow-up. Until that lands, this whole sheet
+    // is gated behind the demo app's "Enable Native Inserter" toggle, so users
+    // outside that opt-in won't see the no-op buttons.
+    val photoPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { /* picked uri — hand-off to editor insertion is a follow-up */ }
+    var pendingCameraUri by remember { mutableStateOf<Uri?>(null) }
+    val cameraLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.TakePicture()
+    ) { /* success:Boolean + pendingCameraUri — hand-off is a follow-up */ }
+    val onPhotosClick = {
+        photoPicker.launch(
+            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+        )
+    }
+    val onCameraClick = {
+        val uri = createCameraOutputUri(context)
+        pendingCameraUri = uri
+        cameraLauncher.launch(uri)
+    }
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(MEDIA_STACK_GAP_DP.dp),
+        modifier = modifier.height(MEDIA_STACK_COMPACT_HEIGHT_DP.dp),
+    ) {
+        MediaActionTile(
+            iconVector = Icons.Filled.PhotoLibrary,
+            label = stringResource(R.string.gbk_block_inserter_photos),
+            background = MaterialTheme.colorScheme.primaryContainer,
+            foreground = MaterialTheme.colorScheme.onPrimaryContainer,
+            onClick = onPhotosClick,
+            modifier = Modifier.fillMaxHeight().weight(1f),
+        )
+        MediaActionTile(
+            iconVector = Icons.Filled.PhotoCamera,
+            label = stringResource(R.string.gbk_block_inserter_camera),
+            background = MaterialTheme.colorScheme.tertiary,
+            foreground = MaterialTheme.colorScheme.onTertiary,
+            onClick = onCameraClick,
+            modifier = Modifier.fillMaxHeight().weight(1f),
+        )
+    }
+}
+
+private fun createCameraOutputUri(context: Context): Uri {
+    val dir = File(context.cacheDir, "camera").apply { mkdirs() }
+    val file = File(dir, "capture_${System.currentTimeMillis()}.jpg")
+    // TODO: clean up captured files once the editor hand-off lands. Each Camera
+    // tap creates a fresh file here; with the result callback inert today, every
+    // capture is orphaned in the cache. When we wire up the URI hand-off, delete
+    // on success/cancel and sweep stale files on next entry.
+    return FileProvider.getUriForFile(
+        context,
+        "${context.packageName}.gutenberg.fileprovider",
+        file,
+    )
+}
+
+@Composable
+private fun MediaActionTile(
+    iconVector: ImageVector,
+    label: String,
+    background: ComposeColor,
+    foreground: ComposeColor,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = modifier
+            .clip(RoundedCornerShape(MEDIA_STACK_CORNER_DP.dp))
+            .background(background)
+            .clickable(onClick = onClick),
+    ) {
+        Icon(
+            imageVector = iconVector,
+            contentDescription = null,
+            tint = foreground,
+            modifier = Modifier.size(MEDIA_STACK_ICON_SIZE_DP.dp),
+        )
+        Text(
+            text = label,
+            color = foreground,
+            fontSize = MEDIA_STACK_LABEL_SP.sp,
+            fontWeight = FontWeight.Medium,
         )
     }
 }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -45,6 +45,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -532,6 +533,7 @@ private fun FullMediaStrip(granted: PhotoAccess.Granted?, contentPadding: Paddin
     // list's nested-scroll dispatch up to BottomSheetBehavior; no manual
     // relay needed.
     val uris = granted?.uris.orEmpty()
+    val partialAccess = granted?.partialAccess
     val columns = (uris.size + 1) / 2
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp),
@@ -539,6 +541,14 @@ private fun FullMediaStrip(granted: PhotoAccess.Granted?, contentPadding: Paddin
         modifier = Modifier.fillMaxWidth(),
     ) {
         item(key = "actions") { PhotosCameraTile(horizontal = false) }
+        if (partialAccess != null) {
+            // Sits right after Photos/Camera so the affordance is visible without
+            // scrolling — partial-access users won't otherwise have any in-app
+            // path to update their selection.
+            item(key = "manage") {
+                ManageSelectionTile(onClick = partialAccess.onManageSelection)
+            }
+        }
         items(columns, key = { uris[it * 2].toString() }) { col ->
             Column(verticalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp)) {
                 RealThumbnail(uri = uris[col * 2])
@@ -549,6 +559,20 @@ private fun FullMediaStrip(granted: PhotoAccess.Granted?, contentPadding: Paddin
             }
         }
     }
+}
+
+@Composable
+private fun ManageSelectionTile(onClick: () -> Unit) {
+    MediaActionTile(
+        iconVector = Icons.Filled.Tune,
+        label = stringResource(R.string.gbk_block_inserter_photos_manage),
+        background = MaterialTheme.colorScheme.secondaryContainer,
+        foreground = MaterialTheme.colorScheme.onSecondaryContainer,
+        onClick = onClick,
+        modifier = Modifier
+            .width(MEDIA_STACK_WIDTH_DP.dp)
+            .height(MEDIA_STACK_HEIGHT_DP.dp),
+    )
 }
 
 @Composable

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/PhotoAccessState.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/PhotoAccessState.kt
@@ -1,0 +1,60 @@
+package org.wordpress.gutenberg.inserter
+
+import android.net.Uri
+
+/**
+ * Photo-library access state for the inserter's media strip. Distinguishes
+ * "never asked" from "permanently denied" by persisting whether the system
+ * prompt has been shown at least once — Android's
+ * `shouldShowRequestPermissionRationale` alone can't tell those apart.
+ */
+internal sealed interface PhotoAccess {
+    data class Granted(val uris: List<Uri>) : PhotoAccess
+    data class NeedsPermission(
+        val state: PromptState,
+        val request: () -> Unit,
+    ) : PhotoAccess
+}
+
+/**
+ * Three mutually exclusive states the rationale card needs to distinguish:
+ * never asked, denied once (system will re-prompt), or permanently denied
+ * (system prompt is suppressed, user must enable via Settings).
+ */
+internal enum class PromptState { Unasked, Denied, PermanentlyDenied }
+
+/**
+ * Pure mapping from the two Android signals to the rationale's three-way state.
+ * `canReprompt` is `Activity.shouldShowRequestPermissionRationale(...)`'s result;
+ * `promptedBefore` is our SharedPreferences flag set after the first system prompt.
+ */
+internal fun resolvePromptState(
+    promptedBefore: Boolean,
+    canReprompt: Boolean,
+): PromptState = when {
+    !promptedBefore -> PromptState.Unasked
+    canReprompt -> PromptState.Denied
+    else -> PromptState.PermanentlyDenied
+}
+
+/**
+ * Which of the three media-strip layouts the inserter should render. A granted
+ * permission always wins over a sticky rejection so users get the thumbnail
+ * strip back if they grant access via system Settings after dismissing the
+ * rationale.
+ */
+internal sealed class MediaStripView {
+    object Rationale : MediaStripView()
+    object CompactTiles : MediaStripView()
+    object FullStrip : MediaStripView()
+}
+
+internal fun resolveMediaStripView(
+    access: PhotoAccess,
+    rejected: Boolean,
+): MediaStripView = when {
+    access is PhotoAccess.Granted -> MediaStripView.FullStrip
+    rejected -> MediaStripView.CompactTiles
+    access is PhotoAccess.NeedsPermission -> MediaStripView.Rationale
+    else -> MediaStripView.FullStrip
+}

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/PhotoAccessState.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/PhotoAccessState.kt
@@ -9,11 +9,22 @@ import android.net.Uri
  * `shouldShowRequestPermissionRationale` alone can't tell those apart.
  */
 internal sealed interface PhotoAccess {
-    data class Granted(val uris: List<Uri>) : PhotoAccess
+    /**
+     * Permission has been granted. `partialAccess` is non-null on Android 14+
+     * when the user picked "Select photos and videos" rather than full access —
+     * its `onManageSelection` reopens the system picker so the user can update
+     * the selection without leaving the app.
+     */
+    data class Granted(
+        val uris: List<Uri>,
+        val partialAccess: PartialAccess? = null,
+    ) : PhotoAccess
     data class NeedsPermission(
         val state: PromptState,
         val request: () -> Unit,
     ) : PhotoAccess
+
+    data class PartialAccess(val onManageSelection: () -> Unit)
 }
 
 /**

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/RecentImages.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/RecentImages.kt
@@ -41,6 +41,7 @@ internal fun rememberPhotoAccess(limit: Int): PhotoAccess {
     val context = LocalContext.current
     val activity = remember(context) { context.findActivity() }
     var granted by remember { mutableStateOf(hasPhotosPermission(context)) }
+    var partial by remember { mutableStateOf(isPartialPhotoAccess(context)) }
     var promptedBefore by remember { mutableStateOf(hasPromptedForPhotos(context)) }
     var uris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     // `canReprompt` is its own state, recomputed at every permission-relevant
@@ -52,16 +53,22 @@ internal fun rememberPhotoAccess(limit: Int): PhotoAccess {
     var canReprompt by remember {
         mutableStateOf(activity?.let { shouldShowRationale(it) } ?: true)
     }
+    // Bumped after every launcher result. Keys the MediaStore re-query so a
+    // partial-access selection update (granted stays true, uris content changes)
+    // refreshes the strip — `granted`/`limit` alone wouldn't trigger that.
+    var refreshTick by remember { mutableStateOf(0) }
     val refreshAccessState = {
         granted = hasPhotosPermission(context)
+        partial = isPartialPhotoAccess(context)
         canReprompt = activity?.let { shouldShowRationale(it) } ?: true
     }
     val launcher = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission()
+        ActivityResultContracts.RequestMultiplePermissions()
     ) { _ ->
         markPromptedForPhotos(context)
         promptedBefore = true
         refreshAccessState()
+        refreshTick++
     }
     // Re-read permission on every RESUME so we notice grants made via system
     // Settings (which happen outside the Compose result-callback path).
@@ -79,20 +86,29 @@ internal fun rememberPhotoAccess(limit: Int): PhotoAccess {
         activityLifecycle.addObserver(observer)
         onDispose { activityLifecycle.removeObserver(observer) }
     }
-    LaunchedEffect(granted, limit) {
+    LaunchedEffect(granted, limit, refreshTick) {
         uris = if (granted) {
             withContext(Dispatchers.IO) { queryRecentImages(context, limit) }
         } else {
             emptyList()
         }
     }
-    if (granted) return PhotoAccess.Granted(uris)
+    if (granted) {
+        return PhotoAccess.Granted(
+            uris = uris,
+            partialAccess = if (partial) {
+                PhotoAccess.PartialAccess(
+                    onManageSelection = { launcher.launch(photosPermissions()) },
+                )
+            } else null,
+        )
+    }
     val state = resolvePromptState(promptedBefore = promptedBefore, canReprompt = canReprompt)
     return PhotoAccess.NeedsPermission(
         state = state,
         request = {
             if (state == PromptState.PermanentlyDenied) openAppSettings(context)
-            else launcher.launch(photosPermission())
+            else launcher.launch(photosPermissions())
         },
     )
 }
@@ -114,8 +130,50 @@ private fun photosPermission(): String =
         Manifest.permission.READ_EXTERNAL_STORAGE
     }
 
-private fun hasPhotosPermission(context: Context): Boolean =
-    ContextCompat.checkSelfPermission(context, photosPermission()) == PackageManager.PERMISSION_GRANTED
+/**
+ * The permission set to request together. On Android 14+ we ask for both the
+ * full and partial-access permissions in one prompt — the system surfaces the
+ * "Select photos and videos" affordance, and on subsequent calls reopens the
+ * picker so the user can update a partial-access selection without leaving us.
+ */
+private fun photosPermissions(): Array<String> = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> arrayOf(
+        Manifest.permission.READ_MEDIA_IMAGES,
+        Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+    )
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> arrayOf(
+        Manifest.permission.READ_MEDIA_IMAGES,
+    )
+    else -> arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+}
+
+/** True when either full or partial-access reads are permitted. */
+private fun hasPhotosPermission(context: Context): Boolean {
+    if (ContextCompat.checkSelfPermission(context, photosPermission()) == PackageManager.PERMISSION_GRANTED) {
+        return true
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+    return false
+}
+
+/** True only when the user picked "Select photos and videos" (Android 14+). */
+private fun isPartialPhotoAccess(context: Context): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false
+    val full = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.READ_MEDIA_IMAGES,
+    ) == PackageManager.PERMISSION_GRANTED
+    if (full) return false
+    return ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+    ) == PackageManager.PERMISSION_GRANTED
+}
 
 private fun shouldShowRationale(activity: Activity): Boolean =
     ActivityCompat.shouldShowRequestPermissionRationale(activity, photosPermission())

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/RecentImages.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/RecentImages.kt
@@ -1,0 +1,191 @@
+package org.wordpress.gutenberg.inserter
+
+import android.Manifest
+import android.app.Activity
+import android.content.ContentUris
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.provider.Settings
+import android.util.Size as AndroidSize
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val PHOTO_PREFS = "gbk_inserter"
+private const val KEY_PHOTOS_PROMPTED = "photos_prompted"
+private const val KEY_RATIONALE_REJECTED = "rationale_rejected"
+
+@Composable
+internal fun rememberPhotoAccess(limit: Int): PhotoAccess {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findActivity() }
+    var granted by remember { mutableStateOf(hasPhotosPermission(context)) }
+    var promptedBefore by remember { mutableStateOf(hasPromptedForPhotos(context)) }
+    var uris by remember { mutableStateOf<List<Uri>>(emptyList()) }
+    // `canReprompt` is its own state, recomputed at every permission-relevant
+    // signal (launcher result, lifecycle resume). Compose's snapshot system
+    // can't see the OS-level `shouldShowRequestPermissionRationale` flip from
+    // true → false on the 2nd denial otherwise — `granted` and `promptedBefore`
+    // are already in their post-deny values, so neither would notify Compose
+    // and the rationale would stay stuck on "Try Again".
+    var canReprompt by remember {
+        mutableStateOf(activity?.let { shouldShowRationale(it) } ?: true)
+    }
+    val refreshAccessState = {
+        granted = hasPhotosPermission(context)
+        canReprompt = activity?.let { shouldShowRationale(it) } ?: true
+    }
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { _ ->
+        markPromptedForPhotos(context)
+        promptedBefore = true
+        refreshAccessState()
+    }
+    // Re-read permission on every RESUME so we notice grants made via system
+    // Settings (which happen outside the Compose result-callback path).
+    // Important: observe the host Activity's lifecycle, not the Compose-default
+    // LocalLifecycleOwner. Inside a BottomSheetDialog the latter resolves to the
+    // dialog's own LifecycleRegistry (per ComponentDialog), which only dispatches
+    // ON_RESUME from `show()` and never refires when the user leaves to system
+    // Settings and returns. The Activity's lifecycle does refire ON_RESUME.
+    val activityLifecycle = (activity as? LifecycleOwner)?.lifecycle
+    DisposableEffect(activityLifecycle) {
+        if (activityLifecycle == null) return@DisposableEffect onDispose { }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) refreshAccessState()
+        }
+        activityLifecycle.addObserver(observer)
+        onDispose { activityLifecycle.removeObserver(observer) }
+    }
+    LaunchedEffect(granted, limit) {
+        uris = if (granted) {
+            withContext(Dispatchers.IO) { queryRecentImages(context, limit) }
+        } else {
+            emptyList()
+        }
+    }
+    if (granted) return PhotoAccess.Granted(uris)
+    val state = resolvePromptState(promptedBefore = promptedBefore, canReprompt = canReprompt)
+    return PhotoAccess.NeedsPermission(
+        state = state,
+        request = {
+            if (state == PromptState.PermanentlyDenied) openAppSettings(context)
+            else launcher.launch(photosPermission())
+        },
+    )
+}
+
+internal fun loadThumbnail(context: Context, uri: Uri, sizePx: Int): ImageBitmap? =
+    runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            context.contentResolver.loadThumbnail(uri, AndroidSize(sizePx, sizePx), null)
+                .asImageBitmap()
+        } else {
+            null
+        }
+    }.getOrNull()
+
+private fun photosPermission(): String =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+
+private fun hasPhotosPermission(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(context, photosPermission()) == PackageManager.PERMISSION_GRANTED
+
+private fun shouldShowRationale(activity: Activity): Boolean =
+    ActivityCompat.shouldShowRequestPermissionRationale(activity, photosPermission())
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
+
+private fun openAppSettings(context: Context) {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", context.packageName, null)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(intent)
+}
+
+private fun hasPromptedForPhotos(context: Context): Boolean =
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .getBoolean(KEY_PHOTOS_PROMPTED, false)
+
+private fun markPromptedForPhotos(context: Context) {
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .edit().putBoolean(KEY_PHOTOS_PROMPTED, true).apply()
+}
+
+internal fun hasRejectedRationale(context: Context): Boolean =
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .getBoolean(KEY_RATIONALE_REJECTED, false)
+
+internal fun markRationaleRejected(context: Context) {
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .edit().putBoolean(KEY_RATIONALE_REJECTED, true).apply()
+}
+
+/**
+ * Clears just the rationale-rejected flag (leaving the prompted-before flag
+ * alone). Called when we observe the photo permission becoming granted, so a
+ * subsequent revocation surfaces the rationale again instead of stranding the
+ * user in CompactTiles with no in-app affordance to re-engage.
+ */
+internal fun clearRejectedRationale(context: Context) {
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .edit().remove(KEY_RATIONALE_REJECTED).apply()
+}
+
+internal fun clearPhotoPreferences(context: Context) {
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .edit().clear().apply()
+}
+
+private fun queryRecentImages(context: Context, limit: Int): List<Uri> {
+    val collection = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL)
+    } else {
+        @Suppress("DEPRECATION")
+        MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+    }
+    val projection = arrayOf(MediaStore.Images.Media._ID)
+    val sortOrder = "${MediaStore.Images.Media.DATE_ADDED} DESC"
+    val result = mutableListOf<Uri>()
+    runCatching {
+        context.contentResolver.query(collection, projection, null, null, sortOrder)?.use { cursor ->
+            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+            while (cursor.moveToNext() && result.size < limit) {
+                val id = cursor.getLong(idColumn)
+                result.add(ContentUris.withAppendedId(collection, id))
+            }
+        }
+    }
+    return result
+}

--- a/android/Gutenberg/src/main/res/values/strings.xml
+++ b/android/Gutenberg/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
     <string name="gbk_block_inserter_clear_search">Clear search</string>
     <string name="gbk_block_inserter_no_results">No results</string>
     <string name="gbk_block_inserter_no_results_for">No blocks match “%1$s”</string>
+    <string name="gbk_block_inserter_photos">Photos</string>
+    <string name="gbk_block_inserter_camera">Camera</string>
 </resources>

--- a/android/Gutenberg/src/main/res/values/strings.xml
+++ b/android/Gutenberg/src/main/res/values/strings.xml
@@ -25,4 +25,5 @@
     <string name="gbk_block_inserter_photos_try_again">Try Again</string>
     <string name="gbk_block_inserter_photos_reject">Reject</string>
     <string name="gbk_block_inserter_photos_open_settings">Open Settings</string>
+    <string name="gbk_block_inserter_photos_manage">Manage</string>
 </resources>

--- a/android/Gutenberg/src/main/res/values/strings.xml
+++ b/android/Gutenberg/src/main/res/values/strings.xml
@@ -18,4 +18,11 @@
     <string name="gbk_block_inserter_no_results_for">No blocks match “%1$s”</string>
     <string name="gbk_block_inserter_photos">Photos</string>
     <string name="gbk_block_inserter_camera">Camera</string>
+    <string name="gbk_block_inserter_photos_rationale">Show your photo library here to quickly insert an image</string>
+    <string name="gbk_block_inserter_photos_rationale_denied">Allow access to show your photo library here</string>
+    <string name="gbk_block_inserter_photos_rationale_permanent">Enable photo access in Settings to show your library here</string>
+    <string name="gbk_block_inserter_photos_allow">Allow</string>
+    <string name="gbk_block_inserter_photos_try_again">Try Again</string>
+    <string name="gbk_block_inserter_photos_reject">Reject</string>
+    <string name="gbk_block_inserter_photos_open_settings">Open Settings</string>
 </resources>

--- a/android/Gutenberg/src/main/res/xml/gbk_file_paths.xml
+++ b/android/Gutenberg/src/main/res/xml/gbk_file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="gbk_camera" path="camera/" />
+</paths>

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/PhotoAccessStateTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/PhotoAccessStateTest.kt
@@ -45,6 +45,16 @@ class PhotoAccessStateTest {
     }
 
     @Test
+    fun `partial access still shows full strip`() {
+        val partial = PhotoAccess.Granted(
+            uris = emptyList(),
+            partialAccess = PhotoAccess.PartialAccess(onManageSelection = {}),
+        )
+        assertEquals(MediaStripView.FullStrip, resolveMediaStripView(partial, rejected = false))
+        assertEquals(MediaStripView.FullStrip, resolveMediaStripView(partial, rejected = true))
+    }
+
+    @Test
     fun `needs-permission shows rationale when not rejected`() {
         val needs = needsPermission(PromptState.Denied)
         assertEquals(MediaStripView.Rationale, resolveMediaStripView(needs, rejected = false))

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/PhotoAccessStateTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/PhotoAccessStateTest.kt
@@ -1,0 +1,72 @@
+package org.wordpress.gutenberg.inserter
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PhotoAccessStateTest {
+
+    // resolvePromptState
+
+    @Test
+    fun `unasked when never prompted, regardless of canReprompt`() {
+        assertEquals(
+            PromptState.Unasked,
+            resolvePromptState(promptedBefore = false, canReprompt = true),
+        )
+        assertEquals(
+            PromptState.Unasked,
+            resolvePromptState(promptedBefore = false, canReprompt = false),
+        )
+    }
+
+    @Test
+    fun `denied when prompted before and system can re-prompt`() {
+        assertEquals(
+            PromptState.Denied,
+            resolvePromptState(promptedBefore = true, canReprompt = true),
+        )
+    }
+
+    @Test
+    fun `permanently denied when prompted before and system cannot re-prompt`() {
+        assertEquals(
+            PromptState.PermanentlyDenied,
+            resolvePromptState(promptedBefore = true, canReprompt = false),
+        )
+    }
+
+    // resolveMediaStripView
+
+    @Test
+    fun `granted access always shows full strip even after rejection`() {
+        val granted = PhotoAccess.Granted(uris = emptyList())
+        assertEquals(MediaStripView.FullStrip, resolveMediaStripView(granted, rejected = false))
+        assertEquals(MediaStripView.FullStrip, resolveMediaStripView(granted, rejected = true))
+    }
+
+    @Test
+    fun `needs-permission shows rationale when not rejected`() {
+        val needs = needsPermission(PromptState.Denied)
+        assertEquals(MediaStripView.Rationale, resolveMediaStripView(needs, rejected = false))
+    }
+
+    @Test
+    fun `needs-permission shows compact tiles when rejected`() {
+        val needs = needsPermission(PromptState.PermanentlyDenied)
+        assertEquals(MediaStripView.CompactTiles, resolveMediaStripView(needs, rejected = true))
+    }
+
+    @Test
+    fun `rationale shows for every prompt state when not rejected`() {
+        for (state in PromptState.entries) {
+            assertEquals(
+                "state=$state",
+                MediaStripView.Rationale,
+                resolveMediaStripView(needsPermission(state), rejected = false),
+            )
+        }
+    }
+
+    private fun needsPermission(state: PromptState) =
+        PhotoAccess.NeedsPermission(state = state, request = {})
+}

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -47,7 +47,9 @@ import com.example.gutenbergkit.ui.dialogs.AddConfigurationDialog
 import com.example.gutenbergkit.ui.dialogs.DeleteConfigurationDialog
 import com.example.gutenbergkit.ui.dialogs.DiscoveringSiteDialog
 import com.example.gutenbergkit.ui.theme.AppTheme
+import androidx.compose.ui.platform.LocalContext
 import org.wordpress.gutenberg.BuildConfig
+import org.wordpress.gutenberg.GutenbergView
 import uniffi.wp_mobile.Account
 
 class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCallback {
@@ -167,6 +169,7 @@ fun MainScreen(
     var showDeleteDialog = remember { mutableStateOf<ConfigurationItem.ConfiguredEditor?>(null) }
     var siteUrlInput = remember { mutableStateOf("") }
     var showOverflowMenu = remember { mutableStateOf(false) }
+    val context = LocalContext.current
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -189,6 +192,13 @@ fun MainScreen(
                             onClick = {
                                 showOverflowMenu.value = false
                                 onMediaProxyServer()
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Reset Photo Permissions Prompts") },
+                            onClick = {
+                                showOverflowMenu.value = false
+                                GutenbergView.resetBlockPickerPhotoPreferences(context)
                             }
                         )
                     }

--- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
@@ -19,7 +19,7 @@ import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.PostType as WpPostType
 
 data class SitePreparationUiState(
-    val enableNativeInserter: Boolean = false,
+    val enableNativeInserter: Boolean = true,
     val enableNetworkLogging: Boolean = false,
     /** All viewable post types fetched from the site, or empty while loading. */
     val postTypes: List<PostTypeDetails> = emptyList(),


### PR DESCRIPTION
## Summary

Layers on top of #510 with proper handling for Android 14's "Select photos and videos" partial-access flow.

Android 14 added a third option to the photo-permission dialog: users can pick **Allow**, **Select photos and videos**, or **Don't allow**. Without opting in to the partial-access permission, the system still shows the three-way prompt, but the app sees a partial grant as full access — and the user has no in-app way to update which photos they've shared. The strip would show the same 3 photos forever, with the only path to add more being a trip to system Settings.

This PR closes that gap.

## Changes

- **Declare `READ_MEDIA_VISUAL_USER_SELECTED`** in the manifest. This is the partial-access opt-in that signals to the system that we understand and handle partial grants.

  | Permission | SDK range | Purpose |
  |---|---|---|
  | `READ_MEDIA_VISUAL_USER_SELECTED` | 34+ | Detect partial grants, expose a Manage tile |

- **Switch the launcher from `RequestPermission` to `RequestMultiplePermissions`**, requesting both `READ_MEDIA_IMAGES` and `READ_MEDIA_VISUAL_USER_SELECTED` together via `photosPermissions(): Array<String>` (API-tiered). When partial is already granted, calling the launcher again reopens the photo picker so the user can update the selection — that's the in-app "Manage" path.

- **`hasPhotosPermission`** now accepts either full or partial reads. **`isPartialPhotoAccess`** distinguishes "selected photos only" so the strip can surface a Manage affordance.

- **`PhotoAccess.PartialAccess`** data class carries `onManageSelection`. `PhotoAccess.Granted` gains an optional `partialAccess: PartialAccess?` field — non-null only when the user picked partial.

- **`ManageSelectionTile`** sits right after the Photos/Camera column when partial access is active. Uses the `Tune` icon and `secondaryContainer` colour so it reads as an editorial control distinct from Photos/Camera. Visible without scrolling so partial-access users find it immediately.

- **`refreshTick`** keys the MediaStore re-query so a selection update (where `granted` stays true but the visible set changes) refreshes the strip — `granted` / `limit` alone wouldn't trigger that.

## Test plan

Requires an Android 14+ device.

- [ ] First launch + tap **Allow** in the rationale → system shows three-way prompt → pick **Select photos and videos** → choose 2-3 photos → strip shows those photos plus a **Manage** tile after the Photos/Camera column.
- [ ] Tap **Manage** → system reopens the photo picker → add another photo → return → strip updates to include the new selection.
- [ ] Tap **Manage** → system reopens the photo picker → remove one photo → return → strip updates to reflect the smaller selection.
- [ ] In system Settings, change from partial to full access → return to the app → Manage tile disappears, full thumbnail strip remains.
- [ ] In system Settings, revoke entirely → return to the app → rationale card returns (sticky rejected flag was cleared on grant in the parent PR).
- [ ] On Android 13 (no `READ_MEDIA_VISUAL_USER_SELECTED` available) → partial-access path is unreachable. Granting `READ_MEDIA_IMAGES` works as before.
- [ ] `PhotoAccessStateTest::partial access still shows full strip` passes.
- [ ] `./gradlew :Gutenberg:detekt :Gutenberg:assembleDebug :Gutenberg:testDebugUnitTest` passes.