### PR TITLE
refactor(android): replace pill chips with M3 scrollable tabs in inserter

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -14,12 +14,7 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.rememberScrollableState
-import androidx.compose.foundation.gestures.scrollable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -37,7 +32,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
@@ -46,9 +40,12 @@ import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SecondaryScrollableTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -80,7 +77,12 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
@@ -140,19 +142,12 @@ private const val MEDIA_STACK_CORNER_DP = 18
 private const val MEDIA_STACK_ICON_SIZE_DP = 28
 private const val MEDIA_STACK_LABEL_SP = 13
 
-private const val TABS_VERTICAL_PAD_DP = 4
-private const val TABS_BOTTOM_PAD_DP = 6
-private const val TABS_CONTENT_VERTICAL_PAD_DP = 4
-private const val TABS_CONTENT_HORIZONTAL_PAD_DP = 16
-private const val TABS_GAP_DP = 8
-private const val CHIP_HEIGHT_DP = 36
-private const val CHIP_HORIZONTAL_PAD_DP = 14
-private const val CHIP_CORNER_DP = 18
-private const val CHIP_BORDER_WIDTH_DP = 1
-private const val CHIP_FONT_SP = 13
-private const val CHIP_LETTER_SPACING_SP = 0.2
+// Matches M3's internal `Tab.HorizontalTextPadding` — the horizontal padding
+// applied by `Tab` between its layout bounds and the text label inside.
+// Hardcoded because the upstream constant is `internal`.
+private const val TAB_INTERNAL_TEXT_PAD_DP = 16
 
-private const val SEARCH_TOP_PAD_DP = 8
+private const val SEARCH_TOP_PAD_DP = 12
 private const val SEARCH_HORIZONTAL_PAD_DP = 20
 private const val SEARCH_BOTTOM_PAD_DP = 10
 private const val SEARCH_HEIGHT_DP = 40
@@ -188,7 +183,7 @@ private const val DISABLED_ALPHA = 0.5f
  * Bottom-sheet block inserter. The outer shell stays a `BottomSheetDialog` so
  * `GutenbergView`'s integration surface is unchanged; everything visible is
  * Compose content matching the Variation B design handoff — header row,
- * pill category tabs, rounded search, 5-column tonal tile grid.
+ * scrollable secondary tabs, rounded search, 5-column tonal tile grid.
  *
  * The sheet background and 28dp top corners are drawn by Compose directly; the
  * dialog's default white pill background is cleared so it doesn't fight the
@@ -411,7 +406,9 @@ private fun Header(onClose: () -> Unit) {
             fontSize = HEADER_TITLE_SP.sp,
             fontWeight = FontWeight.Medium,
             letterSpacing = HEADER_TITLE_LETTER_SPACING_SP.sp,
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .semantics { heading() },
         )
         CloseButton(onClose = onClose)
     }
@@ -558,81 +555,31 @@ private fun MediaActionTile(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun CategoryTabs(
     selected: BlockPickerTab,
     onSelect: (BlockPickerTab) -> Unit,
 ) {
-    val scrollState = rememberScrollState()
-    val verticalRelay = rememberScrollableState { 0f }
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = TABS_VERTICAL_PAD_DP.dp, bottom = TABS_BOTTOM_PAD_DP.dp),
+    val tabs = BlockPickerTab.entries
+    val selectedIndex = tabs.indexOf(selected).coerceAtLeast(0)
+    // Tab labels sit 16dp inside the Tab layout (M3's internal
+    // `HorizontalTextPadding`), so set `edgePadding` to `SEARCH_HORIZONTAL_PAD_DP
+    // - 16` to align the first label's leading edge with the search bar's
+    // outer edge instead of the default 52dp.
+    SecondaryScrollableTabRow(
+        selectedTabIndex = selectedIndex,
+        containerColor = ComposeColor.Transparent,
+        edgePadding = (SEARCH_HORIZONTAL_PAD_DP - TAB_INTERNAL_TEXT_PAD_DP).dp,
+        modifier = Modifier.fillMaxWidth(),
     ) {
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(TABS_GAP_DP.dp),
-            modifier = Modifier
-                .horizontalScroll(scrollState)
-                .scrollable(verticalRelay, Orientation.Vertical)
-                .padding(
-                    horizontal = TABS_CONTENT_HORIZONTAL_PAD_DP.dp,
-                    vertical = TABS_CONTENT_VERTICAL_PAD_DP.dp,
-                ),
-        ) {
-            BlockPickerTab.entries.forEach { tab ->
-                CategoryChip(
-                    label = stringResource(tab.labelRes),
-                    selected = tab == selected,
-                    onClick = { onSelect(tab) },
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun CategoryChip(
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
-    val background = if (selected) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        ComposeColor.Transparent
-    }
-    val textColor = if (selected) {
-        MaterialTheme.colorScheme.onPrimary
-    } else {
-        MaterialTheme.colorScheme.onSurface
-    }
-    val borderColor = if (selected) {
-        ComposeColor.Transparent
-    } else {
-        MaterialTheme.colorScheme.outlineVariant
-    }
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .height(CHIP_HEIGHT_DP.dp)
-            .clip(RoundedCornerShape(CHIP_CORNER_DP.dp))
-            .background(background)
-            .border(
-                width = CHIP_BORDER_WIDTH_DP.dp,
-                color = borderColor,
-                shape = RoundedCornerShape(CHIP_CORNER_DP.dp),
+        tabs.forEach { tab ->
+            Tab(
+                selected = tab == selected,
+                onClick = { onSelect(tab) },
+                text = { Text(stringResource(tab.labelRes)) },
             )
-            .clickable(onClick = onClick)
-            .padding(horizontal = CHIP_HORIZONTAL_PAD_DP.dp),
-    ) {
-        Text(
-            text = label,
-            color = textColor,
-            fontSize = CHIP_FONT_SP.sp,
-            fontWeight = FontWeight.Medium,
-            letterSpacing = CHIP_LETTER_SPACING_SP.sp,
-        )
+        }
     }
 }
 
@@ -690,6 +637,13 @@ private fun SearchInput(
     onQueryChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // The placeholder Text inside `decorationBox` is a visual hint, not an
+    // accessible name — without `contentDescription` on the field, focusing
+    // the empty field would announce as "edit box" with no context.
+    // `clearAndSetSemantics {}` on the placeholder hides its own `text`
+    // semantic so TalkBack reads the field's `contentDescription` once
+    // ("Search blocks, edit box") instead of duplicating from the placeholder.
+    val label = stringResource(R.string.gbk_block_inserter_search)
     BasicTextField(
         value = query,
         onValueChange = onQueryChange,
@@ -699,13 +653,14 @@ private fun SearchInput(
             color = MaterialTheme.colorScheme.onSurface,
         ),
         cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-        modifier = modifier,
+        modifier = modifier.semantics { contentDescription = label },
         decorationBox = { inner ->
             if (query.isEmpty()) {
                 Text(
-                    text = stringResource(R.string.gbk_block_inserter_search),
+                    text = label,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     fontSize = SEARCH_FONT_SP.sp,
+                    modifier = Modifier.clearAndSetSemantics {},
                 )
             }
             inner()
@@ -798,7 +753,11 @@ private fun BlockTile(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(BLOCK_TILE_BUTTON_CORNER_DP.dp))
-            .clickable(enabled = !block.isDisabled, onClick = onClick)
+            .clickable(
+                enabled = !block.isDisabled,
+                role = Role.Button,
+                onClick = onClick,
+            )
             .padding(
                 horizontal = BLOCK_TILE_HORIZONTAL_PAD_DP.dp,
             )
@@ -908,11 +867,21 @@ private fun AutoShrinkTileLabel(
 
 @Composable
 private fun EmptyState(query: String, modifier: Modifier = Modifier) {
-    val text = if (query.isNotBlank()) {
+    val visibleText = if (query.isNotBlank()) {
         stringResource(R.string.gbk_block_inserter_no_results_for, query)
     } else {
         stringResource(R.string.gbk_block_inserter_no_results)
     }
+    val announcedText = stringResource(R.string.gbk_block_inserter_no_results)
+    // `liveRegion` so TalkBack announces the change when search filters the
+    // grid down to no results — otherwise the composition swap is silent.
+    // The visible Text would change on every keystroke that produces no
+    // results, which would queue a fresh announcement each time. Keeping the
+    // box's `contentDescription` constant — and clearing the inner Text's
+    // own semantics — means TalkBack announces "No results" once on the
+    // empty -> empty-results transition. The visible string still shows the
+    // queried term to sighted users; blind users can re-focus the field to
+    // hear the query back via `editableText`.
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
@@ -920,13 +889,18 @@ private fun EmptyState(query: String, modifier: Modifier = Modifier) {
             .padding(
                 horizontal = EMPTY_STATE_HORIZONTAL_PAD_DP.dp,
                 vertical = EMPTY_STATE_VERTICAL_PAD_DP.dp,
-            ),
+            )
+            .semantics {
+                liveRegion = LiveRegionMode.Polite
+                contentDescription = announcedText
+            },
     ) {
         Text(
-            text = text,
+            text = visibleText,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             fontSize = EMPTY_STATE_FONT_SP.sp,
             textAlign = TextAlign.Center,
+            modifier = Modifier.clearAndSetSemantics {},
         )
     }
 }

--- a/src/components/native-inserter/index.jsx
+++ b/src/components/native-inserter/index.jsx
@@ -421,7 +421,7 @@ export default function NativeBlockInserterButton( { open, onToggle } ) {
 	return (
 		<Button
 			ref={ buttonRef }
-			title={ __( 'Add block' ) }
+			label={ __( 'Add block' ) }
 			icon={ plus }
 			onClick={ () => {
 				// Skip the redux toggle and present the native inserter


### PR DESCRIPTION
## Summary

Two related changes to the Android block inserter, all introduced by #461:

1. **Rebuild the category strip on `SecondaryScrollableTabRow` + `Tab`.** Replaces the hand-rolled scrollable pill-chip row. The platform component provides selectable-group semantics, horizontal scroll, auto-scroll-to-selected, ripple, `Role.Tab` a11y, the underline indicator + divider, and the 48dp touch target — all for free. Custom `edgePadding` aligns the first tab label's leading edge with the search bar's outer left edge.

2. **Targeted TalkBack semantics fixes** elsewhere in the sheet — header `heading()`, search-field `contentDescription` with a cleared placeholder, block-tile `Role.Button`, empty-state live region with a stable announcement.

Independent of #509 / #510 / #511.

| Light | Dark |
|:---:|:---:|
| <img alt="Inserter in light mode showing the new scrollable secondary tab row" src="https://github.com/user-attachments/assets/12f83007-90b1-4e7e-90e6-b71fa555f25e" width="360" /> | <img alt="Inserter in dark mode showing the same tab row blending with the dark sheet surface" src="https://github.com/user-attachments/assets/932eb123-81cb-436e-8646-9083b4108c83" width="360" /> |
| Recent tab selected; primary-color underline indicator; first label aligned with search-bar edge | Same layout against the dark bottom-sheet surface |

## Fix

### 1. M3 scrollable tabs

```kotlin
SecondaryScrollableTabRow(
    selectedTabIndex = selectedIndex,
    containerColor = ComposeColor.Transparent,
    edgePadding = (SEARCH_HORIZONTAL_PAD_DP - TAB_INTERNAL_TEXT_PAD_DP).dp,
    modifier = Modifier.fillMaxWidth(),
) {
    tabs.forEach { tab ->
        Tab(
            selected = tab == selected,
            onClick = { onSelect(tab) },
            text = { Text(stringResource(tab.labelRes)) },
        )
    }
}
```

Deletes the custom `CategoryChip`, its shared `MutableInteractionSource` ripple-clip trick, and all the chip-design constants (`CHIP_*`, `TOUCH_TARGET_MIN_DP`, `TABS_*_PAD_*`). `edgePadding = 4.dp` (computed as `SEARCH_HORIZONTAL_PAD_DP - TAB_INTERNAL_TEXT_PAD_DP`) lines the first tab label's leading edge up with the search bar's outer left edge. `containerColor = Transparent` so the tab row blends with the bottom-sheet surface rather than rendering its own opaque container.

**M3 version note**: M3 1.3.1 (pinned by Compose BOM 2024.12.01) hardcodes `ScrollableTabRowMinimumTabWidth = 90.dp`. The `minTabWidth` parameter that would let us override it ships in 1.4.0 and isn't worth a project-wide BOM bump for this PR — short labels like "Text" and "Media" render content-sized inside a 90dp slot.

### 2. Other TalkBack semantics

- **Header title** gets `heading()` so TalkBack users can navigate by heading.
- **Search field** (`BasicTextField`) gets a `contentDescription` matching its visible placeholder, and the placeholder Text uses `clearAndSetSemantics {}` so it doesn't double-announce alongside the field. TalkBack reads "Search blocks, edit box" empty; "Search blocks, edit box, <text>" filled.
- **Block tiles** get `role = Role.Button` on their `clickable` so TalkBack announces them as buttons.
- **Empty state** ("no results") gets `liveRegion = Polite` so TalkBack announces the state change when search filters the grid down to zero. The visible Text still shows "No blocks match '<query>'" for sighted users, but the live region's `contentDescription` is the constant "No results" and the inner Text uses `clearAndSetSemantics {}`. TalkBack announces once on the empty-results transition rather than re-announcing on every keystroke. Blind users can recover the query by focusing the search field, which reads back `editableText`.

Touch-target audit also covered the close button and search-clear `IconButton` — both already meet 48dp via M3's `minimumInteractiveComponentSize`, which expands the layout-node bounds outside the user's `Modifier.size`.

## Test plan

- [x] Open the inserter on a device. Category strip looks like a standard M3 secondary scrollable tab row — labels with an underline indicator under the selected tab, transparent container.
- [x] Tapping any tab animates the underline indicator smoothly to the new tab.
- [ ] Opening the inserter with a selected category that's offscreen-right auto-scrolls the strip to reveal it.
- [x] The first tab label's leading edge lines up vertically with the search bar's outer left edge.
- [x] TalkBack announces each tab as "<label>, tab, selected" or "<label>, tab, not selected".
- [x] TalkBack announces the search field as "Search blocks, edit box" when empty and "Search blocks, edit box, <text>" when filled — only once per focus, no duplicated label from the placeholder.
- [x] TalkBack announces block tiles as buttons.
- [x] TalkBack reads the header title as a heading and lets the user navigate by heading.
- [x] TalkBack announces "No results" exactly once when search filters the grid to zero, and does not re-announce on every keystroke while results remain empty.
- [ ] `./gradlew :Gutenberg:detekt :Gutenberg:assembleDebug :Gutenberg:testDebugUnitTest` passes.
