### PR TITLE
fix(release): replace invalid remove_lane_context_values in validate lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,11 +121,11 @@ lane :validate do |options|
 
   # Clear lane-context values populated by `get_github_release` so a later
   # action doesn't see stale state from this probe call.
-  remove_lane_context_values [
+  [
     SharedValues::GITHUB_API_RESPONSE,
     SharedValues::GITHUB_API_STATUS_CODE,
     SharedValues::GITHUB_API_JSON
-  ]
+  ].each { |key| lane_context.delete(key) }
 end
 
 lane :update_swift_package do |options|


### PR DESCRIPTION
## What?

Fixes the `validate` Fastlane lane that gates tagged releases. Replaces a call to a non-existent action with the canonical Fastlane idiom for deleting lane-context values.

## Why?

Build [#2363](https://buildkite.com/automattic/gutenbergkit/builds/2363) (the 0.17.0 release) failed at the `:white_check_mark: Validate Swift release v0.17.0` step with:

> ``Could not find action, lane or variable 'remove_lane_context_values'``

`remove_lane_context_values` isn't a real Fastlane action. The call was introduced in #502 but never exercised by an actual release until the 0.17.0 attempt, which is why CI didn't catch it earlier. Because `:rocket: Publish Swift release` `depends_on: validate-release`, the tag was never pushed and no public artifact (tag, GH Release, or `gutenbergkit/v0.17.0/` on S3) was ever produced.

## How?

`lane_context` is a built-in Fastlane action that returns `Actions.lane_context` — a `Hash` subclass. Use `Hash#delete` directly:

```ruby
[
  SharedValues::GITHUB_API_RESPONSE,
  SharedValues::GITHUB_API_STATUS_CODE,
  SharedValues::GITHUB_API_JSON
].each { |key| lane_context.delete(key) }
```

The defensive cleanup intent (clear the probe values so a later action doesn't see stale state) is preserved — only the syntax changes.

## Testing Instructions

`validate` is read-only (checks version format, probes git for an existing tag, probes GitHub for an existing release) — safe to run locally:

```bash
bundle install
GITHUB_TOKEN=$(gh auth token) bundle exec fastlane validate version:v0.17.1
```

Expected: `fastlane.tools finished successfully`, with `setup_ci`, `git_tag_exists`, and `get_github_release` in the action summary, and no `Could not find action` error from the cleanup block.

- [x] `ruby -c fastlane/Fastfile` passes (syntax check)
- [x] `bundle exec fastlane validate version:v0.17.1` passes locally