### PR TITLE
ci: fix trunk build by replacing bash 4 `mapfile` with portable loop

### DIFF
--- a/.buildkite/cleanup-pr-build-branches.sh
+++ b/.buildkite/cleanup-pr-build-branches.sh
@@ -22,7 +22,12 @@ echo '--- :robot_face: Use bot for Git operations'
 source use-bot-for-git
 
 echo "--- :mag: Listing pr-build/* branches on origin"
-mapfile -t branches < <(
+# `mapfile` is Bash 4+; macOS CI agents ship Bash 3.2, so use a portable
+# `while read` loop instead.
+branches=()
+while IFS= read -r branch; do
+    branches+=("$branch")
+done < <(
     git ls-remote --heads origin 'refs/heads/pr-build/*' \
         | awk '{print $2}' \
         | sed 's|^refs/heads/||'


### PR DESCRIPTION
## Summary

- Replaces a Bash 4-only `mapfile` builtin in `.buildkite/cleanup-pr-build-branches.sh` with a portable `while IFS= read -r ... done < <(...)` loop, restoring trunk builds.

## Root Cause

The `:wastebasket: Clean up pr-build/*` step runs on the `mac` queue. macOS ships Bash 3.2, which doesn't have `mapfile` (added in Bash 4.0), so line 25 of the script aborts:

```
./.buildkite/cleanup-pr-build-branches.sh: line 25: mapfile: command not found
🚨 Error: The command exited with status 127
```

Every trunk build fails on that step. Build that surfaced it: https://buildkite.com/automattic/gutenbergkit/builds/2360

## Fix

Use the same `while read` pattern that works under both Bash 3.2 and 4+. No behavioral change — `branches` is still a `\n`-delimited array populated from `git ls-remote | awk | sed`.

## Test plan

- [ ] CI: `:wastebasket: Clean up pr-build/* branches for closed PRs` passes on this PR (the step's `if: build.branch == "trunk"` gate means it'll **skip** on PR builds — verify on trunk after merge).
- [x] `bash -n` syntax-check passes under macOS Bash 3.2.57.
- [x] Local smoke test of the loop under `/bin/bash` (Bash 3.2) populates the array correctly from a multi-line input.