### PR TITLE
feat(android): hand inserter media to the JS editor

### DIFF
--- a/android/Gutenberg/src/main/AndroidManifest.xml
+++ b/android/Gutenberg/src/main/AndroidManifest.xml
@@ -3,6 +3,25 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- Used by the block inserter media strip to preview recent device photos.
+         Inherited in the merged manifest, so it shows up in the host's Play
+         Store data-safety disclosure. Hosts that don't render the inserter or
+         already declare these permissions for their own media flows can opt
+         out via the manifest merger:
+
+             <uses-permission
+                 android:name="android.permission.READ_MEDIA_IMAGES"
+                 tools:node="remove" />
+             <uses-permission
+                 android:name="android.permission.READ_EXTERNAL_STORAGE"
+                 tools:node="remove" />
+
+         See docs/integration.md (Android → Manifest Permissions) for details. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
     <application>
         <!-- Exposes a writeable temp-file URI to the camera app so captures can
              come back to us without the host app having to configure its own

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -39,10 +39,11 @@ import org.json.JSONObject
 import org.wordpress.gutenberg.inserter.BlockPickerDialog
 import org.wordpress.gutenberg.inserter.clearPhotoPreferences
 import org.wordpress.gutenberg.inserter.warmupPhotoPrefs
+import kotlinx.serialization.encodeToString
 import org.wordpress.gutenberg.media.MediaFileManager
 import org.wordpress.gutenberg.media.MediaInfo
+import org.wordpress.gutenberg.media.MediaInfoJson
 import org.wordpress.gutenberg.media.MediaPathHandler
-import org.wordpress.gutenberg.media.toJsonArray
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
@@ -903,7 +904,7 @@ class GutenbergView : FrameLayout {
      */
     internal fun insertMediaFromInserter(media: List<MediaInfo>) {
         if (!isEditorLoaded || media.isEmpty()) return
-        val payload = media.toJsonArray().toString()
+        val payload = MediaInfoJson.encodeToString(media)
         handler.post {
             webView.evaluateJavascript(
                 "window.blockInserter?.insertMedia($payload);",

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.launch
 import org.json.JSONException
 import org.json.JSONObject
 import org.wordpress.gutenberg.inserter.BlockPickerDialog
+import org.wordpress.gutenberg.inserter.clearPhotoPreferences
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
@@ -1090,6 +1091,20 @@ class GutenbergView : FrameLayout {
     }
 
     companion object {
+        /**
+         * Clears the block inserter's photo-library preferences (rationale
+         * rejection + first-prompt tracking). Call from a host-app settings
+         * screen if you want users to re-see the rationale after dismissing it.
+         *
+         * The OS-level photo permission itself is not affected — only the
+         * in-app flags. The library's media permissions are declared in the
+         * library's manifest and inherited via manifest merging; see
+         * docs/integration.md (Android → Manifest Permissions) for the opt-out.
+         */
+        fun resetBlockPickerPhotoPreferences(context: Context) {
+            clearPhotoPreferences(context)
+        }
+
         /** Hosts that are safe to serve assets over HTTP (local development only). */
         private val LOCAL_HOSTS = setOf("localhost", "127.0.0.1", "10.0.2.2")
 

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -44,6 +44,7 @@ import org.wordpress.gutenberg.media.MediaFileManager
 import org.wordpress.gutenberg.media.MediaInfo
 import org.wordpress.gutenberg.media.MediaInfoJson
 import org.wordpress.gutenberg.media.MediaPathHandler
+import org.wordpress.gutenberg.media.StoredMedia
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
@@ -103,8 +104,9 @@ class GutenbergView : FrameLayout {
     private val webView: WebView
     private var isEditorLoaded = false
     private var didFireEditorLoaded = false
-    private lateinit var assetLoader: WebViewAssetLoader
-    private lateinit var assetDomain: String
+    private var assetLoader: WebViewAssetLoader by writeOnce()
+    private var assetDomain: String by writeOnce()
+    private var assetScheme: String by writeOnce()
     private val configuration: EditorConfiguration
     private lateinit var dependencies: EditorDependencies
 
@@ -232,14 +234,8 @@ class GutenbergView : FrameLayout {
         // process-wide cache — no async-load placeholder, no visible flash.
         warmupPhotoPrefs(context)
 
-        // Initialize the asset loader now that context is available
-        assetLoader = WebViewAssetLoader.Builder()
-            .addPathHandler("/assets/", AssetsPathHandler(context))
-            .addPathHandler(
-                MediaFileManager.MEDIA_PATH_PREFIX,
-                MediaPathHandler(MediaFileManager.uploadsDir(context)),
-            )
-            .build()
+        // The asset loader is built in `loadEditor`, where the configured
+        // `assetDomain` and HTTP-allowance flag are known.
 
         // Create the internal WebView as first child (behind overlays)
         webView = WebView(context).apply {
@@ -559,10 +555,15 @@ class GutenbergView : FrameLayout {
         // avoid accidentally downgrading asset traffic for production sites.
         val siteUri = Uri.parse(configuration.siteURL)
         val isLocalHttpSite = siteUri.scheme == "http" && siteUri.host in LOCAL_HOSTS
+        assetScheme = if (isLocalHttpSite) "http" else "https"
         assetLoader = WebViewAssetLoader.Builder()
             .setDomain(assetDomain)
             .setHttpAllowed(isLocalHttpSite)
             .addPathHandler("/assets/", AssetsPathHandler(this.context))
+            .addPathHandler(
+                MediaFileManager.MEDIA_PATH_PREFIX,
+                MediaPathHandler(MediaFileManager.uploadsDir(this.context)),
+            )
             .build()
 
         // Transition to spinner phase (WebView initialization)
@@ -570,8 +571,7 @@ class GutenbergView : FrameLayout {
 
         initializeWebView()
 
-        val scheme = if (isLocalHttpSite) "http" else "https"
-        val assetUrl = "$scheme://$assetDomain$ASSET_PATH_INDEX"
+        val assetUrl = "$assetScheme://$assetDomain$ASSET_PATH_INDEX"
         val editorUrl = BuildConfig.GUTENBERG_EDITOR_URL.ifEmpty {
             assetUrl
         }
@@ -898,12 +898,17 @@ class GutenbergView : FrameLayout {
 
     /**
      * Hands a list of inserter-sourced media to the JS editor via
-     * `window.blockInserter.insertMedia(...)`. URLs in each MediaInfo must be
-     * loadable by the WebView — the canonical source is `MediaFileManager`,
-     * which produces same-origin URLs under `/media/`.
+     * `window.blockInserter.insertMedia(...)`. URL stamping happens here, not
+     * in `MediaFileManager`, so the URLs match the live `assetDomain` /
+     * `assetScheme` rather than the build-time defaults — keeping the media
+     * same-origin against the editor bundle however the asset loader is
+     * configured.
      */
-    internal fun insertMediaFromInserter(media: List<MediaInfo>) {
-        if (!isEditorLoaded || media.isEmpty()) return
+    internal fun insertMediaFromInserter(stored: List<StoredMedia>) {
+        if (!isEditorLoaded || stored.isEmpty()) return
+        val media = stored.map {
+            MediaInfo(url = mediaUrlFor(assetScheme, assetDomain, it.fileName), type = it.type)
+        }
         val payload = MediaInfoJson.encodeToString(media)
         handler.post {
             webView.evaluateJavascript(
@@ -1214,6 +1219,15 @@ data class Media(
         }
     }
 }
+
+private fun mediaUrlFor(scheme: String, domain: String, fileName: String): String =
+    Uri.Builder()
+        .scheme(scheme)
+        .authority(domain)
+        .appendEncodedPath(MediaFileManager.MEDIA_PATH_PREFIX.trim('/'))
+        .appendPath(fileName)
+        .build()
+        .toString()
 
 enum class MediaType(var label: String) {
     IMAGE("image"),

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -38,6 +38,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import org.wordpress.gutenberg.inserter.BlockPickerDialog
 import org.wordpress.gutenberg.inserter.clearPhotoPreferences
+import org.wordpress.gutenberg.inserter.warmupPhotoPrefs
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
@@ -219,6 +220,12 @@ class GutenbergView : FrameLayout {
     constructor(configuration: EditorConfiguration, dependencies: EditorDependencies?, coroutineScope: CoroutineScope, context: Context) : super(context) {
         this.configuration = configuration
         this.coroutineScope = coroutineScope
+
+        // Warm the block-inserter's photo-prefs cache off the main thread now,
+        // well before the user can navigate to the inserter. By the time they
+        // tap `+`, the prefs read in `MediaStrip` is synchronous from the
+        // process-wide cache — no async-load placeholder, no visible flash.
+        warmupPhotoPrefs(context)
 
         // Initialize the asset loader now that context is available
         assetLoader = WebViewAssetLoader.Builder()

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -39,6 +39,10 @@ import org.json.JSONObject
 import org.wordpress.gutenberg.inserter.BlockPickerDialog
 import org.wordpress.gutenberg.inserter.clearPhotoPreferences
 import org.wordpress.gutenberg.inserter.warmupPhotoPrefs
+import org.wordpress.gutenberg.media.MediaFileManager
+import org.wordpress.gutenberg.media.MediaInfo
+import org.wordpress.gutenberg.media.MediaPathHandler
+import org.wordpress.gutenberg.media.toJsonArray
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.EditorConfiguration
 import org.wordpress.gutenberg.model.EditorDependencies
@@ -230,6 +234,10 @@ class GutenbergView : FrameLayout {
         // Initialize the asset loader now that context is available
         assetLoader = WebViewAssetLoader.Builder()
             .addPathHandler("/assets/", AssetsPathHandler(context))
+            .addPathHandler(
+                MediaFileManager.MEDIA_PATH_PREFIX,
+                MediaPathHandler(MediaFileManager.uploadsDir(context)),
+            )
             .build()
 
         // Create the internal WebView as first child (behind overlays)
@@ -887,6 +895,23 @@ class GutenbergView : FrameLayout {
         }
     }
 
+    /**
+     * Hands a list of inserter-sourced media to the JS editor via
+     * `window.blockInserter.insertMedia(...)`. URLs in each MediaInfo must be
+     * loadable by the WebView — the canonical source is `MediaFileManager`,
+     * which produces same-origin URLs under `/media/`.
+     */
+    internal fun insertMediaFromInserter(media: List<MediaInfo>) {
+        if (!isEditorLoaded || media.isEmpty()) return
+        val payload = media.toJsonArray().toString()
+        handler.post {
+            webView.evaluateJavascript(
+                "window.blockInserter?.insertMedia($payload);",
+                null,
+            )
+        }
+    }
+
     private fun dismissBlockInserter() {
         if (!isEditorLoaded) return
         handler.post {
@@ -925,6 +950,7 @@ class GutenbergView : FrameLayout {
             context = context,
             payload = payload,
             onBlockSelected = { block -> insertBlock(block.id) },
+            onMediaSelected = { media -> insertMediaFromInserter(media) },
         )
         dialog.setOnDismissListener {
             if (blockInserterDialog === dialog) {

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -234,6 +234,16 @@ class GutenbergView : FrameLayout {
         // process-wide cache — no async-load placeholder, no visible flash.
         warmupPhotoPrefs(context)
 
+        // Sweep stale media imports off the UI thread before the inserter can
+        // trigger them — `listFiles()` + per-file `delete()` would otherwise
+        // jank the first Camera tap, where the cleanup latch would flip on
+        // the main thread. Idempotent via `MediaFileManager`'s process-wide
+        // latch, so re-firing across `GutenbergView` instances is harmless.
+        val appContext = context.applicationContext
+        coroutineScope.launch(Dispatchers.IO) {
+            MediaFileManager.primeCleanup(appContext)
+        }
+
         // The asset loader is built in `loadEditor`, where the configured
         // `assetDomain` and HTTP-allowance flag are known.
 

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/WriteOnce.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/WriteOnce.kt
@@ -1,0 +1,31 @@
+package org.wordpress.gutenberg
+
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Property delegate that allows exactly one assignment per instance. A second
+ * `set` throws `IllegalStateException`; reading before any assignment throws
+ * `UninitializedPropertyAccessException`. Use for `lateinit`-shaped fields
+ * whose initialization is centralized in one method and whose accidental
+ * reassignment would silently overwrite state — e.g., the asset loader, whose
+ * registered path handlers were lost when an earlier refactor introduced a
+ * second builder.
+ */
+internal class WriteOnce<T : Any> : ReadWriteProperty<Any?, T> {
+    private var value: T? = null
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): T =
+        value ?: throw UninitializedPropertyAccessException(
+            "Property ${property.name} has not been initialized",
+        )
+
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        check(this.value == null) {
+            "Property ${property.name} can only be assigned once"
+        }
+        this.value = value
+    }
+}
+
+internal fun <T : Any> writeOnce(): ReadWriteProperty<Any?, T> = WriteOnce()

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import android.os.Build
 import android.util.Log
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -15,6 +16,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,6 +33,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -47,6 +51,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
@@ -62,14 +67,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -99,7 +106,9 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import java.io.File
 import kotlin.math.roundToInt
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.wordpress.gutenberg.R
 import androidx.compose.ui.graphics.Color as ComposeColor
 import org.wordpress.gutenberg.model.BlockInserterPayload
@@ -133,14 +142,30 @@ private const val HEADER_TITLE_LETTER_SPACING_SP = -0.1
 private const val ICON_BUTTON_SIZE_DP = 40
 private const val ICON_SIZE_DP = 20
 
-private const val MEDIA_STRIP_HORIZONTAL_PAD_DP = 20
-private const val MEDIA_STRIP_TOP_PAD_DP = 6
-private const val MEDIA_STRIP_BOTTOM_PAD_DP = 16
+private const val MEDIA_STRIP_TOP_PAD_DP = 4
+private const val MEDIA_STRIP_BOTTOM_PAD_DP = 10
+private const val MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP = 20
+private const val MEDIA_STRIP_CONTENT_TOP_PAD_DP = 2
+private const val MEDIA_STRIP_CONTENT_BOTTOM_PAD_DP = 6
+private const val MEDIA_STRIP_ITEM_GAP_DP = 8
+private const val MEDIA_STACK_WIDTH_DP = 72
+private const val MEDIA_STACK_HEIGHT_DP = 136
 private const val MEDIA_STACK_COMPACT_HEIGHT_DP = 88
 private const val MEDIA_STACK_GAP_DP = 4
 private const val MEDIA_STACK_CORNER_DP = 18
 private const val MEDIA_STACK_ICON_SIZE_DP = 28
 private const val MEDIA_STACK_LABEL_SP = 13
+private const val MEDIA_THUMB_SIZE_DP = 64
+private const val MEDIA_THUMB_CORNER_DP = 16
+private const val RECENT_PHOTO_LIMIT = 64
+
+private const val MEDIA_RATIONALE_PAD_DP = 14
+private const val MEDIA_RATIONALE_FONT_SP = 13
+private const val MEDIA_RATIONALE_LINE_HEIGHT_SP = 18
+private const val MEDIA_RATIONALE_BUTTON_GAP_DP = 6
+private const val MEDIA_RATIONALE_BUTTON_HEIGHT_DP = 32
+private const val MEDIA_RATIONALE_BUTTON_CORNER_DP = 16
+private const val MEDIA_RATIONALE_BUTTON_FONT_SP = 12
 
 // Matches M3's internal `Tab.HorizontalTextPadding` — the horizontal padding
 // applied by `Tab` between its layout bounds and the text label inside.
@@ -180,10 +205,17 @@ private const val EMPTY_STATE_FONT_SP = 14
 private const val DISABLED_ALPHA = 0.5f
 
 /**
+ * Material 3 minimum touch-target. The rationale buttons sit below this for
+ * design reasons; we wrap them in an outer clickable that meets the minimum
+ * without changing the visual size.
+ */
+private const val TOUCH_TARGET_MIN_DP = 48
+
+/**
  * Bottom-sheet block inserter. The outer shell stays a `BottomSheetDialog` so
  * `GutenbergView`'s integration surface is unchanged; everything visible is
- * Compose content matching the Variation B design handoff — header row,
- * scrollable secondary tabs, rounded search, 5-column tonal tile grid.
+ * Compose content matching the Variation B design handoff — header row, recent
+ * media strip, scrollable secondary tabs, rounded search, 5-column tonal tile grid.
  *
  * The sheet background and 28dp top corners are drawn by Compose directly; the
  * dialog's default white pill background is cleared so it doesn't fight the
@@ -196,6 +228,13 @@ internal class BlockPickerDialog(
 ) : BottomSheetDialog(context) {
 
     init {
+        // Render at full size regardless of the IME — without this the dialog
+        // opens compressed above an in-flight soft keyboard, then visibly
+        // resizes once the IME dismisses, looking like a "double launch".
+        window?.setSoftInputMode(
+            WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN or
+                WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
+        )
         val composeView = ComposeView(context).apply {
             setContent {
                 BlockPickerSheet(
@@ -426,12 +465,125 @@ private fun CloseButton(onClose: () -> Unit) {
     }
 }
 
-// Photos and Camera tiles. Photos uses the permissionless system photo picker;
-// Camera uses ACTION_IMAGE_CAPTURE against a cache-scoped FileProvider URI.
-// Neither requires READ_MEDIA_IMAGES — the recent-photos thumbnail strip that
-// needs it lands in a follow-up and will sit alongside this row.
 @Composable
+@Suppress("LongMethod")
 private fun MediaStrip() {
+    val contentPadding = PaddingValues(
+        start = MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP.dp,
+        end = MEDIA_STRIP_CONTENT_HORIZONTAL_PAD_DP.dp,
+        top = MEDIA_STRIP_CONTENT_TOP_PAD_DP.dp,
+        bottom = MEDIA_STRIP_CONTENT_BOTTOM_PAD_DP.dp,
+    )
+    val stripFraming = Modifier
+        .fillMaxWidth()
+        .padding(top = MEDIA_STRIP_TOP_PAD_DP.dp, bottom = MEDIA_STRIP_BOTTOM_PAD_DP.dp)
+    // Pre-Q (Android 7-9, API 24-28): `ContentResolver.loadThumbnail` is
+    // API 29+ and we don't ship a `BitmapFactory.decodeStream` fallback —
+    // full-resolution decodes on the slowest hardware in our minSdk range
+    // would be worse UX than not showing the strip. Skip the permission
+    // prompt entirely and render only the permissionless Photos/Camera
+    // tiles. The user gets a working media-insert path (system picker +
+    // camera) and we don't burn their trust asking for a permission we
+    // can't deliver on.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        Box(modifier = stripFraming) {
+            PhotosCameraTile(
+                horizontal = true,
+                modifier = Modifier.fillMaxWidth().padding(contentPadding),
+            )
+        }
+        return
+    }
+    val access = rememberPhotoAccess(limit = RECENT_PHOTO_LIMIT)
+    val context = LocalContext.current
+    var rejected by remember { mutableStateOf(hasRejectedRationale(context)) }
+    // Clear a prior rejection once the user actually grants the permission.
+    // Without this, a later revocation would leave the user in CompactTiles
+    // with no in-app path back to the rationale.
+    LaunchedEffect(access) {
+        if (access is PhotoAccess.Granted && rejected) {
+            clearRejectedRationale(context)
+            rejected = false
+        }
+    }
+    Box(modifier = stripFraming) {
+        when (resolveMediaStripView(access, rejected)) {
+            MediaStripView.Rationale -> {
+                val needs = access as PhotoAccess.NeedsPermission
+                // Rationale fills the remaining width next to the Photos/Camera
+                // column — no horizontal scroll needed since nothing extends past
+                // the viewport.
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp),
+                    modifier = Modifier.fillMaxWidth().padding(contentPadding),
+                ) {
+                    PhotosCameraTile(horizontal = false)
+                    PhotoAccessRationale(
+                        state = needs.state,
+                        onAllow = needs.request,
+                        onReject = {
+                            markRationaleRejected(context)
+                            rejected = true
+                        },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+            MediaStripView.CompactTiles -> {
+                // Rationale dismissed — keep the Photos/Camera buttons accessible
+                // but flatten them into a single full-width row. Picker and camera
+                // don't need the photo permission; only the recent-photo strip does.
+                PhotosCameraTile(
+                    horizontal = true,
+                    modifier = Modifier.fillMaxWidth().padding(contentPadding),
+                )
+            }
+            MediaStripView.FullStrip -> FullMediaStrip(
+                granted = access as? PhotoAccess.Granted,
+                contentPadding = contentPadding,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FullMediaStrip(granted: PhotoAccess.Granted?, contentPadding: PaddingValues) {
+    // Granted — thumbnail strip extends past the viewport. LazyRow composes
+    // only the visible columns (plus prefetch), so the 64 thumbnails aren't
+    // all decoded into memory upfront. Vertical drags pass through the lazy
+    // list's nested-scroll dispatch up to BottomSheetBehavior; no manual
+    // relay needed.
+    val uris = granted?.uris.orEmpty()
+    val columns = (uris.size + 1) / 2
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp),
+        contentPadding = contentPadding,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        item(key = "actions") { PhotosCameraTile(horizontal = false) }
+        items(columns, key = { uris[it * 2].toString() }) { col ->
+            Column(verticalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp)) {
+                RealThumbnail(uri = uris[col * 2])
+                val secondIndex = col * 2 + 1
+                if (secondIndex < uris.size) {
+                    RealThumbnail(uri = uris[secondIndex])
+                }
+            }
+        }
+    }
+}
+
+// Photos uses the permissionless system photo picker; Camera uses
+// ACTION_IMAGE_CAPTURE against a cache-scoped FileProvider URI — no CAMERA
+// permission required since we delegate to the system camera app. The
+// recent-photos strip (READ_MEDIA_IMAGES-gated) sits alongside this row when
+// granted; otherwise this tile pair is the only media affordance.
+@Composable
+@Suppress("LongMethod")
+private fun PhotosCameraTile(
+    horizontal: Boolean,
+    modifier: Modifier = Modifier,
+) {
     val context = LocalContext.current
     // Hide the Camera tile on devices without any camera hardware (tablets,
     // emulators, e-readers). FEATURE_CAMERA_ANY doesn't require a `<queries>`
@@ -472,35 +624,57 @@ private fun MediaStrip() {
             Toast.makeText(context, cameraUnavailableMessage, Toast.LENGTH_SHORT).show()
         }
     }
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(MEDIA_STACK_GAP_DP.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(
-                start = MEDIA_STRIP_HORIZONTAL_PAD_DP.dp,
-                end = MEDIA_STRIP_HORIZONTAL_PAD_DP.dp,
-                top = MEDIA_STRIP_TOP_PAD_DP.dp,
-                bottom = MEDIA_STRIP_BOTTOM_PAD_DP.dp,
-            )
-            .height(MEDIA_STACK_COMPACT_HEIGHT_DP.dp),
-    ) {
-        MediaActionTile(
-            icon = Icons.Filled.PhotoLibrary,
-            label = stringResource(R.string.gbk_block_inserter_photos),
-            background = MaterialTheme.colorScheme.primaryContainer,
-            foreground = MaterialTheme.colorScheme.onPrimaryContainer,
-            onClick = onPhotosClick,
-            modifier = Modifier.fillMaxHeight().weight(1f),
-        )
-        if (hasCamera) {
+    val photosLabel = stringResource(R.string.gbk_block_inserter_photos)
+    val cameraLabel = stringResource(R.string.gbk_block_inserter_camera)
+    if (horizontal) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(MEDIA_STACK_GAP_DP.dp),
+            modifier = modifier.height(MEDIA_STACK_COMPACT_HEIGHT_DP.dp),
+        ) {
             MediaActionTile(
-                icon = Icons.Filled.PhotoCamera,
-                label = stringResource(R.string.gbk_block_inserter_camera),
-                background = MaterialTheme.colorScheme.tertiary,
-                foreground = MaterialTheme.colorScheme.onTertiary,
-                onClick = onCameraClick,
+                icon = Icons.Filled.PhotoLibrary,
+                label = photosLabel,
+                background = MaterialTheme.colorScheme.primaryContainer,
+                foreground = MaterialTheme.colorScheme.onPrimaryContainer,
+                onClick = onPhotosClick,
                 modifier = Modifier.fillMaxHeight().weight(1f),
             )
+            if (hasCamera) {
+                MediaActionTile(
+                    icon = Icons.Filled.PhotoCamera,
+                    label = cameraLabel,
+                    background = MaterialTheme.colorScheme.tertiary,
+                    foreground = MaterialTheme.colorScheme.onTertiary,
+                    onClick = onCameraClick,
+                    modifier = Modifier.fillMaxHeight().weight(1f),
+                )
+            }
+        }
+    } else {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(MEDIA_STACK_GAP_DP.dp),
+            modifier = modifier
+                .width(MEDIA_STACK_WIDTH_DP.dp)
+                .height(MEDIA_STACK_HEIGHT_DP.dp),
+        ) {
+            MediaActionTile(
+                icon = Icons.Filled.PhotoLibrary,
+                label = photosLabel,
+                background = MaterialTheme.colorScheme.primaryContainer,
+                foreground = MaterialTheme.colorScheme.onPrimaryContainer,
+                onClick = onPhotosClick,
+                modifier = Modifier.fillMaxWidth().weight(1f),
+            )
+            if (hasCamera) {
+                MediaActionTile(
+                    icon = Icons.Filled.PhotoCamera,
+                    label = cameraLabel,
+                    background = MaterialTheme.colorScheme.tertiary,
+                    foreground = MaterialTheme.colorScheme.onTertiary,
+                    onClick = onCameraClick,
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                )
+            }
         }
     }
 }
@@ -551,6 +725,129 @@ private fun MediaActionTile(
             color = foreground,
             fontSize = MEDIA_STACK_LABEL_SP.sp,
             fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PhotoAccessRationale(
+    state: PromptState,
+    onAllow: () -> Unit,
+    onReject: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val bodyRes = when (state) {
+        PromptState.Unasked -> R.string.gbk_block_inserter_photos_rationale
+        PromptState.Denied -> R.string.gbk_block_inserter_photos_rationale_denied
+        PromptState.PermanentlyDenied -> R.string.gbk_block_inserter_photos_rationale_permanent
+    }
+    val primaryLabelRes = when (state) {
+        PromptState.Unasked -> R.string.gbk_block_inserter_photos_allow
+        PromptState.Denied -> R.string.gbk_block_inserter_photos_try_again
+        PromptState.PermanentlyDenied -> R.string.gbk_block_inserter_photos_open_settings
+    }
+    @Composable
+    fun RationaleButton(label: String, filled: Boolean, onClick: () -> Unit, modifier: Modifier) {
+        val bg = if (filled) MaterialTheme.colorScheme.primary else ComposeColor.Transparent
+        val fg = if (filled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary
+        // Outer wrapper inflates the touch zone to the 48dp minimum; the inner
+        // Box paints the design's 32dp pill. The shared interaction source lets
+        // the outer absorb taps with no indication while the inner draws the
+        // ripple — otherwise a default ripple on the outer would render as a
+        // square halo around the rounded pill.
+        val interactionSource = remember { MutableInteractionSource() }
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = modifier
+                .heightIn(min = TOUCH_TARGET_MIN_DP.dp)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    role = Role.Button,
+                    onClick = onClick,
+                ),
+        ) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(MEDIA_RATIONALE_BUTTON_HEIGHT_DP.dp)
+                    .clip(RoundedCornerShape(MEDIA_RATIONALE_BUTTON_CORNER_DP.dp))
+                    .background(bg)
+                    .indication(interactionSource, ripple()),
+            ) {
+                Text(
+                    text = label,
+                    color = fg,
+                    fontSize = MEDIA_RATIONALE_BUTTON_FONT_SP.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+    }
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier
+            .height(MEDIA_STACK_HEIGHT_DP.dp)
+            .clip(RoundedCornerShape(MEDIA_STACK_CORNER_DP.dp))
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .padding(MEDIA_RATIONALE_PAD_DP.dp),
+    ) {
+        Text(
+            text = stringResource(bodyRes),
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            fontSize = MEDIA_RATIONALE_FONT_SP.sp,
+            lineHeight = MEDIA_RATIONALE_LINE_HEIGHT_SP.sp,
+            fontWeight = FontWeight.Medium,
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(MEDIA_RATIONALE_BUTTON_GAP_DP.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            RationaleButton(
+                label = stringResource(primaryLabelRes),
+                filled = true,
+                onClick = onAllow,
+                modifier = Modifier.weight(1f),
+            )
+            RationaleButton(
+                label = stringResource(R.string.gbk_block_inserter_photos_reject),
+                filled = false,
+                onClick = onReject,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun RealThumbnail(uri: Uri) {
+    val context = LocalContext.current
+    val sizePx = with(LocalDensity.current) { MEDIA_THUMB_SIZE_DP.dp.roundToPx() }
+    var bitmap by remember(uri) { mutableStateOf<ImageBitmap?>(null) }
+    LaunchedEffect(uri, sizePx) {
+        bitmap = withContext(Dispatchers.IO) { loadThumbnail(context, uri, sizePx) }
+    }
+    val bmp = bitmap
+    if (bmp != null) {
+        Image(
+            bitmap = bmp,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(MEDIA_THUMB_SIZE_DP.dp)
+                .clip(RoundedCornerShape(MEDIA_THUMB_CORNER_DP.dp)),
+        )
+    } else {
+        // Neutral loading box — avoids flashing colorful mock-photo gradients
+        // between the URI being known and the bitmap finishing async load.
+        Box(
+            modifier = Modifier
+                .size(MEDIA_THUMB_SIZE_DP.dp)
+                .clip(RoundedCornerShape(MEDIA_THUMB_CORNER_DP.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         )
     }
 }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -57,7 +57,9 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -104,13 +106,20 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.FileProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import android.os.Parcelable
 import java.io.File
 import kotlin.math.roundToInt
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.parcelize.Parcelize
 import org.wordpress.gutenberg.R
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.Color as ComposeColor
+import org.wordpress.gutenberg.media.MediaFileManager
+import org.wordpress.gutenberg.media.MediaInfo
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.BlockType
 
@@ -225,6 +234,7 @@ internal class BlockPickerDialog(
     context: Context,
     private val payload: BlockInserterPayload,
     private val onBlockSelected: (BlockType) -> Unit,
+    private val onMediaSelected: (List<MediaInfo>) -> Unit,
 ) : BottomSheetDialog(context) {
 
     init {
@@ -246,6 +256,10 @@ internal class BlockPickerDialog(
                     payload = payload,
                     onBlockSelected = { block ->
                         onBlockSelected(block)
+                        dismiss()
+                    },
+                    onMediaSelected = { media ->
+                        onMediaSelected(media)
                         dismiss()
                     },
                     onClose = { dismiss() },
@@ -270,41 +284,55 @@ internal class BlockPickerDialog(
     }
 }
 
+/**
+ * Ambient handoff for inserter-sourced media. Provided once at the sheet root
+ * so the Photos tile, Camera tile, and recent-photos thumbnails can each fire
+ * a media insertion without prop-drilling the callback through every layout
+ * composable in between.
+ */
+private val LocalMediaInsertion =
+    compositionLocalOf<((List<MediaInfo>) -> Unit)> {
+        error("LocalMediaInsertion not provided")
+    }
+
 @Composable
 private fun BlockPickerSheet(
     payload: BlockInserterPayload,
     onBlockSelected: (BlockType) -> Unit,
+    onMediaSelected: (List<MediaInfo>) -> Unit,
     onClose: () -> Unit,
 ) {
     val colorScheme = rememberColorScheme()
     MaterialTheme(colorScheme = colorScheme) {
-        val allBlocks = remember(payload) { flattenBlocks(payload) }
-        val recentBlocks = remember(payload, allBlocks) { recentBlocks(payload, allBlocks) }
+        CompositionLocalProvider(LocalMediaInsertion provides onMediaSelected) {
+            val allBlocks = remember(payload) { flattenBlocks(payload) }
+            val recentBlocks = remember(payload, allBlocks) { recentBlocks(payload, allBlocks) }
 
-        var selectedTab by remember { mutableStateOf(BlockPickerTab.Recent) }
-        var query by remember { mutableStateOf("") }
-        var debounced by remember { mutableStateOf("") }
-        LaunchedEffect(query) {
-            delay(SEARCH_DEBOUNCE_MS)
-            debounced = query.trim()
+            var selectedTab by remember { mutableStateOf(BlockPickerTab.Recent) }
+            var query by remember { mutableStateOf("") }
+            var debounced by remember { mutableStateOf("") }
+            LaunchedEffect(query) {
+                delay(SEARCH_DEBOUNCE_MS)
+                debounced = query.trim()
+            }
+
+            val filtered = remember(selectedTab, debounced, allBlocks, recentBlocks) {
+                val tabBlocks = filterByTab(selectedTab, allBlocks, recentBlocks)
+                if (debounced.isEmpty()) tabBlocks else searchBlocks(debounced, tabBlocks)
+            }
+
+            SheetContent(
+                selectedTab = selectedTab,
+                onSelectTab = { selectedTab = it },
+                query = query,
+                onQueryChange = { query = it },
+                debouncedQuery = debounced,
+                blocks = filtered,
+                onBlockSelected = onBlockSelected,
+                onClose = onClose,
+                surface = colorScheme.surfaceContainerLow,
+            )
         }
-
-        val filtered = remember(selectedTab, debounced, allBlocks, recentBlocks) {
-            val tabBlocks = filterByTab(selectedTab, allBlocks, recentBlocks)
-            if (debounced.isEmpty()) tabBlocks else searchBlocks(debounced, tabBlocks)
-        }
-
-        SheetContent(
-            selectedTab = selectedTab,
-            onSelectTab = { selectedTab = it },
-            query = query,
-            onQueryChange = { query = it },
-            debouncedQuery = debounced,
-            blocks = filtered,
-            onBlockSelected = onBlockSelected,
-            onClose = onClose,
-            surface = colorScheme.surfaceContainerLow,
-        )
     }
 }
 
@@ -611,41 +639,59 @@ private fun PhotosCameraTile(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val insertMedia = LocalMediaInsertion.current
     // Hide the Camera tile on devices without any camera hardware (tablets,
     // emulators, e-readers). FEATURE_CAMERA_ANY doesn't require a `<queries>`
     // manifest entry, unlike resolving ACTION_IMAGE_CAPTURE directly.
     val hasCamera = remember(context) {
         context.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)
     }
-    // The result callbacks below are intentionally inert: the picked URI / camera
-    // capture needs to round-trip through `WebViewAssetLoader` so the JS editor
-    // can `fetch()` it, which is a follow-up. Until that lands, this whole sheet
-    // is gated behind the demo app's "Enable Native Inserter" toggle, so users
-    // outside that opt-in won't see the no-op buttons.
     val photoPicker = rememberLauncherForActivityResult(
         ActivityResultContracts.PickVisualMedia()
-    ) { /* picked uri — hand-off to editor insertion is a follow-up */ }
+    ) { uri ->
+        if (uri != null) handlePickedUri(scope, context, uri, insertMedia)
+    }
     // Saveable so the URI survives process death while the camera app is in
     // the foreground; `Uri` is `Parcelable`, which the default saver handles.
-    // Written on each Camera tap so the follow-up `TakePicture` callback can
-    // read back the capture target — unused by the inert callback today.
-    var pendingCameraUri by rememberSaveable { mutableStateOf<Uri?>(null) }
+    // Written on each Camera tap, read back when the launcher returns to
+    // resolve the captured file → MediaInfo → editor insertion.
+    var pendingCameraCapture by rememberSaveable { mutableStateOf<CameraCapture?>(null) }
     val cameraLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.TakePicture()
-    ) { /* success:Boolean + pendingCameraUri — hand-off is a follow-up */ }
+    ) { success ->
+        val capture = pendingCameraCapture
+        pendingCameraCapture = null
+        if (success && capture != null) {
+            // Captured file is already inside MediaFileManager's uploads dir,
+            // so no copy step — hand the MediaInfo straight to the editor.
+            insertMedia(listOf(MediaFileManager.mediaInfoForFile(File(capture.filePath))))
+        } else if (capture != null) {
+            // Cancellation / failure leaves an empty file behind from the
+            // FileProvider grant; sweep it eagerly so it doesn't have to wait
+            // for the 2-day TTL cleanup.
+            runCatching { File(capture.filePath).delete() }
+        }
+    }
     val imageOnly = remember { PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly) }
     val onPhotosClick = { photoPicker.launch(imageOnly) }
     val cameraUnavailableMessage = stringResource(R.string.gbk_block_inserter_camera_unavailable)
     val onCameraClick = {
-        val uri = createCameraOutputUri(context)
-        pendingCameraUri = uri
+        val file = MediaFileManager.newCameraOutputFile(context)
+        val uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.gutenberg.fileprovider",
+            file,
+        )
+        pendingCameraCapture = CameraCapture(filePath = file.absolutePath)
         try {
             cameraLauncher.launch(uri)
         } catch (e: ActivityNotFoundException) {
             // Defense-in-depth: hasCamera gates the tile, but corp-locked
             // devices can have camera hardware without any handler for
             // ACTION_IMAGE_CAPTURE installed.
-            pendingCameraUri = null
+            pendingCameraCapture = null
+            runCatching { file.delete() }
             Log.w("BlockPickerDialog", "No activity to handle ACTION_IMAGE_CAPTURE", e)
             Toast.makeText(context, cameraUnavailableMessage, Toast.LENGTH_SHORT).show()
         }
@@ -705,18 +751,39 @@ private fun PhotosCameraTile(
     }
 }
 
-private fun createCameraOutputUri(context: Context): Uri {
-    val dir = File(context.cacheDir, "camera").apply { mkdirs() }
-    val file = File(dir, "capture_${System.currentTimeMillis()}.jpg")
-    // TODO: clean up captured files once the editor hand-off lands. Each Camera
-    // tap creates a fresh file here; with the result callback inert today, every
-    // capture is orphaned in the cache. When we wire up the URI hand-off, delete
-    // on success/cancel and sweep stale files on next entry.
-    return FileProvider.getUriForFile(
-        context,
-        "${context.packageName}.gutenberg.fileprovider",
-        file,
-    )
+/**
+ * `Parcelable` payload that lets `rememberSaveable` survive the round-trip to
+ * the camera app. Only the file path matters across process death — the
+ * FileProvider URI is rebuilt by the system on launch.
+ */
+@Parcelize
+internal data class CameraCapture(val filePath: String) : Parcelable
+
+private fun handlePickedUri(
+    scope: CoroutineScope,
+    context: Context,
+    uri: Uri,
+    insertMedia: (List<MediaInfo>) -> Unit,
+) {
+    scope.launch {
+        // Import can fail for transient reasons (cloud-only photo without
+        // network, MediaStore deletion race, SAF provider crash). On failure,
+        // surface a toast and leave the sheet open so the user can pick again.
+        val info = runCatching { MediaFileManager.import(context, uri) }
+            .onFailure { Log.w("BlockPickerDialog", "Failed to import picked URI: $uri", it) }
+            .getOrNull()
+        if (info == null) {
+            withContext(Dispatchers.Main) {
+                Toast.makeText(
+                    context,
+                    R.string.gbk_block_inserter_media_import_failed,
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+            return@launch
+        }
+        insertMedia(listOf(info))
+    }
 }
 
 @Composable
@@ -851,6 +918,8 @@ private fun PhotoAccessRationale(
 @Composable
 private fun RealThumbnail(uri: Uri, onLoadFailed: (Uri) -> Unit) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val insertMedia = LocalMediaInsertion.current
     val sizePx = with(LocalDensity.current) { MEDIA_THUMB_SIZE_DP.dp.roundToPx() }
     // Seed from the process-wide cache so a scroll-back or dialog-reopen
     // skips the grey-placeholder flash entirely. On a cache miss the
@@ -865,22 +934,23 @@ private fun RealThumbnail(uri: Uri, onLoadFailed: (Uri) -> Unit) {
         }
     }
     val bmp = bitmap
+    val thumbModifier = Modifier
+        .size(MEDIA_THUMB_SIZE_DP.dp)
+        .clip(RoundedCornerShape(MEDIA_THUMB_CORNER_DP.dp))
+        .clickable { handlePickedUri(scope, context, uri, insertMedia) }
+        .semantics { role = Role.Button }
     if (bmp != null) {
         Image(
             bitmap = bmp,
             contentDescription = null,
             contentScale = ContentScale.Crop,
-            modifier = Modifier
-                .size(MEDIA_THUMB_SIZE_DP.dp)
-                .clip(RoundedCornerShape(MEDIA_THUMB_CORNER_DP.dp)),
+            modifier = thumbModifier,
         )
     } else {
         // Neutral loading box — avoids flashing colorful mock-photo gradients
         // between the URI being known and the bitmap finishing async load.
         Box(
-            modifier = Modifier
-                .size(MEDIA_THUMB_SIZE_DP.dp)
-                .clip(RoundedCornerShape(MEDIA_THUMB_CORNER_DP.dp))
+            modifier = thumbModifier
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh),
         )
     }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -228,12 +228,17 @@ internal class BlockPickerDialog(
 ) : BottomSheetDialog(context) {
 
     init {
-        // Render at full size regardless of the IME — without this the dialog
-        // opens compressed above an in-flight soft keyboard, then visibly
-        // resizes once the IME dismisses, looking like a "double launch".
+        // `STATE_HIDDEN` dismisses any in-flight soft keyboard on dialog open
+        // — without it the sheet renders compressed above the editor's IME and
+        // then visibly resizes when the IME dismisses, looking like a "double
+        // launch". `ADJUST_RESIZE` lets the sheet shrink back to make room when
+        // the user later taps the search field; previously we paired
+        // `STATE_HIDDEN` with `ADJUST_NOTHING`, which fixed the open-time race
+        // but latched in for the dialog's lifetime — the IME then covered the
+        // search field and the results grid below it.
         window?.setSoftInputMode(
             WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN or
-                WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
+                WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
         )
         val composeView = ComposeView(context).apply {
             setContent {
@@ -494,9 +499,22 @@ private fun MediaStrip() {
         }
         return
     }
-    val access = rememberPhotoAccess(limit = RECENT_PHOTO_LIMIT)
     val context = LocalContext.current
-    var rejected by remember { mutableStateOf(hasRejectedRationale(context)) }
+    // SharedPreferences are read async on `Dispatchers.IO` to keep the main
+    // thread IO-free. While loading we render a same-height placeholder so
+    // the strip's vertical rhythm doesn't shift when the real state arrives
+    // a few ms later. After process-warmup (cache hot) this returns
+    // synchronously and no placeholder shows.
+    val prefs = rememberPhotoPrefs(context)
+    if (prefs == null) {
+        Box(modifier = stripFraming.height(MEDIA_STACK_HEIGHT_DP.dp))
+        return
+    }
+    val access = rememberPhotoAccess(
+        limit = RECENT_PHOTO_LIMIT,
+        initialPromptedBefore = prefs.promptedBefore,
+    )
+    var rejected by remember(prefs) { mutableStateOf(prefs.rejected) }
     // Clear a prior rejection once the user actually grants the permission.
     // Without this, a later revocation would leave the user in CompactTiles
     // with no in-app path back to the rationale.
@@ -553,8 +571,16 @@ private fun FullMediaStrip(granted: PhotoAccess.Granted?, contentPadding: Paddin
     // all decoded into memory upfront. Vertical drags pass through the lazy
     // list's nested-scroll dispatch up to BottomSheetBehavior; no manual
     // relay needed.
-    val uris = granted?.uris.orEmpty()
+    //
+    // When a thumbnail fails to load (deleted-mid-scroll URI, partial-grant
+    // denial, OEM MediaStore quirk, offline + cloud-only stub) we drop the
+    // URI from the displayed set. The strip shrinks gracefully — better
+    // than stranding a grey placeholder where a real thumbnail should be.
+    val sourceUris = granted?.uris.orEmpty()
+    var failed by remember(granted) { mutableStateOf<Set<Uri>>(emptySet()) }
+    val uris = sourceUris.filterNot { it in failed }
     val columns = (uris.size + 1) / 2
+    val onThumbnailFailed: (Uri) -> Unit = { failed = failed + it }
     LazyRow(
         horizontalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp),
         contentPadding = contentPadding,
@@ -563,10 +589,10 @@ private fun FullMediaStrip(granted: PhotoAccess.Granted?, contentPadding: Paddin
         item(key = "actions") { PhotosCameraTile(horizontal = false) }
         items(columns, key = { uris[it * 2].toString() }) { col ->
             Column(verticalArrangement = Arrangement.spacedBy(MEDIA_STRIP_ITEM_GAP_DP.dp)) {
-                RealThumbnail(uri = uris[col * 2])
+                RealThumbnail(uri = uris[col * 2], onLoadFailed = onThumbnailFailed)
                 val secondIndex = col * 2 + 1
                 if (secondIndex < uris.size) {
-                    RealThumbnail(uri = uris[secondIndex])
+                    RealThumbnail(uri = uris[secondIndex], onLoadFailed = onThumbnailFailed)
                 }
             }
         }
@@ -823,12 +849,20 @@ private fun PhotoAccessRationale(
 }
 
 @Composable
-private fun RealThumbnail(uri: Uri) {
+private fun RealThumbnail(uri: Uri, onLoadFailed: (Uri) -> Unit) {
     val context = LocalContext.current
     val sizePx = with(LocalDensity.current) { MEDIA_THUMB_SIZE_DP.dp.roundToPx() }
-    var bitmap by remember(uri) { mutableStateOf<ImageBitmap?>(null) }
+    // Seed from the process-wide cache so a scroll-back or dialog-reopen
+    // skips the grey-placeholder flash entirely. On a cache miss the
+    // LaunchedEffect below fetches off-thread and populates the cache;
+    // on a load failure we notify the parent so the URI is dropped from
+    // the displayed set and a pool spare takes its place.
+    var bitmap by remember(uri, sizePx) { mutableStateOf(cachedThumbnail(uri, sizePx)) }
     LaunchedEffect(uri, sizePx) {
-        bitmap = withContext(Dispatchers.IO) { loadThumbnail(context, uri, sizePx) }
+        if (bitmap == null) {
+            val loaded = withContext(Dispatchers.IO) { loadThumbnail(context, uri, sizePx) }
+            if (loaded == null) onLoadFailed(uri) else bitmap = loaded
+        }
     }
     val bmp = bitmap
     if (bmp != null) {

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -119,7 +119,7 @@ import org.wordpress.gutenberg.R
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.Color as ComposeColor
 import org.wordpress.gutenberg.media.MediaFileManager
-import org.wordpress.gutenberg.media.MediaInfo
+import org.wordpress.gutenberg.media.StoredMedia
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.BlockType
 
@@ -234,7 +234,7 @@ internal class BlockPickerDialog(
     context: Context,
     private val payload: BlockInserterPayload,
     private val onBlockSelected: (BlockType) -> Unit,
-    private val onMediaSelected: (List<MediaInfo>) -> Unit,
+    private val onMediaSelected: (List<StoredMedia>) -> Unit,
 ) : BottomSheetDialog(context) {
 
     init {
@@ -291,7 +291,7 @@ internal class BlockPickerDialog(
  * composable in between.
  */
 private val LocalMediaInsertion =
-    compositionLocalOf<((List<MediaInfo>) -> Unit)> {
+    compositionLocalOf<((List<StoredMedia>) -> Unit)> {
         error("LocalMediaInsertion not provided")
     }
 
@@ -299,7 +299,7 @@ private val LocalMediaInsertion =
 private fun BlockPickerSheet(
     payload: BlockInserterPayload,
     onBlockSelected: (BlockType) -> Unit,
-    onMediaSelected: (List<MediaInfo>) -> Unit,
+    onMediaSelected: (List<StoredMedia>) -> Unit,
     onClose: () -> Unit,
 ) {
     val colorScheme = rememberColorScheme()
@@ -655,7 +655,7 @@ private fun PhotosCameraTile(
     // Saveable so the URI survives process death while the camera app is in
     // the foreground; `Uri` is `Parcelable`, which the default saver handles.
     // Written on each Camera tap, read back when the launcher returns to
-    // resolve the captured file → MediaInfo → editor insertion.
+    // resolve the captured file → StoredMedia → editor insertion.
     var pendingCameraCapture by rememberSaveable { mutableStateOf<CameraCapture?>(null) }
     val cameraLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.TakePicture()
@@ -664,8 +664,8 @@ private fun PhotosCameraTile(
         pendingCameraCapture = null
         if (success && capture != null) {
             // Captured file is already inside MediaFileManager's uploads dir,
-            // so no copy step — hand the MediaInfo straight to the editor.
-            insertMedia(listOf(MediaFileManager.mediaInfoForFile(File(capture.filePath))))
+            // so no copy step — hand the StoredMedia straight to the editor.
+            insertMedia(listOf(MediaFileManager.storedMediaForFile(File(capture.filePath))))
         } else if (capture != null) {
             // Cancellation / failure leaves an empty file behind from the
             // FileProvider grant; sweep it eagerly so it doesn't have to wait
@@ -763,7 +763,7 @@ private fun handlePickedUri(
     scope: CoroutineScope,
     context: Context,
     uri: Uri,
-    insertMedia: (List<MediaInfo>) -> Unit,
+    insertMedia: (List<StoredMedia>) -> Unit,
 ) {
     scope.launch {
         // Import can fail for transient reasons (cloud-only photo without

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/PhotoAccessState.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/PhotoAccessState.kt
@@ -1,0 +1,60 @@
+package org.wordpress.gutenberg.inserter
+
+import android.net.Uri
+
+/**
+ * Photo-library access state for the inserter's media strip. Distinguishes
+ * "never asked" from "permanently denied" by persisting whether the system
+ * prompt has been shown at least once — Android's
+ * `shouldShowRequestPermissionRationale` alone can't tell those apart.
+ */
+internal sealed interface PhotoAccess {
+    data class Granted(val uris: List<Uri>) : PhotoAccess
+    data class NeedsPermission(
+        val state: PromptState,
+        val request: () -> Unit,
+    ) : PhotoAccess
+}
+
+/**
+ * Three mutually exclusive states the rationale card needs to distinguish:
+ * never asked, denied once (system will re-prompt), or permanently denied
+ * (system prompt is suppressed, user must enable via Settings).
+ */
+internal enum class PromptState { Unasked, Denied, PermanentlyDenied }
+
+/**
+ * Pure mapping from the two Android signals to the rationale's three-way state.
+ * `canReprompt` is `Activity.shouldShowRequestPermissionRationale(...)`'s result;
+ * `promptedBefore` is our SharedPreferences flag set after the first system prompt.
+ */
+internal fun resolvePromptState(
+    promptedBefore: Boolean,
+    canReprompt: Boolean,
+): PromptState = when {
+    !promptedBefore -> PromptState.Unasked
+    canReprompt -> PromptState.Denied
+    else -> PromptState.PermanentlyDenied
+}
+
+/**
+ * Which of the three media-strip layouts the inserter should render. A granted
+ * permission always wins over a sticky rejection so users get the thumbnail
+ * strip back if they grant access via system Settings after dismissing the
+ * rationale.
+ */
+internal sealed class MediaStripView {
+    object Rationale : MediaStripView()
+    object CompactTiles : MediaStripView()
+    object FullStrip : MediaStripView()
+}
+
+internal fun resolveMediaStripView(
+    access: PhotoAccess,
+    rejected: Boolean,
+): MediaStripView = when {
+    access is PhotoAccess.Granted -> MediaStripView.FullStrip
+    rejected -> MediaStripView.CompactTiles
+    access is PhotoAccess.NeedsPermission -> MediaStripView.Rationale
+    else -> MediaStripView.FullStrip
+}

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/RecentImages.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/RecentImages.kt
@@ -11,6 +11,8 @@ import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import android.provider.Settings
+import android.util.Log
+import android.util.LruCache
 import android.util.Size as AndroidSize
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -29,19 +31,101 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+// Process-wide thumbnail cache keyed by content URI. Sized for ~half the
+// strip (RECENT_PHOTO_LIMIT / 2) — enough that the user can scroll back
+// and forth without re-fetching the leading items, and bounded so the
+// memory footprint stays predictable (32 entries * ~200KB ARGB_8888 at
+// 64dp/3.5x density ≈ 6MB worst case). Bitmaps are immutable, so cache
+// hits are safe to share across composables.
+//
+// Without this cache, `LazyRow`'s offscreen disposal forced every
+// scroll-back into view to re-run `RealThumbnail`'s `LaunchedEffect`,
+// re-hitting `ContentResolver.loadThumbnail` via binder for a thumbnail
+// the user just saw — and every dialog reopen re-decoded the same 64
+// URIs from scratch.
+private const val THUMBNAIL_CACHE_SIZE = 32
+// Key includes `sizePx` so a density or `MEDIA_THUMB_SIZE_DP` change doesn't
+// serve a bitmap decoded for a different render size.
+private val thumbnailCache = LruCache<Pair<Uri, Int>, ImageBitmap>(THUMBNAIL_CACHE_SIZE)
+
+private const val TAG = "RecentImages"
 
 private const val PHOTO_PREFS = "gbk_inserter"
 private const val KEY_PHOTOS_PROMPTED = "photos_prompted"
 private const val KEY_RATIONALE_REJECTED = "rationale_rejected"
 
+/**
+ * Immutable snapshot of the inserter's photo prefs. Two booleans:
+ *  - `promptedBefore`: have we shown the system permission prompt at least once.
+ *  - `rejected`: has the user dismissed the rationale card.
+ */
+internal data class PhotoPrefs(
+    val promptedBefore: Boolean = false,
+    val rejected: Boolean = false,
+)
+
+// Process-wide cache populated on first async load. SharedPreferences reads
+// and writes are dispatched off the main thread — composables read from the
+// cache (synchronous, no IO) and writers update the cache atomically before
+// queuing a disk `.apply()` on `photoPrefsScope`.
+@Volatile
+private var cachedPhotoPrefs: PhotoPrefs? = null
+private val photoPrefsScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+internal suspend fun ensurePhotoPrefsLoaded(context: Context): PhotoPrefs {
+    cachedPhotoPrefs?.let { return it }
+    return withContext(Dispatchers.IO) {
+        cachedPhotoPrefs ?: run {
+            val sp = context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+            PhotoPrefs(
+                promptedBefore = sp.getBoolean(KEY_PHOTOS_PROMPTED, false),
+                rejected = sp.getBoolean(KEY_RATIONALE_REJECTED, false),
+            ).also { cachedPhotoPrefs = it }
+        }
+    }
+}
+
+/**
+ * Returns the cached prefs synchronously if already loaded; otherwise kicks
+ * off an async load and returns `null` until the load completes. In practice
+ * the cache is warmed by `warmupPhotoPrefs` during `GutenbergView` construction,
+ * so by the time the inserter is openable the prefs are loaded and this
+ * returns synchronously. The async path is a defensive fallback that should
+ * never render visibly under normal use.
+ */
 @Composable
-internal fun rememberPhotoAccess(limit: Int): PhotoAccess {
+internal fun rememberPhotoPrefs(context: Context): PhotoPrefs? {
+    var prefs by remember { mutableStateOf(cachedPhotoPrefs) }
+    LaunchedEffect(Unit) {
+        if (prefs == null) prefs = ensurePhotoPrefsLoaded(context)
+    }
+    return prefs
+}
+
+/**
+ * Fire-and-forget warmup that loads the photo prefs into the process-wide
+ * cache. Called from `GutenbergView`'s constructor so that by the time the
+ * user can navigate to and open the inserter, the cache is hot and the
+ * inserter's prefs read is synchronous — no async-load placeholder flashes.
+ */
+internal fun warmupPhotoPrefs(context: Context) {
+    if (cachedPhotoPrefs != null) return
+    val appContext = context.applicationContext
+    photoPrefsScope.launch { ensurePhotoPrefsLoaded(appContext) }
+}
+
+@Composable
+internal fun rememberPhotoAccess(limit: Int, initialPromptedBefore: Boolean): PhotoAccess {
     val context = LocalContext.current
     val activity = remember(context) { context.findActivity() }
     var granted by remember { mutableStateOf(hasPhotosPermission(context)) }
-    var promptedBefore by remember { mutableStateOf(hasPromptedForPhotos(context)) }
+    var promptedBefore by remember { mutableStateOf(initialPromptedBefore) }
     var uris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     // `canReprompt` is its own state, recomputed at every permission-relevant
     // signal (launcher result, lifecycle resume). Compose's snapshot system
@@ -97,15 +181,28 @@ internal fun rememberPhotoAccess(limit: Int): PhotoAccess {
     )
 }
 
-internal fun loadThumbnail(context: Context, uri: Uri, sizePx: Int): ImageBitmap? =
-    runCatching {
+internal fun cachedThumbnail(uri: Uri, sizePx: Int): ImageBitmap? =
+    thumbnailCache.get(uri to sizePx)
+
+internal fun loadThumbnail(context: Context, uri: Uri, sizePx: Int): ImageBitmap? {
+    val key = uri to sizePx
+    thumbnailCache.get(key)?.let { return it }
+    // MediaStore failures here are expected (deleted-mid-scroll URIs,
+    // partial-grant SecurityExceptions on Android 14+, OEM-specific
+    // FileNotFoundException). Log at warn so the failure isn't silent
+    // for engineers watching logcat, but don't crash — the strip
+    // gracefully falls back to the neutral placeholder for this tile.
+    val decoded = runCatching {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             context.contentResolver.loadThumbnail(uri, AndroidSize(sizePx, sizePx), null)
                 .asImageBitmap()
         } else {
             null
         }
-    }.getOrNull()
+    }.onFailure { Log.w(TAG, "Failed to load thumbnail: $uri", it) }.getOrNull()
+    decoded?.let { thumbnailCache.put(key, it) }
+    return decoded
+}
 
 private fun photosPermission(): String =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -114,8 +211,32 @@ private fun photosPermission(): String =
         Manifest.permission.READ_EXTERNAL_STORAGE
     }
 
-private fun hasPhotosPermission(context: Context): Boolean =
-    ContextCompat.checkSelfPermission(context, photosPermission()) == PackageManager.PERMISSION_GRANTED
+private fun hasPhotosPermission(context: Context): Boolean {
+    if (ContextCompat.checkSelfPermission(context, photosPermission()) ==
+        PackageManager.PERMISSION_GRANTED
+    ) {
+        return true
+    }
+    // Android 14+ shows a three-option dialog ("Allow all" / "Select photos" /
+    // "Don't allow") whenever an app at targetSdk >= 34 requests
+    // `READ_MEDIA_IMAGES` — regardless of whether the manifest opts in to
+    // `READ_MEDIA_VISUAL_USER_SELECTED`. If the user picks "Select photos",
+    // `READ_MEDIA_IMAGES` stays denied but `READ_MEDIA_VISUAL_USER_SELECTED`
+    // is granted, and MediaStore automatically scopes our query to the
+    // user-selected items. Treat that as granted so we don't tell the user
+    // they have no access when they actually granted partial access.
+    //
+    // Declaring `READ_MEDIA_VISUAL_USER_SELECTED` in the library manifest
+    // (which would unlock the "Select more photos" re-prompt affordance)
+    // is the follow-up PR.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+    return false
+}
 
 private fun shouldShowRationale(activity: Activity): Boolean =
     ActivityCompat.shouldShowRequestPermissionRationale(activity, photosPermission())
@@ -134,22 +255,26 @@ private fun openAppSettings(context: Context) {
     context.startActivity(intent)
 }
 
-private fun hasPromptedForPhotos(context: Context): Boolean =
-    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
-        .getBoolean(KEY_PHOTOS_PROMPTED, false)
-
+// Cache update is synchronous so subsequent composition reads see the new
+// value immediately; the disk `.apply()` runs on `photoPrefsScope` so the
+// caller never blocks on IO (including `SharedPreferences.edit()` itself,
+// which can block waiting for the file's background load to complete).
 private fun markPromptedForPhotos(context: Context) {
-    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
-        .edit().putBoolean(KEY_PHOTOS_PROMPTED, true).apply()
+    cachedPhotoPrefs = (cachedPhotoPrefs ?: PhotoPrefs()).copy(promptedBefore = true)
+    val appContext = context.applicationContext
+    photoPrefsScope.launch {
+        appContext.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_PHOTOS_PROMPTED, true).apply()
+    }
 }
 
-internal fun hasRejectedRationale(context: Context): Boolean =
-    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
-        .getBoolean(KEY_RATIONALE_REJECTED, false)
-
 internal fun markRationaleRejected(context: Context) {
-    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
-        .edit().putBoolean(KEY_RATIONALE_REJECTED, true).apply()
+    cachedPhotoPrefs = (cachedPhotoPrefs ?: PhotoPrefs()).copy(rejected = true)
+    val appContext = context.applicationContext
+    photoPrefsScope.launch {
+        appContext.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_RATIONALE_REJECTED, true).apply()
+    }
 }
 
 /**
@@ -159,13 +284,21 @@ internal fun markRationaleRejected(context: Context) {
  * user in CompactTiles with no in-app affordance to re-engage.
  */
 internal fun clearRejectedRationale(context: Context) {
-    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
-        .edit().remove(KEY_RATIONALE_REJECTED).apply()
+    cachedPhotoPrefs = (cachedPhotoPrefs ?: PhotoPrefs()).copy(rejected = false)
+    val appContext = context.applicationContext
+    photoPrefsScope.launch {
+        appContext.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+            .edit().remove(KEY_RATIONALE_REJECTED).apply()
+    }
 }
 
 internal fun clearPhotoPreferences(context: Context) {
-    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
-        .edit().clear().apply()
+    cachedPhotoPrefs = PhotoPrefs()
+    val appContext = context.applicationContext
+    photoPrefsScope.launch {
+        appContext.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+            .edit().clear().apply()
+    }
 }
 
 private fun queryRecentImages(context: Context, limit: Int): List<Uri> {
@@ -178,6 +311,9 @@ private fun queryRecentImages(context: Context, limit: Int): List<Uri> {
     val projection = arrayOf(MediaStore.Images.Media._ID)
     val sortOrder = "${MediaStore.Images.Media.DATE_ADDED} DESC"
     val result = mutableListOf<Uri>()
+    // Query failures here strand the user with an empty strip rather
+    // than a crash — surface to logcat so engineers see when a real
+    // permission/cursor problem (vs. genuinely no photos) is the cause.
     runCatching {
         context.contentResolver.query(collection, projection, null, null, sortOrder)?.use { cursor ->
             val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
@@ -186,6 +322,6 @@ private fun queryRecentImages(context: Context, limit: Int): List<Uri> {
                 result.add(ContentUris.withAppendedId(collection, id))
             }
         }
-    }
+    }.onFailure { Log.w(TAG, "Failed to query recent images from MediaStore", it) }
     return result
 }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/RecentImages.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/RecentImages.kt
@@ -1,0 +1,191 @@
+package org.wordpress.gutenberg.inserter
+
+import android.Manifest
+import android.app.Activity
+import android.content.ContentUris
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.provider.Settings
+import android.util.Size as AndroidSize
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val PHOTO_PREFS = "gbk_inserter"
+private const val KEY_PHOTOS_PROMPTED = "photos_prompted"
+private const val KEY_RATIONALE_REJECTED = "rationale_rejected"
+
+@Composable
+internal fun rememberPhotoAccess(limit: Int): PhotoAccess {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findActivity() }
+    var granted by remember { mutableStateOf(hasPhotosPermission(context)) }
+    var promptedBefore by remember { mutableStateOf(hasPromptedForPhotos(context)) }
+    var uris by remember { mutableStateOf<List<Uri>>(emptyList()) }
+    // `canReprompt` is its own state, recomputed at every permission-relevant
+    // signal (launcher result, lifecycle resume). Compose's snapshot system
+    // can't see the OS-level `shouldShowRequestPermissionRationale` flip from
+    // true → false on the 2nd denial otherwise — `granted` and `promptedBefore`
+    // are already in their post-deny values, so neither would notify Compose
+    // and the rationale would stay stuck on "Try Again".
+    var canReprompt by remember {
+        mutableStateOf(activity?.let { shouldShowRationale(it) } ?: true)
+    }
+    val refreshAccessState = {
+        granted = hasPhotosPermission(context)
+        canReprompt = activity?.let { shouldShowRationale(it) } ?: true
+    }
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { _ ->
+        markPromptedForPhotos(context)
+        promptedBefore = true
+        refreshAccessState()
+    }
+    // Re-read permission on every RESUME so we notice grants made via system
+    // Settings (which happen outside the Compose result-callback path).
+    // Important: observe the host Activity's lifecycle, not the Compose-default
+    // LocalLifecycleOwner. Inside a BottomSheetDialog the latter resolves to the
+    // dialog's own LifecycleRegistry (per ComponentDialog), which only dispatches
+    // ON_RESUME from `show()` and never refires when the user leaves to system
+    // Settings and returns. The Activity's lifecycle does refire ON_RESUME.
+    val activityLifecycle = (activity as? LifecycleOwner)?.lifecycle
+    DisposableEffect(activityLifecycle) {
+        if (activityLifecycle == null) return@DisposableEffect onDispose { }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) refreshAccessState()
+        }
+        activityLifecycle.addObserver(observer)
+        onDispose { activityLifecycle.removeObserver(observer) }
+    }
+    LaunchedEffect(granted, limit) {
+        uris = if (granted) {
+            withContext(Dispatchers.IO) { queryRecentImages(context, limit) }
+        } else {
+            emptyList()
+        }
+    }
+    if (granted) return PhotoAccess.Granted(uris)
+    val state = resolvePromptState(promptedBefore = promptedBefore, canReprompt = canReprompt)
+    return PhotoAccess.NeedsPermission(
+        state = state,
+        request = {
+            if (state == PromptState.PermanentlyDenied) openAppSettings(context)
+            else launcher.launch(photosPermission())
+        },
+    )
+}
+
+internal fun loadThumbnail(context: Context, uri: Uri, sizePx: Int): ImageBitmap? =
+    runCatching {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            context.contentResolver.loadThumbnail(uri, AndroidSize(sizePx, sizePx), null)
+                .asImageBitmap()
+        } else {
+            null
+        }
+    }.getOrNull()
+
+private fun photosPermission(): String =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+
+private fun hasPhotosPermission(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(context, photosPermission()) == PackageManager.PERMISSION_GRANTED
+
+private fun shouldShowRationale(activity: Activity): Boolean =
+    ActivityCompat.shouldShowRequestPermissionRationale(activity, photosPermission())
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
+
+private fun openAppSettings(context: Context) {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", context.packageName, null)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(intent)
+}
+
+private fun hasPromptedForPhotos(context: Context): Boolean =
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .getBoolean(KEY_PHOTOS_PROMPTED, false)
+
+private fun markPromptedForPhotos(context: Context) {
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .edit().putBoolean(KEY_PHOTOS_PROMPTED, true).apply()
+}
+
+internal fun hasRejectedRationale(context: Context): Boolean =
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .getBoolean(KEY_RATIONALE_REJECTED, false)
+
+internal fun markRationaleRejected(context: Context) {
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .edit().putBoolean(KEY_RATIONALE_REJECTED, true).apply()
+}
+
+/**
+ * Clears just the rationale-rejected flag (leaving the prompted-before flag
+ * alone). Called when we observe the photo permission becoming granted, so a
+ * subsequent revocation surfaces the rationale again instead of stranding the
+ * user in CompactTiles with no in-app affordance to re-engage.
+ */
+internal fun clearRejectedRationale(context: Context) {
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .edit().remove(KEY_RATIONALE_REJECTED).apply()
+}
+
+internal fun clearPhotoPreferences(context: Context) {
+    context.getSharedPreferences(PHOTO_PREFS, Context.MODE_PRIVATE)
+        .edit().clear().apply()
+}
+
+private fun queryRecentImages(context: Context, limit: Int): List<Uri> {
+    val collection = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL)
+    } else {
+        @Suppress("DEPRECATION")
+        MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+    }
+    val projection = arrayOf(MediaStore.Images.Media._ID)
+    val sortOrder = "${MediaStore.Images.Media.DATE_ADDED} DESC"
+    val result = mutableListOf<Uri>()
+    runCatching {
+        context.contentResolver.query(collection, projection, null, null, sortOrder)?.use { cursor ->
+            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
+            while (cursor.moveToNext() && result.size < limit) {
+                val id = cursor.getLong(idColumn)
+                result.add(ContentUris.withAppendedId(collection, id))
+            }
+        }
+    }
+    return result
+}

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
@@ -42,6 +42,13 @@ internal object MediaFileManager {
             .build()
             .toString()
 
+    /**
+     * Process-wide latch ensuring the TTL sweep runs at most once per process
+     * lifetime. The first `import` / `newCameraOutputFile` call flips it and
+     * scans for stale files; every subsequent call is a no-op. Cheaper than
+     * scanning the directory on every import, and the 2-day TTL is coarse
+     * enough that one sweep per process is enough.
+     */
     private val cleanupOnce = AtomicBoolean(false)
 
     fun uploadsDir(context: Context): File =

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
@@ -121,35 +121,64 @@ internal object MediaFileManager {
     }
 }
 
-@Suppress("ReturnCount", "MagicNumber")
+/** A byte sequence that must appear at a fixed offset in the header. */
+private class Anchor(val offset: Int, val bytes: ByteArray) {
+    fun matchesIn(header: ByteArray, read: Int): Boolean {
+        if (read < offset + bytes.size) return false
+        for (i in bytes.indices) if (header[offset + i] != bytes[i]) return false
+        return true
+    }
+}
+
+/** A MIME type identified by one or more byte anchors in the header. */
+private class MagicSignature(val mime: String, val anchors: List<Anchor>)
+
+private fun bytes(vararg values: Int): ByteArray =
+    ByteArray(values.size) { values[it].toByte() }
+
+private val PREFIX_SIGNATURES: List<MagicSignature> = listOf(
+    MagicSignature("image/jpeg", listOf(Anchor(0, bytes(0xFF, 0xD8, 0xFF)))),
+    MagicSignature("image/png", listOf(Anchor(0, bytes(0x89, 0x50, 0x4E, 0x47)))),
+    MagicSignature("image/gif", listOf(Anchor(0, bytes(0x47, 0x49, 0x46, 0x38)))),
+    MagicSignature(
+        "image/webp",
+        listOf(
+            Anchor(0, bytes(0x52, 0x49, 0x46, 0x46)), // 'RIFF'
+            Anchor(8, bytes(0x57, 0x45, 0x42, 0x50)), // 'WEBP'
+        ),
+    ),
+)
+
+/**
+ * ISO BMFF ftyp brands → MIME. The container has 'ftyp' at bytes 4-7 and the
+ * major brand at bytes 8-11. HEIC has several conformant brands; AVIF has two.
+ * Add brands here rather than touching `mimeFromMagicBytes`.
+ */
+private val FTYP_BRANDS: Map<String, String> = mapOf(
+    "heic" to "image/heic",
+    "heix" to "image/heic",
+    "heim" to "image/heic",
+    "heis" to "image/heic",
+    "mif1" to "image/heic",
+    "msf1" to "image/heic",
+    "avif" to "image/avif",
+    "avis" to "image/avif",
+)
+
+private const val ISO_BMFF_HEADER_BYTES = 12
+
 private fun mimeFromMagicBytes(input: InputStream): String? {
-    val header = ByteArray(12)
+    val header = ByteArray(ISO_BMFF_HEADER_BYTES)
     val read = input.read(header)
     if (read < 4) return null
-    if (matchesAt(header, 0, 0xFF, 0xD8, 0xFF)) return "image/jpeg"
-    if (matchesAt(header, 0, 0x89, 0x50, 0x4E, 0x47)) return "image/png"
-    if (matchesAt(header, 0, 0x47, 0x49, 0x46, 0x38)) return "image/gif"
-    if (read >= 12 &&
-        matchesAt(header, 0, 0x52, 0x49, 0x46, 0x46) &&
-        matchesAt(header, 8, 0x57, 0x45, 0x42, 0x50)
-    ) {
-        return "image/webp"
-    }
-    // ISO BMFF: bytes 4-7 spell 'ftyp', brand at bytes 8-11.
-    if (read >= 12 && asciiAt(header, 4, 4) == "ftyp") {
-        return when (asciiAt(header, 8, 4)) {
-            "heic", "heix", "heim", "heis", "mif1", "msf1" -> "image/heic"
-            "avif", "avis" -> "image/avif"
-            else -> null
-        }
+    PREFIX_SIGNATURES.firstOrNull { sig ->
+        sig.anchors.all { it.matchesIn(header, read) }
+    }?.let { return it.mime }
+    if (read >= ISO_BMFF_HEADER_BYTES && asciiAt(header, 4, 4) == "ftyp") {
+        return FTYP_BRANDS[asciiAt(header, 8, 4)]
     }
     return null
 }
 
 private fun asciiAt(buf: ByteArray, offset: Int, length: Int): String =
     if (buf.size >= offset + length) String(buf, offset, length) else ""
-
-private fun matchesAt(buf: ByteArray, offset: Int, vararg expected: Int): Boolean {
-    if (buf.size < offset + expected.size) return false
-    return expected.indices.all { buf[offset + it] == expected[it].toByte() }
-}

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
@@ -174,7 +174,7 @@ private val FTYP_BRANDS: Map<String, String> = mapOf(
 
 private const val ISO_BMFF_HEADER_BYTES = 12
 
-private fun mimeFromMagicBytes(input: InputStream): String? {
+internal fun mimeFromMagicBytes(input: InputStream): String? {
     val header = ByteArray(ISO_BMFF_HEADER_BYTES)
     val read = input.read(header)
     if (read < 4) return null

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
@@ -42,10 +42,10 @@ internal object MediaFileManager {
 
     /**
      * Process-wide latch ensuring the TTL sweep runs at most once per process
-     * lifetime. The first `import` / `newCameraOutputFile` call flips it and
-     * scans for stale files; every subsequent call is a no-op. Cheaper than
-     * scanning the directory on every import, and the 2-day TTL is coarse
-     * enough that one sweep per process is enough.
+     * lifetime. `GutenbergView` flips it on construction via `primeCleanup`,
+     * dispatched off the UI thread. Cheaper than scanning the directory on
+     * every import, and the 2-day TTL is coarse enough that one sweep per
+     * process is enough.
      */
     private val cleanupOnce = AtomicBoolean(false)
 
@@ -57,7 +57,6 @@ internal object MediaFileManager {
      * the caller can stamp with the editor's asset origin via `MediaPathHandler`.
      */
     suspend fun import(context: Context, uri: Uri): StoredMedia = withContext(Dispatchers.IO) {
-        ensureCleanup(context)
         val mime = resolveMime(context, uri)
         val ext = preferredExtension(mime, uri)
         val fileName = "${UUID.randomUUID()}.$ext"
@@ -75,15 +74,21 @@ internal object MediaFileManager {
      * camera writes directly into uploads, so a successful capture is
      * already-imported — no copy step.
      */
-    fun newCameraOutputFile(context: Context): File {
-        ensureCleanup(context)
-        return File(uploadsDir(context), "${UUID.randomUUID()}.jpg")
-    }
+    fun newCameraOutputFile(context: Context): File =
+        File(uploadsDir(context), "${UUID.randomUUID()}.jpg")
 
     fun storedMediaForFile(file: File, mime: String = "image/jpeg"): StoredMedia =
         StoredMedia(fileName = file.name, type = mime)
 
-    private fun ensureCleanup(context: Context) {
+    /**
+     * Runs the TTL sweep synchronously. Idempotent — subsequent calls are
+     * no-ops once the process-wide latch flips. Expected to be dispatched on
+     * `Dispatchers.IO` (or equivalent worker thread) by the caller; doing
+     * `listFiles()` + per-file `delete()` on the UI thread is a StrictMode
+     * violation and would jank the first user-tap that triggered it.
+     */
+    @androidx.annotation.WorkerThread
+    fun primeCleanup(context: Context) {
         if (!cleanupOnce.compareAndSet(false, true)) return
         try {
             sweepStaleFiles(uploadsDir(context))

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import android.webkit.MimeTypeMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.wordpress.gutenberg.DEFAULT_ASSET_DOMAIN
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -15,12 +14,20 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Imports user-picked / captured media into an app-private uploads directory
- * and produces an editor-loadable URL. Pairs with `MediaPathHandler`, which
- * serves files back to the WebView under the same origin as the editor bundle.
+ * On-disk handle to a file inside `MediaFileManager`'s uploads directory.
+ * URL stamping is intentionally not done here — `GutenbergView` builds the
+ * editor-facing URL with the live `assetDomain` / `assetScheme` so the media
+ * is same-origin against the loaded editor bundle, whatever the host app
+ * configures.
+ */
+internal data class StoredMedia(val fileName: String, val type: String)
+
+/**
+ * Imports user-picked / captured media into an app-private uploads directory.
+ * Pairs with `MediaPathHandler`, which serves files back to the WebView under
+ * the asset-loader origin via `/media/<fileName>`.
  *
- * Mirrors iOS's `MediaFileManager` actor — same 2-day TTL, same on-disk layout,
- * same MediaInfo shape on the wire.
+ * Mirrors iOS's `MediaFileManager` actor — same 2-day TTL, same on-disk layout.
  */
 internal object MediaFileManager {
     private const val ROOT_DIR = "GutenbergKit"
@@ -32,15 +39,6 @@ internal object MediaFileManager {
 
     /** WebViewAssetLoader prefix — leading and trailing slash are required by the API. */
     const val MEDIA_PATH_PREFIX = "/$MEDIA_PATH_SEGMENT/"
-
-    private fun mediaUrlFor(fileName: String): String =
-        Uri.Builder()
-            .scheme("https")
-            .authority(DEFAULT_ASSET_DOMAIN)
-            .appendPath(MEDIA_PATH_SEGMENT)
-            .appendPath(fileName)
-            .build()
-            .toString()
 
     /**
      * Process-wide latch ensuring the TTL sweep runs at most once per process
@@ -55,10 +53,10 @@ internal object MediaFileManager {
         File(File(context.filesDir, ROOT_DIR), UPLOADS_DIR).apply { mkdirs() }
 
     /**
-     * Copies the source URI into uploads and returns a MediaInfo whose `url`
-     * resolves against the editor's asset origin via `MediaPathHandler`.
+     * Copies the source URI into uploads and returns a `StoredMedia` handle
+     * the caller can stamp with the editor's asset origin via `MediaPathHandler`.
      */
-    suspend fun import(context: Context, uri: Uri): MediaInfo = withContext(Dispatchers.IO) {
+    suspend fun import(context: Context, uri: Uri): StoredMedia = withContext(Dispatchers.IO) {
         ensureCleanup(context)
         val mime = resolveMime(context, uri)
         val ext = preferredExtension(mime, uri)
@@ -69,7 +67,7 @@ internal object MediaFileManager {
         input.use { source ->
             dest.outputStream().use { sink -> source.copyTo(sink) }
         }
-        MediaInfo(url = mediaUrlFor(fileName), type = mime)
+        StoredMedia(fileName = fileName, type = mime)
     }
 
     /**
@@ -82,8 +80,8 @@ internal object MediaFileManager {
         return File(uploadsDir(context), "${UUID.randomUUID()}.jpg")
     }
 
-    fun mediaInfoForFile(file: File, mime: String = "image/jpeg"): MediaInfo =
-        MediaInfo(url = mediaUrlFor(file.name), type = mime)
+    fun storedMediaForFile(file: File, mime: String = "image/jpeg"): StoredMedia =
+        StoredMedia(fileName = file.name, type = mime)
 
     private fun ensureCleanup(context: Context) {
         if (!cleanupOnce.compareAndSet(false, true)) return

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
@@ -25,12 +25,22 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal object MediaFileManager {
     private const val ROOT_DIR = "GutenbergKit"
     private const val UPLOADS_DIR = "Uploads"
+    private const val MEDIA_PATH_SEGMENT = "media"
     private const val FILE_TTL_DAYS = 2L
     private const val FALLBACK_EXT = "bin"
     private const val FALLBACK_MIME = "application/octet-stream"
 
-    const val MEDIA_PATH_PREFIX = "/media/"
-    val mediaUrlPrefix: String = "https://$DEFAULT_ASSET_DOMAIN$MEDIA_PATH_PREFIX"
+    /** WebViewAssetLoader prefix — leading and trailing slash are required by the API. */
+    const val MEDIA_PATH_PREFIX = "/$MEDIA_PATH_SEGMENT/"
+
+    private fun mediaUrlFor(fileName: String): String =
+        Uri.Builder()
+            .scheme("https")
+            .authority(DEFAULT_ASSET_DOMAIN)
+            .appendPath(MEDIA_PATH_SEGMENT)
+            .appendPath(fileName)
+            .build()
+            .toString()
 
     private val cleanupOnce = AtomicBoolean(false)
 
@@ -52,7 +62,7 @@ internal object MediaFileManager {
         input.use { source ->
             dest.outputStream().use { sink -> source.copyTo(sink) }
         }
-        MediaInfo(url = mediaUrlPrefix + fileName, type = mime)
+        MediaInfo(url = mediaUrlFor(fileName), type = mime)
     }
 
     /**
@@ -66,7 +76,7 @@ internal object MediaFileManager {
     }
 
     fun mediaInfoForFile(file: File, mime: String = "image/jpeg"): MediaInfo =
-        MediaInfo(url = mediaUrlPrefix + file.name, type = mime)
+        MediaInfo(url = mediaUrlFor(file.name), type = mime)
 
     private fun ensureCleanup(context: Context) {
         if (!cleanupOnce.compareAndSet(false, true)) return

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaFileManager.kt
@@ -1,0 +1,145 @@
+package org.wordpress.gutenberg.media
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import android.webkit.MimeTypeMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.wordpress.gutenberg.DEFAULT_ASSET_DOMAIN
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Imports user-picked / captured media into an app-private uploads directory
+ * and produces an editor-loadable URL. Pairs with `MediaPathHandler`, which
+ * serves files back to the WebView under the same origin as the editor bundle.
+ *
+ * Mirrors iOS's `MediaFileManager` actor — same 2-day TTL, same on-disk layout,
+ * same MediaInfo shape on the wire.
+ */
+internal object MediaFileManager {
+    private const val ROOT_DIR = "GutenbergKit"
+    private const val UPLOADS_DIR = "Uploads"
+    private const val FILE_TTL_DAYS = 2L
+    private const val FALLBACK_EXT = "bin"
+    private const val FALLBACK_MIME = "application/octet-stream"
+
+    const val MEDIA_PATH_PREFIX = "/media/"
+    val mediaUrlPrefix: String = "https://$DEFAULT_ASSET_DOMAIN$MEDIA_PATH_PREFIX"
+
+    private val cleanupOnce = AtomicBoolean(false)
+
+    fun uploadsDir(context: Context): File =
+        File(File(context.filesDir, ROOT_DIR), UPLOADS_DIR).apply { mkdirs() }
+
+    /**
+     * Copies the source URI into uploads and returns a MediaInfo whose `url`
+     * resolves against the editor's asset origin via `MediaPathHandler`.
+     */
+    suspend fun import(context: Context, uri: Uri): MediaInfo = withContext(Dispatchers.IO) {
+        ensureCleanup(context)
+        val mime = resolveMime(context, uri)
+        val ext = preferredExtension(mime, uri)
+        val fileName = "${UUID.randomUUID()}.$ext"
+        val dest = File(uploadsDir(context), fileName)
+        val input = context.contentResolver.openInputStream(uri)
+            ?: throw IOException("Could not open URI for read: $uri")
+        input.use { source ->
+            dest.outputStream().use { sink -> source.copyTo(sink) }
+        }
+        MediaInfo(url = mediaUrlPrefix + fileName, type = mime)
+    }
+
+    /**
+     * Provisions a destination file for the camera capture launcher. The
+     * camera writes directly into uploads, so a successful capture is
+     * already-imported — no copy step.
+     */
+    fun newCameraOutputFile(context: Context): File {
+        ensureCleanup(context)
+        return File(uploadsDir(context), "${UUID.randomUUID()}.jpg")
+    }
+
+    fun mediaInfoForFile(file: File, mime: String = "image/jpeg"): MediaInfo =
+        MediaInfo(url = mediaUrlPrefix + file.name, type = mime)
+
+    private fun ensureCleanup(context: Context) {
+        if (!cleanupOnce.compareAndSet(false, true)) return
+        try {
+            sweepStaleFiles(uploadsDir(context))
+        } catch (e: SecurityException) {
+            Log.w("MediaFileManager", "Cleanup skipped", e)
+        }
+    }
+
+    private fun sweepStaleFiles(dir: File) {
+        val cutoff = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(FILE_TTL_DAYS)
+        dir.listFiles()?.forEach { file ->
+            if (file.lastModified() < cutoff) file.delete()
+        }
+    }
+
+    private fun resolveMime(context: Context, uri: Uri): String {
+        // ContentResolver knows the MIME for content:// URIs (MediaStore, SAF,
+        // photo picker) and for FileProvider-backed file:// URIs from our own
+        // camera launcher — that's every source we produce today.
+        context.contentResolver.getType(uri)?.let { return it }
+        val pathExt = MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+        if (!pathExt.isNullOrEmpty()) {
+            MimeTypeMap.getSingleton()
+                .getMimeTypeFromExtension(pathExt.lowercase())
+                ?.let { return it }
+        }
+        // Last-ditch sniff for SAF providers that hand back octet-streams.
+        // Magic-byte coverage focuses on the formats `getType` and the system
+        // tables miss most often: HEIC and AVIF.
+        return runCatching {
+            context.contentResolver.openInputStream(uri)?.use { mimeFromMagicBytes(it) }
+        }.getOrNull() ?: FALLBACK_MIME
+    }
+
+    private fun preferredExtension(mime: String, uri: Uri): String {
+        MimeTypeMap.getSingleton().getExtensionFromMimeType(mime)?.let { return it }
+        val pathExt = MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+        if (!pathExt.isNullOrEmpty()) return pathExt.lowercase()
+        return FALLBACK_EXT
+    }
+}
+
+@Suppress("ReturnCount", "MagicNumber")
+private fun mimeFromMagicBytes(input: InputStream): String? {
+    val header = ByteArray(12)
+    val read = input.read(header)
+    if (read < 4) return null
+    if (matchesAt(header, 0, 0xFF, 0xD8, 0xFF)) return "image/jpeg"
+    if (matchesAt(header, 0, 0x89, 0x50, 0x4E, 0x47)) return "image/png"
+    if (matchesAt(header, 0, 0x47, 0x49, 0x46, 0x38)) return "image/gif"
+    if (read >= 12 &&
+        matchesAt(header, 0, 0x52, 0x49, 0x46, 0x46) &&
+        matchesAt(header, 8, 0x57, 0x45, 0x42, 0x50)
+    ) {
+        return "image/webp"
+    }
+    // ISO BMFF: bytes 4-7 spell 'ftyp', brand at bytes 8-11.
+    if (read >= 12 && asciiAt(header, 4, 4) == "ftyp") {
+        return when (asciiAt(header, 8, 4)) {
+            "heic", "heix", "heim", "heis", "mif1", "msf1" -> "image/heic"
+            "avif", "avis" -> "image/avif"
+            else -> null
+        }
+    }
+    return null
+}
+
+private fun asciiAt(buf: ByteArray, offset: Int, length: Int): String =
+    if (buf.size >= offset + length) String(buf, offset, length) else ""
+
+private fun matchesAt(buf: ByteArray, offset: Int, vararg expected: Int): Boolean {
+    if (buf.size < offset + expected.size) return false
+    return expected.indices.all { buf[offset + it] == expected[it].toByte() }
+}

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaInfo.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaInfo.kt
@@ -1,7 +1,7 @@
 package org.wordpress.gutenberg.media
 
-import org.json.JSONArray
-import org.json.JSONObject
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 /**
  * Mirrors `MediaInfo` on iOS — the shape the JS editor's
@@ -11,25 +11,23 @@ import org.json.JSONObject
  * attachment; native-inserter handoffs leave it null and the JS side
  * falls back to URL-fetch-and-transform.
  */
+@Serializable
 internal data class MediaInfo(
     val id: Int? = null,
     val url: String,
-    val type: String?,
+    val type: String? = null,
     val title: String? = null,
     val caption: String? = null,
     val alt: String? = null,
     val metadata: Map<String, String> = emptyMap(),
-) {
-    fun toJson(): JSONObject = JSONObject().apply {
-        if (id != null) put("id", id)
-        put("url", url)
-        if (type != null) put("type", type)
-        if (title != null) put("title", title)
-        if (caption != null) put("caption", caption)
-        if (alt != null) put("alt", alt)
-        put("metadata", JSONObject(metadata as Map<*, *>))
-    }
-}
+)
 
-internal fun List<MediaInfo>.toJsonArray(): JSONArray =
-    JSONArray().also { array -> forEach { array.put(it.toJson()) } }
+/**
+ * - `explicitNulls = false`: a null `id` / `type` / etc. encodes as a missing key, matching iOS Codable.
+ * - `encodeDefaults = true`: keep `metadata` in the output even when it's `emptyMap()`, matching iOS
+ *   (where non-optional `metadata: [String: String]` always encodes) and the JS receiver's expectation.
+ */
+internal val MediaInfoJson: Json = Json {
+    explicitNulls = false
+    encodeDefaults = true
+}

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaInfo.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaInfo.kt
@@ -1,0 +1,35 @@
+package org.wordpress.gutenberg.media
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Mirrors `MediaInfo` on iOS — the shape the JS editor's
+ * `window.blockInserter.insertMedia(...)` receiver expects per item.
+ *
+ * `id` is reserved for media-library round-trips that resolve a known
+ * attachment; native-inserter handoffs leave it null and the JS side
+ * falls back to URL-fetch-and-transform.
+ */
+internal data class MediaInfo(
+    val id: Int? = null,
+    val url: String,
+    val type: String?,
+    val title: String? = null,
+    val caption: String? = null,
+    val alt: String? = null,
+    val metadata: Map<String, String> = emptyMap(),
+) {
+    fun toJson(): JSONObject = JSONObject().apply {
+        if (id != null) put("id", id)
+        put("url", url)
+        if (type != null) put("type", type)
+        if (title != null) put("title", title)
+        if (caption != null) put("caption", caption)
+        if (alt != null) put("alt", alt)
+        put("metadata", JSONObject(metadata as Map<*, *>))
+    }
+}
+
+internal fun List<MediaInfo>.toJsonArray(): JSONArray =
+    JSONArray().also { array -> forEach { array.put(it.toJson()) } }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaPathHandler.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaPathHandler.kt
@@ -7,6 +7,7 @@ import androidx.webkit.WebViewAssetLoader
 import java.io.File
 import java.io.FileInputStream
 import java.io.IOException
+import java.nio.file.Path
 
 /**
  * Serves files from `MediaFileManager`'s uploads directory under the editor's
@@ -16,24 +17,25 @@ import java.io.IOException
  * Path traversal is rejected outright — only flat `<name>` filenames inside
  * the uploads dir are servable.
  */
-internal class MediaPathHandler(uploadsDir: File) : WebViewAssetLoader.PathHandler {
+internal class MediaPathHandler(private val uploadsDir: File) : WebViewAssetLoader.PathHandler {
 
-    private val uploadsCanonicalPath: String = uploadsDir.canonicalPath
-    private val uploadsRoot: File = uploadsDir
+    private val uploadsRoot: Path = uploadsDir.canonicalFile.toPath()
 
     override fun handle(path: String): WebResourceResponse {
         val name = path.trimStart('/')
         if (name.isEmpty() || name.contains('/') || name.contains("..")) {
             return notFound()
         }
-        val file = File(uploadsRoot, name)
-        val canonical = try {
-            file.canonicalPath
+        val file = File(uploadsDir, name)
+        val resolved = try {
+            file.canonicalFile.toPath()
         } catch (e: IOException) {
             Log.w("MediaPathHandler", "Refusing /media/$name — canonical path resolution failed", e)
             return notFound()
         }
-        if (!canonical.startsWith(uploadsCanonicalPath + File.separator) || !file.isFile) {
+        // Segment-aware containment check via Path.startsWith — refuses
+        // `/foo-evil` matching `/foo` the way naive string-prefix would.
+        if (!resolved.startsWith(uploadsRoot) || !file.isFile) {
             return notFound()
         }
         val mime = MimeTypeMap.getSingleton()

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaPathHandler.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaPathHandler.kt
@@ -1,0 +1,47 @@
+package org.wordpress.gutenberg.media
+
+import android.util.Log
+import android.webkit.MimeTypeMap
+import android.webkit.WebResourceResponse
+import androidx.webkit.WebViewAssetLoader
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
+
+/**
+ * Serves files from `MediaFileManager`'s uploads directory under the editor's
+ * asset origin. Registered at `/media/` so JS `fetch()` can read picked /
+ * captured media same-origin against `appassets.androidplatform.net`.
+ *
+ * Path traversal is rejected outright — only flat `<name>` filenames inside
+ * the uploads dir are servable.
+ */
+internal class MediaPathHandler(uploadsDir: File) : WebViewAssetLoader.PathHandler {
+
+    private val uploadsCanonicalPath: String = uploadsDir.canonicalPath
+    private val uploadsRoot: File = uploadsDir
+
+    override fun handle(path: String): WebResourceResponse {
+        val name = path.trimStart('/')
+        if (name.isEmpty() || name.contains('/') || name.contains("..")) {
+            return notFound()
+        }
+        val file = File(uploadsRoot, name)
+        val canonical = try {
+            file.canonicalPath
+        } catch (e: IOException) {
+            Log.w("MediaPathHandler", "Refusing /media/$name — canonical path resolution failed", e)
+            return notFound()
+        }
+        if (!canonical.startsWith(uploadsCanonicalPath + File.separator) || !file.isFile) {
+            return notFound()
+        }
+        val mime = MimeTypeMap.getSingleton()
+            .getMimeTypeFromExtension(file.extension.lowercase())
+            ?: "application/octet-stream"
+        return WebResourceResponse(mime, null, FileInputStream(file))
+    }
+
+    private fun notFound(): WebResourceResponse =
+        WebResourceResponse("text/plain", "utf-8", 404, "Not Found", emptyMap(), null)
+}

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaPathHandler.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/media/MediaPathHandler.kt
@@ -7,41 +7,55 @@ import androidx.webkit.WebViewAssetLoader
 import java.io.File
 import java.io.FileInputStream
 import java.io.IOException
-import java.nio.file.Path
 
 /**
  * Serves files from `MediaFileManager`'s uploads directory under the editor's
  * asset origin. Registered at `/media/` so JS `fetch()` can read picked /
- * captured media same-origin against `appassets.androidplatform.net`.
+ * captured media same-origin against the asset loader's host.
  *
  * Path traversal is rejected outright — only flat `<name>` filenames inside
  * the uploads dir are servable.
  */
-internal class MediaPathHandler(private val uploadsDir: File) : WebViewAssetLoader.PathHandler {
+internal class MediaPathHandler(uploadsDir: File) : WebViewAssetLoader.PathHandler {
 
-    private val uploadsRoot: Path = uploadsDir.canonicalFile.toPath()
+    private val uploadsRoot: File = uploadsDir.canonicalFile
 
     override fun handle(path: String): WebResourceResponse {
         val name = path.trimStart('/')
         if (name.isEmpty() || name.contains('/') || name.contains("..")) {
             return notFound()
         }
-        val file = File(uploadsDir, name)
+        val file = File(uploadsRoot, name)
         val resolved = try {
-            file.canonicalFile.toPath()
+            file.canonicalFile
         } catch (e: IOException) {
-            Log.w("MediaPathHandler", "Refusing /media/$name — canonical path resolution failed", e)
+            Log.w("MediaPathHandler", "Refusing /media/$name — canonical resolution failed", e)
+            return notFound()
+        } catch (e: SecurityException) {
+            Log.w("MediaPathHandler", "Refusing /media/$name — canonical resolution denied", e)
             return notFound()
         }
-        // Segment-aware containment check via Path.startsWith — refuses
-        // `/foo-evil` matching `/foo` the way naive string-prefix would.
-        if (!resolved.startsWith(uploadsRoot) || !file.isFile) {
+        // Segment-aware containment check: walk `parentFile` from the resolved
+        // candidate up to the filesystem root, accepting only if we pass
+        // through `uploadsRoot`. This refuses `/foo-evil` matching `/foo` the
+        // way a naive string-prefix would, without depending on
+        // `java.nio.file.Path` (API 26+, `minSdk = 24` here).
+        if (!resolved.isWithin(uploadsRoot) || !resolved.isFile) {
             return notFound()
         }
         val mime = MimeTypeMap.getSingleton()
-            .getMimeTypeFromExtension(file.extension.lowercase())
+            .getMimeTypeFromExtension(resolved.extension.lowercase())
             ?: "application/octet-stream"
-        return WebResourceResponse(mime, null, FileInputStream(file))
+        return WebResourceResponse(mime, null, FileInputStream(resolved))
+    }
+
+    private fun File.isWithin(root: File): Boolean {
+        var current: File? = this
+        while (current != null) {
+            if (current == root) return true
+            current = current.parentFile
+        }
+        return false
     }
 
     private fun notFound(): WebResourceResponse =

--- a/android/Gutenberg/src/main/res/values/strings.xml
+++ b/android/Gutenberg/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="gbk_block_inserter_photos">Photos</string>
     <string name="gbk_block_inserter_camera">Camera</string>
     <string name="gbk_block_inserter_camera_unavailable">Camera not available on this device</string>
+    <string name="gbk_block_inserter_media_import_failed">Couldn\'t add that photo. Try another.</string>
     <string name="gbk_block_inserter_photos_rationale">Show your photo library here to quickly insert an image</string>
     <string name="gbk_block_inserter_photos_rationale_denied">Allow access to show your photo library here</string>
     <string name="gbk_block_inserter_photos_rationale_permanent">Enable photo access in Settings to show your library here</string>

--- a/android/Gutenberg/src/main/res/values/strings.xml
+++ b/android/Gutenberg/src/main/res/values/strings.xml
@@ -19,4 +19,11 @@
     <string name="gbk_block_inserter_photos">Photos</string>
     <string name="gbk_block_inserter_camera">Camera</string>
     <string name="gbk_block_inserter_camera_unavailable">Camera not available on this device</string>
+    <string name="gbk_block_inserter_photos_rationale">Show your photo library here to quickly insert an image</string>
+    <string name="gbk_block_inserter_photos_rationale_denied">Allow access to show your photo library here</string>
+    <string name="gbk_block_inserter_photos_rationale_permanent">Enable photo access in Settings to show your library here</string>
+    <string name="gbk_block_inserter_photos_allow">Allow</string>
+    <string name="gbk_block_inserter_photos_try_again">Try Again</string>
+    <string name="gbk_block_inserter_photos_reject">Reject</string>
+    <string name="gbk_block_inserter_photos_open_settings">Open Settings</string>
 </resources>

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/PhotoAccessStateTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/PhotoAccessStateTest.kt
@@ -1,0 +1,72 @@
+package org.wordpress.gutenberg.inserter
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PhotoAccessStateTest {
+
+    // resolvePromptState
+
+    @Test
+    fun `unasked when never prompted, regardless of canReprompt`() {
+        assertEquals(
+            PromptState.Unasked,
+            resolvePromptState(promptedBefore = false, canReprompt = true),
+        )
+        assertEquals(
+            PromptState.Unasked,
+            resolvePromptState(promptedBefore = false, canReprompt = false),
+        )
+    }
+
+    @Test
+    fun `denied when prompted before and system can re-prompt`() {
+        assertEquals(
+            PromptState.Denied,
+            resolvePromptState(promptedBefore = true, canReprompt = true),
+        )
+    }
+
+    @Test
+    fun `permanently denied when prompted before and system cannot re-prompt`() {
+        assertEquals(
+            PromptState.PermanentlyDenied,
+            resolvePromptState(promptedBefore = true, canReprompt = false),
+        )
+    }
+
+    // resolveMediaStripView
+
+    @Test
+    fun `granted access always shows full strip even after rejection`() {
+        val granted = PhotoAccess.Granted(uris = emptyList())
+        assertEquals(MediaStripView.FullStrip, resolveMediaStripView(granted, rejected = false))
+        assertEquals(MediaStripView.FullStrip, resolveMediaStripView(granted, rejected = true))
+    }
+
+    @Test
+    fun `needs-permission shows rationale when not rejected`() {
+        val needs = needsPermission(PromptState.Denied)
+        assertEquals(MediaStripView.Rationale, resolveMediaStripView(needs, rejected = false))
+    }
+
+    @Test
+    fun `needs-permission shows compact tiles when rejected`() {
+        val needs = needsPermission(PromptState.PermanentlyDenied)
+        assertEquals(MediaStripView.CompactTiles, resolveMediaStripView(needs, rejected = true))
+    }
+
+    @Test
+    fun `rationale shows for every prompt state when not rejected`() {
+        for (state in PromptState.entries) {
+            assertEquals(
+                "state=$state",
+                MediaStripView.Rationale,
+                resolveMediaStripView(needsPermission(state), rejected = false),
+            )
+        }
+    }
+
+    private fun needsPermission(state: PromptState) =
+        PhotoAccess.NeedsPermission(state = state, request = {})
+}

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/media/MagicByteSniffingTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/media/MagicByteSniffingTest.kt
@@ -1,0 +1,90 @@
+package org.wordpress.gutenberg.media
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.io.ByteArrayInputStream
+
+class MagicByteSniffingTest {
+
+    @Test
+    fun `sniffs JPEG`() {
+        assertEquals("image/jpeg", mime(0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10))
+    }
+
+    @Test
+    fun `sniffs PNG`() {
+        assertEquals("image/png", mime(0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A))
+    }
+
+    @Test
+    fun `sniffs GIF87a and GIF89a`() {
+        assertEquals("image/gif", mime(0x47, 0x49, 0x46, 0x38, 0x37, 0x61))
+        assertEquals("image/gif", mime(0x47, 0x49, 0x46, 0x38, 0x39, 0x61))
+    }
+
+    @Test
+    fun `sniffs WebP`() {
+        // RIFF....WEBP — size bytes between RIFF and WEBP can be anything.
+        assertEquals(
+            "image/webp",
+            mime(0x52, 0x49, 0x46, 0x46, 0xAA, 0xBB, 0xCC, 0xDD, 0x57, 0x45, 0x42, 0x50),
+        )
+    }
+
+    @Test
+    fun `sniffs HEIC across conformant brands`() {
+        listOf("heic", "heix", "heim", "heis", "mif1", "msf1").forEach { brand ->
+            assertEquals(
+                "expected HEIC for brand $brand",
+                "image/heic",
+                mimeWithFtypBrand(brand),
+            )
+        }
+    }
+
+    @Test
+    fun `sniffs AVIF still and sequence brands`() {
+        assertEquals("image/avif", mimeWithFtypBrand("avif"))
+        assertEquals("image/avif", mimeWithFtypBrand("avis"))
+    }
+
+    @Test
+    fun `returns null for unknown ftyp brand`() {
+        assertNull(mimeWithFtypBrand("mp42"))
+    }
+
+    @Test
+    fun `returns null for too-short input`() {
+        assertNull(mime(0xFF, 0xD8))
+    }
+
+    @Test
+    fun `returns null for empty input`() {
+        assertNull(mimeFromMagicBytes(ByteArrayInputStream(ByteArray(0))))
+    }
+
+    @Test
+    fun `returns null for unrecognised header`() {
+        assertNull(mime(0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07))
+    }
+
+    @Test
+    fun `WebP needs both RIFF and WEBP anchors`() {
+        // RIFF without WEBP brand → not WebP
+        assertNull(
+            mime(0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45),
+        )
+    }
+
+    private fun mime(vararg bytes: Int): String? =
+        mimeFromMagicBytes(ByteArrayInputStream(ByteArray(bytes.size) { bytes[it].toByte() }))
+
+    private fun mimeWithFtypBrand(brand: String): String? {
+        val header = ByteArray(12)
+        // Bytes 0-3: box size (any 4 bytes). Bytes 4-7: 'ftyp'. Bytes 8-11: brand.
+        "ftyp".toByteArray(Charsets.US_ASCII).copyInto(header, destinationOffset = 4)
+        brand.toByteArray(Charsets.US_ASCII).copyInto(header, destinationOffset = 8)
+        return mimeFromMagicBytes(ByteArrayInputStream(header))
+    }
+}

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/media/MediaInfoTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/media/MediaInfoTest.kt
@@ -1,0 +1,54 @@
+package org.wordpress.gutenberg.media
+
+import kotlinx.serialization.encodeToString
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the JSON shape passed to `window.blockInserter.insertMedia(...)`.
+ * If a field is renamed or its null-handling changes, the JS side will
+ * silently receive `undefined`; these tests catch that at build time.
+ */
+class MediaInfoTest {
+
+    @Test
+    fun `omits null optional fields`() {
+        val info = MediaInfo(url = "https://example/img.jpg", type = "image/jpeg")
+        assertEquals(
+            """{"url":"https://example/img.jpg","type":"image/jpeg","metadata":{}}""",
+            MediaInfoJson.encodeToString(info),
+        )
+    }
+
+    @Test
+    fun `includes all fields when populated`() {
+        val info = MediaInfo(
+            id = 42,
+            url = "https://example/img.jpg",
+            type = "image/jpeg",
+            title = "title",
+            caption = "caption",
+            alt = "alt",
+            metadata = mapOf("source" to "inserter"),
+        )
+        assertEquals(
+            """{"id":42,"url":"https://example/img.jpg","type":"image/jpeg",""" +
+                """"title":"title","caption":"caption","alt":"alt",""" +
+                """"metadata":{"source":"inserter"}}""",
+            MediaInfoJson.encodeToString(info),
+        )
+    }
+
+    @Test
+    fun `serialises a list as a JSON array`() {
+        val media = listOf(
+            MediaInfo(url = "https://example/a.jpg", type = "image/jpeg"),
+            MediaInfo(url = "https://example/b.png", type = "image/png"),
+        )
+        assertEquals(
+            """[{"url":"https://example/a.jpg","type":"image/jpeg","metadata":{}},""" +
+                """{"url":"https://example/b.png","type":"image/png","metadata":{}}]""",
+            MediaInfoJson.encodeToString(media),
+        )
+    }
+}

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/media/MediaPathHandlerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/media/MediaPathHandlerTest.kt
@@ -1,0 +1,141 @@
+package org.wordpress.gutenberg.media
+
+import android.webkit.MimeTypeMap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Pins the path-traversal-rejection contract on `MediaPathHandler`. The
+ * handler is the security boundary for everything under `/media/`; if a
+ * future refactor regresses any of these cases, a request could be served
+ * from outside the uploads dir.
+ *
+ * Robolectric provides `WebResourceResponse` and `MimeTypeMap`; symlink cases
+ * use `java.nio.file.Files` from the host JVM, which has no API-level gate
+ * under unit tests.
+ */
+@RunWith(RobolectricTestRunner::class)
+class MediaPathHandlerTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private lateinit var uploadsDir: File
+    private lateinit var handler: MediaPathHandler
+
+    @Before
+    fun setUp() {
+        uploadsDir = tempFolder.newFolder("Uploads")
+        handler = MediaPathHandler(uploadsDir)
+        // Robolectric's shadow MimeTypeMap is empty by default — register the
+        // extensions the served-file test exercises so `getMimeTypeFromExtension`
+        // returns the same value the production singleton would.
+        shadowOf(MimeTypeMap.getSingleton())
+            .addExtensionMimeTypeMapping("jpg", "image/jpeg")
+    }
+
+    // `WebResourceResponse`'s 3-arg success constructor doesn't set a status
+    // code (the framework defaults it), so the test contract is "data is
+    // non-null on success, null on a 404 from `notFound()`."
+
+    @Test
+    fun `serves an existing file inside uploads with resolved MIME`() {
+        val payload = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())
+        File(uploadsDir, "abc.jpg").writeBytes(payload)
+
+        val response = handler.handle("/abc.jpg")
+
+        assertNotNull(response.data)
+        assertEquals("image/jpeg", response.mimeType)
+    }
+
+    @Test
+    fun `falls back to octet-stream when extension is unknown`() {
+        File(uploadsDir, "abc.weirdext").writeBytes(byteArrayOf(0x00))
+
+        val response = handler.handle("/abc.weirdext")
+
+        assertNotNull(response.data)
+        assertEquals("application/octet-stream", response.mimeType)
+    }
+
+    @Test
+    fun `rejects empty path`() {
+        assertEquals(404, handler.handle("").statusCode)
+    }
+
+    @Test
+    fun `rejects slash-only path`() {
+        assertEquals(404, handler.handle("/").statusCode)
+    }
+
+    @Test
+    fun `rejects path containing dotdot segment`() {
+        // Caught by the upfront pattern check; never reaches canonical resolution.
+        assertEquals(404, handler.handle("/../etc/passwd").statusCode)
+        assertEquals(404, handler.handle("/..").statusCode)
+    }
+
+    @Test
+    fun `rejects multi-segment paths`() {
+        File(uploadsDir, "sub").mkdir()
+        File(uploadsDir, "sub/nested.jpg").writeBytes(byteArrayOf(0xFF.toByte()))
+
+        // Multi-segment paths are rejected upfront, even when the underlying
+        // file exists — the handler only serves flat names directly under uploads.
+        assertEquals(404, handler.handle("/sub/nested.jpg").statusCode)
+    }
+
+    @Test
+    fun `returns 404 for a missing file`() {
+        assertEquals(404, handler.handle("/does-not-exist.jpg").statusCode)
+    }
+
+    @Test
+    fun `returns 404 when the name resolves to a directory`() {
+        File(uploadsDir, "subdir").mkdir()
+
+        // Containment passes (the dir is inside uploads), but `!isFile` rejects.
+        assertEquals(404, handler.handle("/subdir").statusCode)
+    }
+
+    @Test
+    fun `rejects a symlink resolving outside uploads`() {
+        val outside = tempFolder.newFile("outside.jpg").apply {
+            writeBytes(byteArrayOf(0x01))
+        }
+        // Symlink inside uploads, target outside — canonical resolution follows
+        // the link, parentFile walk never passes through uploadsRoot.
+        Files.createSymbolicLink(
+            File(uploadsDir, "link.jpg").toPath(),
+            outside.toPath(),
+        )
+
+        assertEquals(404, handler.handle("/link.jpg").statusCode)
+    }
+
+    @Test
+    fun `rejects a sibling-prefix directory request`() {
+        // Defence against any future regression that swaps the parentFile walk
+        // for a naive `canonicalPath.startsWith(uploadsRoot.canonicalPath)`:
+        // a sibling dir whose path is a string-prefix of uploads must not match.
+        // The handler only sees flat names so this can't arrive as a request;
+        // assert that even if a symlink resolves into such a dir, it's rejected.
+        val sibling = tempFolder.newFolder("Uploads-evil")
+        val target = File(sibling, "evil.jpg").apply { writeBytes(byteArrayOf(0x01)) }
+        Files.createSymbolicLink(
+            File(uploadsDir, "evil.jpg").toPath(),
+            target.toPath(),
+        )
+
+        assertEquals(404, handler.handle("/evil.jpg").statusCode)
+    }
+}

--- a/android/app/src/androidTest/java/com/example/gutenbergkit/EditorTestHelpers.kt
+++ b/android/app/src/androidTest/java/com/example/gutenbergkit/EditorTestHelpers.kt
@@ -58,8 +58,12 @@ object EditorTestHelpers {
         rule.waitForNodeWithText("Standalone editor")
         rule.onNodeWithText("Standalone editor").performClick()
 
-        // Wait for and tap the "Start" button on the configuration screen.
+        // Wait for the configuration screen to render. The native inserter
+        // toggle defaults to on; turn it off so "Add block" opens the web
+        // Gutenberg dialog (which the WebView-side helpers below assert on)
+        // rather than the native BlockPickerDialog bottom sheet.
         rule.waitForNodeWithText("Start")
+        rule.onNodeWithContentDescription("Enable Native Inserter").performClick()
         rule.onNodeWithText("Start").performClick()
 
         // Block until the editor JS has booted and the bridge API is live.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -58,6 +58,9 @@
         <activity
             android:name=".MediaProxyServerActivity"
             android:exported="true" />
+        <activity
+            android:name=".ManagePermissionsActivity"
+            android:exported="false" />
     </application>
     <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/MainActivity.kt
@@ -113,6 +113,9 @@ class MainActivity : ComponentActivity(), AuthenticationManager.AuthenticationCa
                     onMediaProxyServer = {
                         startActivity(Intent(this, MediaProxyServerActivity::class.java))
                     },
+                    onManagePermissions = {
+                        startActivity(Intent(this, ManagePermissionsActivity::class.java))
+                    },
                     isDiscoveringSite = isDiscoveringSite.value,
                     onDismissDiscovering = { isDiscoveringSite.value = false },
                     isLoadingCapabilities = isLoadingCapabilities.value,
@@ -150,6 +153,7 @@ private fun isDevServerRunning(): Boolean {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongParameterList", "LongMethod")
 fun MainScreen(
     configurations: List<ConfigurationItem>,
     onConfigurationClick: (ConfigurationItem) -> Unit,
@@ -157,6 +161,7 @@ fun MainScreen(
     onAddConfiguration: (String) -> Unit,
     onDeleteConfiguration: (ConfigurationItem) -> Unit,
     onMediaProxyServer: () -> Unit = {},
+    onManagePermissions: () -> Unit = {},
     isDiscoveringSite: Boolean = false,
     onDismissDiscovering: () -> Unit = {},
     isLoadingCapabilities: Boolean = false,
@@ -189,6 +194,13 @@ fun MainScreen(
                             onClick = {
                                 showOverflowMenu.value = false
                                 onMediaProxyServer()
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Manage Permissions") },
+                            onClick = {
+                                showOverflowMenu.value = false
+                                onManagePermissions()
                             }
                         )
                     }

--- a/android/app/src/main/java/com/example/gutenbergkit/ManagePermissionsActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/ManagePermissionsActivity.kt
@@ -1,0 +1,234 @@
+package com.example.gutenbergkit
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import com.example.gutenbergkit.ui.theme.AppTheme
+import org.wordpress.gutenberg.GutenbergView
+
+class ManagePermissionsActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            AppTheme {
+                ManagePermissionsScreen(onBack = { finish() })
+            }
+        }
+    }
+}
+
+private enum class OsPermissionState {
+    Granted,
+    DeniedCanReprompt,
+    DeniedSuppressed,
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ManagePermissionsScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findActivity() }
+    var state by remember { mutableStateOf(readPermissionState(context, activity)) }
+    val refresh = { state = readPermissionState(context, activity) }
+
+    // Re-read on RESUME so revokes/grants made via system Settings are reflected
+    // when the user returns to this screen. Observes the host Activity directly
+    // (it implements LifecycleOwner) — avoids the deprecated compose-ui
+    // `LocalLifecycleOwner` without pulling in `lifecycle-runtime-compose`.
+    val lifecycle = (activity as? LifecycleOwner)?.lifecycle
+    DisposableEffect(lifecycle) {
+        if (lifecycle == null) return@DisposableEffect onDispose { }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) refresh()
+        }
+        lifecycle.addObserver(observer)
+        onDispose { lifecycle.removeObserver(observer) }
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Manage Permissions") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(PaddingValues(16.dp)),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            CurrentStateCard(state)
+            ResetFlagsCard(onReset = {
+                GutenbergView.resetBlockPickerPhotoPreferences(context)
+                refresh()
+            })
+            OpenSettingsCard(
+                state = state,
+                onOpen = { openAppSettings(context) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun CurrentStateCard(state: OsPermissionState) {
+    val (label, detail) = when (state) {
+        OsPermissionState.Granted ->
+            "Granted" to "The library can read MediaStore images; the inserter renders the thumbnail strip."
+        OsPermissionState.DeniedCanReprompt ->
+            "Denied (system will re-prompt)" to "The next Allow tap in the rationale will show the system prompt."
+        OsPermissionState.DeniedSuppressed ->
+            "Denied (system prompt suppressed)" to
+                "The OS has stopped offering the system prompt for this permission. Re-enable via Settings."
+    }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text("READ_MEDIA_IMAGES", style = MaterialTheme.typography.labelMedium)
+            Text(label, style = MaterialTheme.typography.titleMedium)
+            Text(
+                detail,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ResetFlagsCard(onReset: () -> Unit) {
+    ActionCard(
+        title = "Reset App Rationale Flags",
+        body = "Clears the in-app rationale-rejection and first-prompt flags. Does not touch the OS-level permission grant.",
+        action = {
+            OutlinedButton(onClick = onReset) { Text("Reset flags") }
+        },
+    )
+}
+
+// `revokeSelfPermissionOnKill` + self-kill was the obvious path but Android
+// 16 (and arguably earlier versions per the docs' "may delay the revocation"
+// language) doesn't reliably honor it — the process dies but the OS keeps
+// the grant. System Settings hand-off is deterministic and works on every
+// version, so we route all OS-permission flips through there.
+@Composable
+private fun OpenSettingsCard(state: OsPermissionState, onOpen: () -> Unit) {
+    val body = when (state) {
+        OsPermissionState.Granted ->
+            "Open the system permission settings to revoke photo access. Return to the demo to see the rationale flow restart."
+        OsPermissionState.DeniedCanReprompt ->
+            "Open the system permission settings if you want to inspect or change the OS-level photo permission."
+        OsPermissionState.DeniedSuppressed ->
+            "The system has suppressed the permission prompt for this app. " +
+                "Toggle photos access from system Settings to test the granted path."
+    }
+    ActionCard(
+        title = "Open Permission Settings",
+        body = body,
+        action = {
+            OutlinedButton(onClick = onOpen) { Text("Open Settings") }
+        },
+    )
+}
+
+@Composable
+private fun ActionCard(title: String, body: String, action: @Composable () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(title, style = MaterialTheme.typography.titleMedium)
+            Text(
+                body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            action()
+        }
+    }
+}
+
+private fun readPermissionState(context: Context, activity: Activity?): OsPermissionState {
+    val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+    val granted = ContextCompat.checkSelfPermission(context, permission) ==
+        PackageManager.PERMISSION_GRANTED
+    if (granted) return OsPermissionState.Granted
+    val canReprompt = activity?.let {
+        ActivityCompat.shouldShowRequestPermissionRationale(it, permission)
+    } ?: false
+    return if (canReprompt) OsPermissionState.DeniedCanReprompt else OsPermissionState.DeniedSuppressed
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is android.content.ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
+
+private fun openAppSettings(context: Context) {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", context.packageName, null)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(intent)
+}

--- a/android/app/src/main/java/com/example/gutenbergkit/ManagePermissionsActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/ManagePermissionsActivity.kt
@@ -159,11 +159,13 @@ private fun ResetFlagsCard(onReset: () -> Unit) {
     )
 }
 
-// `revokeSelfPermissionOnKill` + self-kill was the obvious path but Android
-// 16 (and arguably earlier versions per the docs' "may delay the revocation"
-// language) doesn't reliably honor it — the process dies but the OS keeps
-// the grant. System Settings hand-off is deterministic and works on every
-// version, so we route all OS-permission flips through there.
+// Settings hand-off rather than `revokeSelfPermissionOnKill` + self-kill:
+//   - The API is API 33+ only and the demo's minSdk is 24, so we'd need
+//     two code paths regardless.
+//   - Settings gives the user an OS-owned confirmation surface — they
+//     see exactly which permission flipped and when.
+//   - No lifecycle race between an async self-kill and the user landing
+//     back in the demo to verify the new state.
 @Composable
 private fun OpenSettingsCard(state: OsPermissionState, onOpen: () -> Unit) {
     val body = when (state) {

--- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationActivity.kt
@@ -51,6 +51,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelProvider
 import com.example.gutenbergkit.ui.theme.AppTheme
@@ -408,7 +410,10 @@ private fun FeatureConfigurationCard(
                 Text("Enable Native Inserter")
                 Switch(
                     checked = enableNativeInserter,
-                    onCheckedChange = onEnableNativeInserterChange
+                    onCheckedChange = onEnableNativeInserterChange,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Enable Native Inserter"
+                    },
                 )
             }
 

--- a/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/SitePreparationViewModel.kt
@@ -19,7 +19,7 @@ import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.PostType as WpPostType
 
 data class SitePreparationUiState(
-    val enableNativeInserter: Boolean = false,
+    val enableNativeInserter: Boolean = true,
     val enableNetworkLogging: Boolean = false,
     /** All viewable post types fetched from the site, or empty while loading. */
     val postTypes: List<PostTypeDetails> = emptyList(),

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -154,6 +154,31 @@ dependencies {
 
 Include the `android/Gutenberg/` module directly in your project.
 
+### Manifest Permissions
+
+GutenbergKit's `AndroidManifest.xml` declares the following permissions, which are merged into the host app's manifest:
+
+| Permission              | SDK range | Why                                                    |
+| ----------------------- | --------- | ------------------------------------------------------ |
+| `ACCESS_NETWORK_STATE`  | all       | Detects offline state so the editor can react.         |
+| `READ_MEDIA_IMAGES`     | 33+       | Powers the block inserter's recent-photos strip.       |
+| `READ_EXTERNAL_STORAGE` | ≤32       | Pre-Android-13 fallback for the same recent-photos UI. |
+
+The two media permissions show up in your app's Play Store data-safety disclosure and in the OS app-info screen. Hosts that don't render the inserter, don't want the recent-photos strip, or already declare these permissions for their own media flows can opt out via the manifest merger:
+
+```xml
+<uses-permission
+    android:name="android.permission.READ_MEDIA_IMAGES"
+    tools:node="remove" />
+<uses-permission
+    android:name="android.permission.READ_EXTERNAL_STORAGE"
+    tools:node="remove" />
+```
+
+With the media permissions removed, the inserter's Photos and Camera tiles still work (both are permissionless — Photos uses the system photo picker, Camera uses `ACTION_IMAGE_CAPTURE`). Only the recent-photos preview strip is suppressed.
+
+The recent-photos strip itself requires Android 10+ (API 29). On Android 7–9, the inserter automatically falls back to the Photos and Camera tiles and never requests the media permission, regardless of what the merged manifest declares.
+
 ### Basic Setup
 
 Create a `GutenbergView` and start the editor:


### PR DESCRIPTION
Stacks on #510. Closes the round-trip gap that #510 explicitly defers — the Photos tile, Camera tile, and recent-photos thumbnail-tap now insert a real image block in the editor.

## Summary

- New `org.wordpress.gutenberg.media` package: `MediaInfo` (Codable parity with iOS), `MediaFileManager` (storage + import + TTL cleanup), `MediaPathHandler` (serves under `/media/` on the existing `appassets.androidplatform.net` asset host)
- `GutenbergView.insertMediaFromInserter(List<MediaInfo>)` mirrors iOS `EditorViewController.insertMediaFromInserter` at `EditorViewController.swift:548`, calling `window.blockInserter.insertMedia(...)` — the JS receiver at `src/components/native-inserter/index.jsx:172` is reused unchanged
- `BlockPickerDialog` exposes a `LocalMediaInsertion` `CompositionLocal` so the three call sites fire `insertMedia` without prop-drilling the callback through every layout composable in between

## Architecture

### Storage + serving

`MediaFileManager` owns `filesDir/GutenbergKit/Uploads/` and copies imports into a UUID-named file per import. The returned `MediaInfo.url` resolves against `appassets.androidplatform.net/media/<uuid>.<ext>`, which `MediaPathHandler` serves back from disk via the existing `WebViewAssetLoader`. Same-origin against the editor bundle, so no CORS plumbing and no custom URL scheme.

The main alternative was an iOS-equivalent custom `gbk-media-file://` scheme via a `WKURLSchemeHandler`-style handler. `WebViewAssetLoader` is the well-trodden Android equivalent and the asset host is already inside the editor's trust boundary, so this lands without any new content-serving surface area.

### MIME resolution

`ContentResolver.getType(uri)` → `MimeTypeMap.getMimeTypeFromExtension(...)` → magic-byte sniff → `application/octet-stream`.

- `URLConnection.guessContentTypeFromStream` reads magic bytes but its table doesn't recognize HEIC, WebP, or AVIF — the formats the system photo picker most often returns on modern Android. The hand-rolled sniff covers JPEG / PNG / GIF / WebP / HEIC / AVIF.
- In practice steps 1–2 cover every source we produce today (photo picker + MediaStore yield content:// URIs with known MIMEs; camera output is `.jpg`). The sniff fallback only kicks in for SAF providers handing back `application/octet-stream`.

### Camera capture path

Camera output is now written directly into the managed Uploads dir (not `cacheDir/camera/` anymore), so a successful capture **is** the import — no copy step. Cancellation eagerly deletes the empty FileProvider-grant file rather than waiting for the 2-day TTL sweep.

`CameraCapture` is `@Parcelize` so `rememberSaveable` survives the process death window while the camera app is in the foreground.

## What's not in this PR

- **Multi-select**: the Photos tile still uses `PickVisualMedia` (single). `PickMultipleVisualMedia` for gallery insertion is a follow-up.
- **No end-to-end emulator verification yet** — Detekt, `:Gutenberg:assembleDebug`, and `:Gutenberg:testDebugUnitTest` all pass, but the round-trip (pick → editor receives → image block renders) hasn't been exercised against a real WebView. That's the next step before this leaves draft.

## Test plan

- [ ] Open the inserter, tap **Photos**, pick an image → system picker dismisses → image block appears in the editor with the picked photo
- [ ] Tap **Camera**, take a photo → camera dismisses → image block appears
- [ ] Tap **Camera**, cancel without capturing → no block inserted → the empty FileProvider file under `filesDir/GutenbergKit/Uploads/` is deleted (verify via Device File Explorer)
- [ ] With photo permission granted, tap a thumbnail in the recent-photos strip → image block appears with that photo
- [ ] HEIC photo (iCloud-synced or Pixel default) round-trips correctly — MIME resolves and the block renders
- [ ] Force-kill the app while camera is in the foreground; reopen, take photo → block still inserts (Parcelable saver survives process death)
- [ ] After 48h, stale files under `filesDir/GutenbergKit/Uploads/` are swept on next inserter entry
- [ ] `./gradlew :Gutenberg:detekt :Gutenberg:assembleDebug :Gutenberg:testDebugUnitTest` passes