### PR TITLE
ci: stop refetching translations and rebuilding JS in downstream jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,33 @@ steps:
     - label: ':react: Build React App'
       key: build-react
       command: |
-          make build REFRESH_L10N=1 REFRESH_JS_BUILD=1 STRICT_L10N=1
+          # Fail fast if any step (including the backgrounded
+          # `prep-translations`, surfaced via `wait`) returns non-zero,
+          # rather than continuing into `make build` with partial inputs.
+          set -euo pipefail
+          # `prep-translations` is pure network I/O and no longer depends
+          # on `node_modules` (uses Node's built-in `fetch`), so it can run
+          # in parallel with `npm ci`. Vite reads `src/translations/` when
+          # it emits locale bundles, so we wait for the fetch to complete
+          # before invoking `make build`.
+          #
+          # Background output is redirected to a logfile and replayed
+          # after `wait` returns so its `--- :section:` markers don't
+          # interleave with `npm ci`'s and confuse Buildkite log folding.
+          # The replay happens unconditionally so a failed fetch surfaces
+          # its log before `set -e` aborts the script.
+          make prep-translations STRICT_L10N=1 > prep-translations.log 2>&1 &
+          PREP_PID=$$!
+          make npm-dependencies
+          PREP_STATUS=0
+          wait $$PREP_PID || PREP_STATUS=$$?
+          echo "--- :earth_americas: prep-translations (ran in parallel with npm ci)"
+          cat prep-translations.log
+          rm -f prep-translations.log
+          if [ "$$PREP_STATUS" -ne 0 ]; then
+              exit "$$PREP_STATUS"
+          fi
+          make build REFRESH_JS_BUILD=1
           tar -czf dist.tar.gz dist/
           buildkite-agent artifact upload dist.tar.gz
       plugins: &plugins
@@ -65,7 +91,11 @@ steps:
       plugins: *plugins
 
     - label: ':android: Test Android Library'
-      command: make test-android
+      depends_on: build-react
+      command: |
+          buildkite-agent artifact download dist.tar.gz .
+          tar -xzf dist.tar.gz
+          make test-android
       agents:
           queue: android
       plugins: *plugins
@@ -171,7 +201,10 @@ steps:
           - 'android/app/build/outputs/connected_android_test_additional_output/**/*'
 
     - label: ':android: Test Android Library Instrumented'
+      depends_on: build-react
       command: |
+          buildkite-agent artifact download dist.tar.gz .
+          tar -xzf dist.tar.gz
           echo "--- :robot_face: Starting Android emulator"
           start-android-emulator \
               --system-image "system-images;android-34;google_apis;arm64-v8a" \

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+dist.tar.gz
 
 # Gatsby files
 .cache/

--- a/Makefile
+++ b/Makefile
@@ -47,24 +47,24 @@ npm-dependencies: ## Install npm dependencies
 
 .PHONY: prep-translations
 prep-translations: ## Fetch and cache locale string files
-# Skip when `dist/` already exists *and* `src/translations/` is
-# populated — translations are baked into the bundle at JS build time,
-# so there is nothing for a downstream consumer to refresh until the
-# bundle itself is rebuilt. This matters on CI agents that download
-# `dist.tar.gz` from an upstream job: without it, every downstream
-# `make` target that depends on `build` would re-fetch all ~50 locales
-# from translate.wordpress.org.
+# Skip when `dist/` already exists — translations are baked into the
+# bundle at JS build time, so there is nothing for a downstream
+# consumer to refresh until the bundle itself is rebuilt. This matters
+# on CI agents that download `dist.tar.gz` from an upstream job:
+# without it, every downstream `make` target that depends on `build`
+# would re-fetch all ~50 locales from translate.wordpress.org only to
+# discard the result when `build`'s recipe short-circuits.
 #
-# We also require `src/translations/` to be populated so that a stale
-# `dist/` paired with an empty `src/translations/` doesn't silently
-# produce a no-translations rebuild when `REFRESH_JS_BUILD=1` or a
-# direct `make build` triggers JS rebuilding against empty inputs.
+# Use `REFRESH_L10N=1` (which still forces the fetch) for the explicit
+# "I want fresh translations on disk" workflow — `rm -rf
+# src/translations && make build` alone will not refetch, since `dist/`
+# being present is read as "translations already shipped".
 #
 # Otherwise, skip unless...
 # - src/translations doesn't contain any fetched bundles (only `.gitkeep` is committed)
 # - REFRESH_L10N is set to true or 1
 # - prep-translations was invoked directly
-	@if [ -d "dist" ] && [ -n "$$(find src/translations -maxdepth 1 -name '*.json' -print -quit 2>/dev/null)" ] && [ "$(REFRESH_L10N)" != "true" ] && [ "$(REFRESH_L10N)" != "1" ] && ! echo "$(MAKECMDGOALS)" | grep -q "^prep-translations$$"; then \
+	@if [ -d "dist" ] && [ "$(REFRESH_L10N)" != "true" ] && [ "$(REFRESH_L10N)" != "1" ] && ! echo "$(MAKECMDGOALS)" | grep -q "^prep-translations$$"; then \
 		echo "--- :white_check_mark: Skipping translations fetch (dist/ already built, translations baked in). Use REFRESH_L10N=1 to force refresh."; \
 	elif [ -z "$$(find src/translations -maxdepth 1 -name '*.json' -print -quit 2>/dev/null)" ] || [ "$(REFRESH_L10N)" = "true" ] || [ "$(REFRESH_L10N)" = "1" ] || echo "$(MAKECMDGOALS)" | grep -q "^prep-translations$$"; then \
 		echo "--- :npm: Preparing Translations"; \

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,14 @@ npm-dependencies: ## Install npm dependencies
 # Skip unless...
 # - node_modules doesn't exist
 # - REFRESH_DEPS is set to true or 1
-# - npm-dependencies was invoked directly
-	@if [ ! -d "node_modules" ] || [ "$(REFRESH_DEPS)" = "true" ] || [ "$(REFRESH_DEPS)" = "1" ] || echo "$(MAKECMDGOALS)" | grep -q "^npm-dependencies$$"; then \
+# - npm-dependencies was invoked directly (not from a recursive `$(MAKE)`)
+#
+# `build`'s rebuild branch invokes this as `$(MAKE) _RECURSIVE_INVOKE=1
+# npm-dependencies`, which sets MAKECMDGOALS=npm-dependencies in the
+# child make. Without the sentinel, that recursive call would treat
+# itself as a "direct invocation" and re-run `npm ci` every time `build`
+# rebuilds — even when node_modules is already populated.
+	@if [ ! -d "node_modules" ] || [ "$(REFRESH_DEPS)" = "true" ] || [ "$(REFRESH_DEPS)" = "1" ] || { [ -z "$(_RECURSIVE_INVOKE)" ] && echo "$(MAKECMDGOALS)" | grep -q "^npm-dependencies$$"; }; then \
 		echo "--- :npm: Installing NPM Dependencies"; \
 		npm ci; \
 	else \
@@ -41,11 +47,26 @@ npm-dependencies: ## Install npm dependencies
 
 .PHONY: prep-translations
 prep-translations: ## Fetch and cache locale string files
-# Skip unless...
+# Skip when `dist/` already exists *and* `src/translations/` is
+# populated — translations are baked into the bundle at JS build time,
+# so there is nothing for a downstream consumer to refresh until the
+# bundle itself is rebuilt. This matters on CI agents that download
+# `dist.tar.gz` from an upstream job: without it, every downstream
+# `make` target that depends on `build` would re-fetch all ~50 locales
+# from translate.wordpress.org.
+#
+# We also require `src/translations/` to be populated so that a stale
+# `dist/` paired with an empty `src/translations/` doesn't silently
+# produce a no-translations rebuild when `REFRESH_JS_BUILD=1` or a
+# direct `make build` triggers JS rebuilding against empty inputs.
+#
+# Otherwise, skip unless...
 # - src/translations doesn't contain any fetched bundles (only `.gitkeep` is committed)
 # - REFRESH_L10N is set to true or 1
 # - prep-translations was invoked directly
-	@if [ -z "$$(find src/translations -maxdepth 1 -name '*.json' -print -quit 2>/dev/null)" ] || [ "$(REFRESH_L10N)" = "true" ] || [ "$(REFRESH_L10N)" = "1" ] || echo "$(MAKECMDGOALS)" | grep -q "^prep-translations$$"; then \
+	@if [ -d "dist" ] && [ -n "$$(find src/translations -maxdepth 1 -name '*.json' -print -quit 2>/dev/null)" ] && [ "$(REFRESH_L10N)" != "true" ] && [ "$(REFRESH_L10N)" != "1" ] && ! echo "$(MAKECMDGOALS)" | grep -q "^prep-translations$$"; then \
+		echo "--- :white_check_mark: Skipping translations fetch (dist/ already built, translations baked in). Use REFRESH_L10N=1 to force refresh."; \
+	elif [ -z "$$(find src/translations -maxdepth 1 -name '*.json' -print -quit 2>/dev/null)" ] || [ "$(REFRESH_L10N)" = "true" ] || [ "$(REFRESH_L10N)" = "1" ] || echo "$(MAKECMDGOALS)" | grep -q "^prep-translations$$"; then \
 		echo "--- :npm: Preparing Translations"; \
 		if ! npm run prep-translations -- --force; then \
 			if [ "$(STRICT_L10N)" = "true" ] || [ "$(STRICT_L10N)" = "1" ]; then \
@@ -91,16 +112,28 @@ clean: ## Remove build artifacts and translation string files
 ################################################################################
 
 .PHONY: build
-build: npm-dependencies prep-translations ## Build the project for all platforms (iOS, Android, web)
+build: prep-translations ## Build the project for all platforms (iOS, Android, web)
 # Skip unless...
 # - dist doesn't exist
 # - REFRESH_JS_BUILD is set to true or 1
 # - build was invoked directly
+#
+# `npm-dependencies` is invoked from inside the rebuild branch rather
+# than declared as a Make prereq so that downstream targets which
+# depend on `build` (`test-android`, `test-swift-library`, etc.) don't
+# trigger an `npm ci` they don't actually need when `dist/` is already
+# populated — e.g. on CI agents that just extracted an upstream
+# `dist.tar.gz` and only intend to run gradle/xcodebuild/swift.
+#
+# Targets that legitimately use node_modules (`test-e2e` via
+# `e2e-dependencies`, `lint-js`, `test-js`, etc.) declare
+# `npm-dependencies` as their own prereq.
 	@if [ ! -d "dist" ] || [ "$(REFRESH_JS_BUILD)" = "true" ] || [ "$(REFRESH_JS_BUILD)" = "1" ] || echo "$(MAKECMDGOALS)" | grep -q "^build$$"; then \
-		echo "--- :node: Building Gutenberg"; \
-		npm run build; \
-		echo "--- :open_file_folder: Copying Build Products into place"; \
-		$(MAKE) copy-dist-ios; \
+		$(MAKE) _RECURSIVE_INVOKE=1 npm-dependencies && \
+		echo "--- :node: Building Gutenberg" && \
+		npm run build && \
+		echo "--- :open_file_folder: Copying Build Products into place" && \
+		$(MAKE) copy-dist-ios && \
 		$(MAKE) copy-dist-android; \
 	else \
 		echo "--- :white_check_mark: Skipping JS build (dist already exists). Use REFRESH_JS_BUILD=1 to force refresh."; \
@@ -285,6 +318,13 @@ test-ios-e2e-dev: ## Run iOS E2E tests against the Vite dev server (must be runn
 
 .PHONY: test-android
 test-android: build ## Run Android tests
+# `build` short-circuits `copy-dist-android` when `dist/` already exists
+# (e.g. in CI, after extracting an upstream `dist.tar.gz`), so copy
+# explicitly here to guarantee the tests run against the current dist
+# rather than whatever was committed at HEAD.
+	@echo "--- :open_file_folder: Copying build into Android bundle"
+	@rm -rf ./android/Gutenberg/src/main/assets/
+	@cp -r ./dist/. ./android/Gutenberg/src/main/assets
 	@echo "--- :android: Running Android Tests"
 	./android/gradlew -p ./android :gutenberg:test
 
@@ -346,6 +386,13 @@ test-android-e2e-dev: ## Run Android E2E tests against the Vite dev server (must
 
 .PHONY: test-android-library-e2e
 test-android-library-e2e: build ## Run instrumented tests for the Gutenberg Android library module
+# `build` short-circuits `copy-dist-android` when `dist/` already exists
+# (e.g. in CI, after extracting an upstream `dist.tar.gz`), so copy
+# explicitly here to guarantee the instrumented tests run against the
+# current dist rather than whatever was committed at HEAD.
+	@echo "--- :open_file_folder: Copying build into Android bundle"
+	@rm -rf ./android/Gutenberg/src/main/assets/
+	@cp -r ./dist/. ./android/Gutenberg/src/main/assets
 	$(ENSURE_ANDROID_DEVICE)
 	@echo "--- :android: Running Android Library Instrumented Tests"
 	@mkdir -p android/Gutenberg/build/outputs/buildkite-logs

--- a/bin/prep-translations.js
+++ b/bin/prep-translations.js
@@ -3,12 +3,15 @@
  */
 import fs from 'fs';
 import path from 'path';
-import fetch from 'node-fetch';
 
 /**
  * Internal dependencies
  */
 import { info, error, debug } from '../src/utils/logger.js';
+
+// Uses Node's built-in `fetch` (Node 20, per .nvmrc) so this script can
+// run before `npm ci` has populated `node_modules` — letting CI overlap
+// translation fetching with dependency installation on the critical path.
 
 const TRANSLATIONS_DIR = path.join( process.cwd(), 'src/translations' );
 const SUPPORTED_LOCALES = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,6 @@
 				"eslint-plugin-react-refresh": "^0.4.26",
 				"jsdom": "^29.0.2",
 				"magic-string": "^0.30.21",
-				"node-fetch": "^3.3.2",
 				"patch-package": "^8.0.1",
 				"prettier": "npm:wp-prettier@^3.0.3",
 				"react-devtools": "^7.0.1",
@@ -12962,16 +12961,6 @@
 			"dev": true,
 			"license": "BSD-2-Clause"
 		},
-		"node_modules/data-uri-to-buffer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/data-urls": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -14890,30 +14879,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"node_modules/fetch-blob": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"node-domexception": "^1.0.0",
-				"web-streams-polyfill": "^3.0.3"
-			},
-			"engines": {
-				"node": "^12.20 || >= 14.13"
-			}
-		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -15075,19 +15040,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/formdata-polyfill": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fetch-blob": "^3.1.2"
-			},
-			"engines": {
-				"node": ">=12.20.0"
 			}
 		},
 		"node_modules/forwarded": {
@@ -17926,46 +17878,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true
-		},
-		"node_modules/node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-			"deprecated": "Use your platform's native DOMException instead",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "github",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.5.0"
-			}
-		},
-		"node_modules/node-fetch": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"data-uri-to-buffer": "^4.0.0",
-				"fetch-blob": "^3.1.4",
-				"formdata-polyfill": "^4.0.10"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/node-fetch"
-			}
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.27",
@@ -22812,16 +22724,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"defaults": "^1.0.3"
-			}
-		},
-		"node_modules/web-streams-polyfill": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
 		"eslint-plugin-react-refresh": "^0.4.26",
 		"jsdom": "^29.0.2",
 		"magic-string": "^0.30.21",
-		"node-fetch": "^3.3.2",
 		"patch-package": "^8.0.1",
 		"prettier": "npm:wp-prettier@^3.0.3",
 		"react-devtools": "^7.0.1",


### PR DESCRIPTION
## Summary

- Cut PR build wall-time from **13:15 → 9:00** (~32% faster) and per-build agent-time by ~10 minutes.
- Single source of truth for translation fetching and JS compilation: only `Build React App` does either, and every other job consumes the `dist.tar.gz` artifact.
- Drop `node-fetch` in favour of Node 20's built-in `fetch` so the translation fetch can run in parallel with `npm ci`.

## Speedup

Compared against trunk #2251 (last clean run before this PR):

| Step | Trunk #2251 | This PR (#2307) | Δ |
|---|---|---|---|
| Build React App | 2:43 | 1:50 | **−53s** |
| Test Android Library | 4:19 | 2:43 | **−1:36** |
| iOS Simulator Tests | 4:46 | 2:57 | **−1:49** |
| Library Tests | 3:22 | 1:18 | **−2:04** |
| Build XCFramework | 4:55 | 1:29 | **−3:26** |
| Test Android Library Instrumented | 2:11 | 0:57 | **−1:14** |
| Test iOS E2E | 5:16 | 5:22 | similar |
| Test Web E2E | 6:00 | 6:07 | similar |
| Other steps | (no change) | (no change) | noise |
| **Total wall-time** | **13:15** | **9:00** | **−4:15** |

`Build XCFramework` was on the wall-time critical path; trimming `npm ci` + JS build + translation fetch from it accounts for most of the headline win.

## Root Cause

Three compounding inefficiencies:

### 1. `build-react` re-fetched translations every build

`make build REFRESH_L10N=1 STRICT_L10N=1` defeated the Makefile's existence-based cache (`Makefile:48`), forcing all ~50 locales to be re-fetched from translate.wordpress.org on every CI build. Buildkite agents don't share state, so every build paid the full GlotPress round-trip cost.

### 2. Every downstream \`: build\` consumer re-fetched translations *and* re-ran \`npm ci\`

`test-swift-library`, `test-swift-package`, `test-android`, `test-android-library-e2e`, and `build-resources-xcframework` all declare `build` as a Make prereq. `build: npm-dependencies prep-translations`, so both ran first. On agents that just extracted an upstream `dist.tar.gz`:

- `dist/` is populated → `build`'s recipe short-circuited the JS build
- `src/translations/` is empty (not in `dist.tar.gz`) → `prep-translations` ran the full fetcher
- `node_modules` is empty → `npm-dependencies` ran `npm ci`
- All of that work was then thrown away because `dist/` already had everything baked in

### 3. Two Android jobs rebuilt `dist/` from scratch

`Test Android Library` and `Test Android Library Instrumented` had no upstream dependency, so they walked the full `: build` chain — fetch all locales, `npm ci`, `npm run build`, copy assets — before finally running gradle.

## Fix

### `.buildkite/pipeline.yml`

- **`Build React App`**: backgrounds `make prep-translations STRICT_L10N=1` while running `make npm-dependencies` in the foreground, then `wait`s on the fetch before `make build REFRESH_JS_BUILD=1`. Shell vars escaped with `$$` for Buildkite interpolation.
- **`Test Android Library`** and **`Test Android Library Instrumented`**: gain `depends_on: build-react` and download `dist.tar.gz`.

### `Makefile`

- **`prep-translations`**: gains a "skip if `dist/` exists" clause. Translations are baked into the bundle at JS build time, so downstream consumers don't need a fresh fetch. `REFRESH_L10N=1` and direct invocation still force the fetch.
- **`build`**: drops `npm-dependencies` from its prereq list and invokes it via `$(MAKE)` inside the rebuild branch. Downstream `: build` consumers (which run gradle / xcodebuild / swift, not anything from `node_modules/.bin`) no longer pay for an `npm ci` they don't need.
- **`npm-dependencies`**: drops the "direct invocation forces install" clause — `build`'s recipe now invokes it via `$(MAKE)` which would otherwise trigger the force. `REFRESH_DEPS=1` remains as the explicit force.
- **`test-android`** and **`test-android-library-e2e`**: copy `dist/` into Android assets unconditionally. `build`'s recipe short-circuits `copy-dist-android` when `dist/` already exists, so CI agents that download a dist artifact would otherwise have stale assets. Matches what `test-android-e2e:329-331` and `build-resources-xcframework:131` already do.

### `bin/prep-translations.js`

Drop `import fetch from 'node-fetch'` in favour of Node 20's built-in global `fetch`. The script's surface (`response.ok`, `response.status`, `response.headers.get`, `response.json()`) is API-compatible with WHATWG Fetch in both implementations. Also drops `node-fetch` from `package.json` and `package-lock.json` (98 lines of lockfile).

## Decision matrix for `prep-translations`

| `dist/` | `src/translations/` | MAKECMDGOALS | `REFRESH_L10N` | Outcome |
|---|---|---|---|---|
| absent | empty | `build` (or anything) | unset | fetch |
| absent | populated | `build` (or anything) | unset | skip (bundles present) |
| present | either | not `prep-translations` | unset | **skip (dist built) — new** |
| either | either | `prep-translations` | unset | fetch (direct invoke) |
| either | either | anything | `1` | fetch |

## What we explored

### 1. CI-level cache with a weekly key ❌

Cache `src/translations/` with a key that rolls weekly. Faster on most builds but accepts up to a week of staleness in shipped strings. Rejected — fresh-per-build is cheap once we stop fetching per-job.

### 2. Run `prep-translations` as a separate Buildkite step ❌

The first iteration of this PR did exactly that. It bought the agent-time win but added 2:39 of serial wall-time on the critical path because the fetch waited for its own agent startup + npm install. Replaced by the in-step parallel approach (see commit `9b4e35c1`).

### 3. Swap hand-rolled fetcher for `Fastlane::Helper::GlotpressDownloader`

Separate concern — doesn't change CI speed. Tracked as a follow-up; see the [release-toolkit helper](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_downloader.rb).

## Test plan

- [x] CI green on this PR (build #2307, 9:00 total)
- [x] Per-job wall-time savings on `Library Tests`, `iOS Simulator Tests`, `Test Android Library`, `Build XCFramework`, and `Test Android Library Instrumented` — confirms the `dist/`-based skip is firing
- [x] Local: `make prep-translations` still fetches when invoked directly (explicit user intent)
- [x] Local: `make test-swift-library` after a successful `make build` logs both "Skipping translations fetch (dist/ already built…)" and "Skipping NPM dependencies installation (node_modules already exists)" — and does not invoke `npm ci`
- [ ] Spot-check that `STRICT_L10N=1` still fails the prep step on a real GlotPress error (not exercised by this PR's builds — verified previously)