### PR TITLE
fix(release): pass NEW_VERSION through to publish step's job shell

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -169,6 +169,12 @@ steps:
           - test-web-e2e
           - test-ios-e2e
       if: build.env("NEW_VERSION") != null && build.branch == "trunk" && build.pull_request.id == null
+      # Build-level env vars (passed via API/UI when triggering the build) are
+      # available to YAML interpolation at pipeline-upload time, but the
+      # `queue: mac` agents don't expose them as runtime env vars to job
+      # shells. Re-pass `NEW_VERSION` here so `release.sh` can read it.
+      env:
+          NEW_VERSION: $NEW_VERSION
       command: .buildkite/release.sh
       plugins: *plugins
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -169,13 +169,11 @@ steps:
           - test-web-e2e
           - test-ios-e2e
       if: build.env("NEW_VERSION") != null && build.branch == "trunk" && build.pull_request.id == null
-      # Build-level env vars (passed via API/UI when triggering the build) are
-      # available to YAML interpolation at pipeline-upload time, but the
-      # `queue: mac` agents don't expose them as runtime env vars to job
-      # shells. Re-pass `NEW_VERSION` here so `release.sh` can read it.
-      env:
-          NEW_VERSION: $NEW_VERSION
-      command: .buildkite/release.sh
+      # Pass NEW_VERSION as an argument: build-level env vars set when
+      # triggering aren't exposed to job runtime shells on `queue: mac`, but
+      # `$NEW_VERSION` here gets YAML-interpolated at pipeline-upload time
+      # so the literal version lands in the command line.
+      command: .buildkite/release.sh "$NEW_VERSION"
       plugins: *plugins
 
     - label: ':ios: Test iOS E2E'

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -2,9 +2,10 @@
 
 set -euo pipefail
 
-if [[ -z "${NEW_VERSION:-}" ]]; then
-    echo "ERROR: NEW_VERSION is not set or is empty." >&2
-    echo "Set NEW_VERSION=vX.Y.Z when triggering this build." >&2
+NEW_VERSION="${1:-}"
+if [[ -z "$NEW_VERSION" ]]; then
+    echo "ERROR: version argument is required." >&2
+    echo "Usage: $0 vX.Y.Z" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

The `:rocket: Publish Swift release` step runs `.buildkite/release.sh`, which previously read `$NEW_VERSION` at runtime from bash. Build-level env vars passed via the API/UI when triggering a build aren't exposed as runtime env vars to job shells on `queue: mac` agents — they're only available for YAML interpolation at pipeline-upload time. So the script saw an empty value and bailed early.

The `validate-release` step happened to work because its command inlines `$NEW_VERSION` in YAML:

\`\`\`yaml
bundle exec fastlane validate "version:$NEW_VERSION"
\`\`\`

That gets interpolated to the literal `version:v0.17.1` at upload time, with no runtime env dependency.

## Root Cause

Two distinct Buildkite mechanisms, only one of which worked on `queue: mac`:

| Mechanism | Available on `queue: mac` | Used by |
|---|---|---|
| YAML `$NEW_VERSION` interpolation at upload | ✅ | label rendering, `validate` step |
| `$NEW_VERSION` in job shell env at runtime | ❌ | `release.sh` (before this fix) |

The build's `env` metadata had `NEW_VERSION=v0.17.1` (confirmed in the API response and in the rendered step label `Publish Swift release v0.17.1`), but the runtime shell didn't see it.

## What We Explored

### 1. Step-level `env:` block ❌

First attempt was to add `env: NEW_VERSION: $NEW_VERSION` on the rocket step. Step env blocks are documented to propagate to job runtime, so the value would land in the shell env via that mechanism. This *should* work but relies on Buildkite step-env-propagation behavior on `queue: mac`, which we haven't verified end-to-end.

### 2. Command argument ✅

Pass `$NEW_VERSION` as a positional arg to `release.sh`. The arg is YAML-interpolated to the literal version string at pipeline-upload time on `queue: upload` (where the build-level env var **is** visible) and lands in the command line — so by job execution time there's no env-variable plumbing left to trust. Script reads `$1`.

Chose option 2 — more explicit, doesn't depend on env-propagation rules.

## Fix

\`\`\`yaml
# pipeline.yml — rocket step
command: .buildkite/release.sh "$NEW_VERSION"
\`\`\`

\`\`\`bash
# release.sh
NEW_VERSION="${1:-}"
if [[ -z "$NEW_VERSION" ]]; then
    echo "ERROR: version argument is required." >&2
    ...
\`\`\`

## Impact

Surfaced in build [#2367](https://buildkite.com/automattic/gutenbergkit/builds/2367) attempting to publish v0.17.1. The publish step failed before pushing any tag or creating any GH release. v0.17.1 itself was published by running the sub-lanes (\`update_swift_package\` → \`publish_to_s3\` → \`publish_release_to_github\`) manually from a local checkout against the XCFramework artifact that build #2367 had already built and signed.

The previous v0.17.0 release commit also never produced a tag for the same reason — only `v0.16.0` exists on the remote.

## Test plan

- [ ] Trigger a Buildkite build with `NEW_VERSION=v0.17.2` (or similar) pinned to a future release commit and confirm the publish step receives the version correctly
- [ ] Confirm the existing `validate-release` step continues to render the version in its label and command

## Related

- v0.17.1 (already published): https://github.com/wordpress-mobile/GutenbergKit/releases/tag/v0.17.1
- Originating build: https://buildkite.com/automattic/gutenbergkit/builds/2367