### PR TITLE
fix(android): derive inserter tabs from payload sections

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerDialog.kt
@@ -105,8 +105,6 @@ import androidx.compose.ui.graphics.Color as ComposeColor
 import org.wordpress.gutenberg.model.BlockInserterPayload
 import org.wordpress.gutenberg.model.BlockType
 
-private const val SEARCH_ONLY_CATEGORY = "gbk-search-only"
-private const val MOST_USED_CATEGORY = "gbk-most-used"
 private const val SEARCH_DEBOUNCE_MS = 150L
 
 /** WordPress brand navy — seed for the fallback scheme on pre-API-31 devices. */
@@ -237,10 +235,12 @@ private fun BlockPickerSheet(
 ) {
     val colorScheme = rememberColorScheme()
     MaterialTheme(colorScheme = colorScheme) {
-        val allBlocks = remember(payload) { flattenBlocks(payload) }
+        val sections = remember(payload) { browsableSections(payload) }
+        val tabs = remember(sections) { buildTabs(sections) }
+        val allBlocks = remember(sections) { allBrowsableBlocks(sections) }
         val recentBlocks = remember(payload, allBlocks) { recentBlocks(payload, allBlocks) }
 
-        var selectedTab by remember { mutableStateOf(BlockPickerTab.Recent) }
+        var selectedTab by remember { mutableStateOf<BlockPickerTab>(BlockPickerTab.Recent) }
         var query by remember { mutableStateOf("") }
         var debounced by remember { mutableStateOf("") }
         LaunchedEffect(query) {
@@ -248,12 +248,13 @@ private fun BlockPickerSheet(
             debounced = query.trim()
         }
 
-        val filtered = remember(selectedTab, debounced, allBlocks, recentBlocks) {
-            val tabBlocks = filterByTab(selectedTab, allBlocks, recentBlocks)
+        val filtered = remember(selectedTab, debounced, recentBlocks) {
+            val tabBlocks = blocksForTab(selectedTab, recentBlocks)
             if (debounced.isEmpty()) tabBlocks else searchBlocks(debounced, tabBlocks)
         }
 
         SheetContent(
+            tabs = tabs,
             selectedTab = selectedTab,
             onSelectTab = { selectedTab = it },
             query = query,
@@ -271,6 +272,7 @@ private fun BlockPickerSheet(
 @Composable
 @Suppress("LongParameterList")
 private fun SheetContent(
+    tabs: List<BlockPickerTab>,
     selectedTab: BlockPickerTab,
     onSelectTab: (BlockPickerTab) -> Unit,
     query: String,
@@ -299,7 +301,7 @@ private fun SheetContent(
         if (showMediaStrip) {
             MediaStrip()
         }
-        CategoryTabs(selected = selectedTab, onSelect = onSelectTab)
+        CategoryTabs(tabs = tabs, selected = selectedTab, onSelect = onSelectTab)
         SearchField(query = query, onQueryChange = onQueryChange)
         BlockGridContent(
             blocks = blocks,
@@ -310,24 +312,6 @@ private fun SheetContent(
                 .weight(1f, fill = true),
         )
     }
-}
-
-private fun flattenBlocks(payload: BlockInserterPayload): List<BlockType> =
-    dedupeById(
-        payload.sections
-            .filter { it.category != SEARCH_ONLY_CATEGORY }
-            .flatMap { it.blocks }
-    )
-
-private fun recentBlocks(
-    payload: BlockInserterPayload,
-    allBlocks: List<BlockType>,
-): List<BlockType> {
-    val mostUsed = payload.sections
-        .firstOrNull { it.category == MOST_USED_CATEGORY }
-        ?.blocks
-        .orEmpty()
-    return if (mostUsed.isNotEmpty()) dedupeById(mostUsed) else allBlocks
 }
 
 @Composable
@@ -565,10 +549,10 @@ private fun MediaActionTile(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun CategoryTabs(
+    tabs: List<BlockPickerTab>,
     selected: BlockPickerTab,
     onSelect: (BlockPickerTab) -> Unit,
 ) {
-    val tabs = BlockPickerTab.entries
     val selectedIndex = tabs.indexOf(selected).coerceAtLeast(0)
     // Tab labels sit 16dp inside the Tab layout (M3's internal
     // `HorizontalTextPadding`), so set `edgePadding` to `SEARCH_HORIZONTAL_PAD_DP
@@ -584,10 +568,16 @@ private fun CategoryTabs(
             Tab(
                 selected = tab == selected,
                 onClick = { onSelect(tab) },
-                text = { Text(stringResource(tab.labelRes)) },
+                text = { Text(tabLabel(tab)) },
             )
         }
     }
+}
+
+@Composable
+private fun tabLabel(tab: BlockPickerTab): String = when (tab) {
+    BlockPickerTab.Recent -> stringResource(R.string.gbk_block_inserter_tab_recent)
+    is BlockPickerTab.Category -> tab.section.name ?: tab.section.category
 }
 
 @Composable
@@ -912,53 +902,3 @@ private fun EmptyState(query: String, modifier: Modifier = Modifier) {
     }
 }
 
-private fun dedupeById(blocks: List<BlockType>): List<BlockType> {
-    val seen = HashSet<String>()
-    return blocks.filter { seen.add(it.id) }
-}
-
-private fun filterByTab(
-    tab: BlockPickerTab,
-    allBlocks: List<BlockType>,
-    recentBlocks: List<BlockType>,
-): List<BlockType> {
-    if (tab == BlockPickerTab.Recent) return recentBlocks
-    val ids = tab.blockIds ?: return allBlocks
-    return allBlocks.filter { it.name.substringAfterLast('/') in ids }
-}
-
-/**
- * Hardcoded block-id groupings from the design handoff. Production will likely
- * derive these from the payload, but the design freezes the taxonomy shown in
- * the tabs so we pin it here to match Variation B exactly.
- */
-private enum class BlockPickerTab(
-    val labelRes: Int,
-    val blockIds: Set<String>?,
-) {
-    Recent(R.string.gbk_block_inserter_tab_recent, null),
-    Text(
-        R.string.gbk_block_inserter_tab_text,
-        setOf("paragraph", "heading", "list", "quote", "preformatted"),
-    ),
-    Media(
-        R.string.gbk_block_inserter_tab_media,
-        setOf("image", "gallery", "video", "audio", "cover", "file"),
-    ),
-    Design(
-        R.string.gbk_block_inserter_tab_design,
-        setOf("table", "separator", "code", "columns", "button", "buttons"),
-    ),
-    Widgets(
-        R.string.gbk_block_inserter_tab_widgets,
-        setOf("button", "buttons", "separator"),
-    ),
-    Theme(
-        R.string.gbk_block_inserter_tab_theme,
-        setOf("cover", "columns", "gallery"),
-    ),
-    Embeds(
-        R.string.gbk_block_inserter_tab_embeds,
-        setOf("video", "audio", "embed"),
-    );
-}

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerTabs.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/inserter/BlockPickerTabs.kt
@@ -1,0 +1,64 @@
+package org.wordpress.gutenberg.inserter
+
+import org.wordpress.gutenberg.model.BlockInserterPayload
+import org.wordpress.gutenberg.model.BlockInserterSection
+import org.wordpress.gutenberg.model.BlockType
+
+/**
+ * Prefix used by the JS bridge for sections that don't represent a real block
+ * category (`gbk-most-used`, `gbk-contextual`, `gbk-search-only`, …). Browsable
+ * tabs are derived from non-synthetic sections only.
+ */
+private const val SYNTHETIC_CATEGORY_PREFIX = "gbk-"
+
+internal const val MOST_USED_CATEGORY = "gbk-most-used"
+
+/**
+ * One tab in the block picker. `Recent` is special-cased — it has its own
+ * localized label and shows the payload's most-used blocks (falling back to
+ * every browsable block when the payload doesn't carry a most-used section).
+ * Every other tab is a [Category] driven by a non-synthetic payload section,
+ * so the taxonomy is whatever the web editor's `getBlockCategories()` returns
+ * (core categories first, plugin categories appended). This avoids hand-curating
+ * a Kotlin-side allowlist that silently drops plugin and unfamiliar core blocks.
+ */
+internal sealed class BlockPickerTab {
+    object Recent : BlockPickerTab()
+    data class Category(val section: BlockInserterSection) : BlockPickerTab()
+}
+
+internal fun browsableSections(payload: BlockInserterPayload): List<BlockInserterSection> =
+    payload.sections.filter { !it.category.startsWith(SYNTHETIC_CATEGORY_PREFIX) }
+
+internal fun buildTabs(sections: List<BlockInserterSection>): List<BlockPickerTab> =
+    buildList {
+        add(BlockPickerTab.Recent)
+        sections.forEach { add(BlockPickerTab.Category(it)) }
+    }
+
+internal fun allBrowsableBlocks(sections: List<BlockInserterSection>): List<BlockType> =
+    dedupeById(sections.flatMap { it.blocks })
+
+internal fun recentBlocks(
+    payload: BlockInserterPayload,
+    allBlocks: List<BlockType>,
+): List<BlockType> {
+    val mostUsed = payload.sections
+        .firstOrNull { it.category == MOST_USED_CATEGORY }
+        ?.blocks
+        .orEmpty()
+    return if (mostUsed.isNotEmpty()) dedupeById(mostUsed) else allBlocks
+}
+
+internal fun blocksForTab(
+    tab: BlockPickerTab,
+    recentBlocks: List<BlockType>,
+): List<BlockType> = when (tab) {
+    BlockPickerTab.Recent -> recentBlocks
+    is BlockPickerTab.Category -> tab.section.blocks
+}
+
+internal fun dedupeById(blocks: List<BlockType>): List<BlockType> {
+    val seen = HashSet<String>()
+    return blocks.filter { seen.add(it.id) }
+}

--- a/android/Gutenberg/src/main/res/values/strings.xml
+++ b/android/Gutenberg/src/main/res/values/strings.xml
@@ -7,12 +7,6 @@
     <string name="gbk_block_inserter_title">Add block</string>
     <string name="gbk_block_inserter_close">Close</string>
     <string name="gbk_block_inserter_tab_recent">Recent</string>
-    <string name="gbk_block_inserter_tab_text">Text</string>
-    <string name="gbk_block_inserter_tab_media">Media</string>
-    <string name="gbk_block_inserter_tab_design">Design</string>
-    <string name="gbk_block_inserter_tab_widgets">Widgets</string>
-    <string name="gbk_block_inserter_tab_theme">Theme</string>
-    <string name="gbk_block_inserter_tab_embeds">Embeds</string>
     <string name="gbk_block_inserter_clear_search">Clear search</string>
     <string name="gbk_block_inserter_no_results">No results</string>
     <string name="gbk_block_inserter_no_results_for">No blocks match “%1$s”</string>

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/BlockPickerTabsTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/inserter/BlockPickerTabsTest.kt
@@ -1,0 +1,138 @@
+package org.wordpress.gutenberg.inserter
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.wordpress.gutenberg.model.BlockInserterPayload
+import org.wordpress.gutenberg.model.BlockInserterSection
+import org.wordpress.gutenberg.model.BlockType
+
+class BlockPickerTabsTest {
+
+    private val paragraph = block("core/paragraph", title = "Paragraph", category = "text")
+    private val heading = block("core/heading", title = "Heading", category = "text")
+    private val image = block("core/image", title = "Image", category = "media")
+    private val jetpackAi = block(
+        "jetpack/ai-assistant",
+        title = "AI Assistant",
+        category = "jetpack",
+    )
+    private val headingH2 = block(
+        "core/heading/h2",
+        name = "core/heading",
+        title = "Heading (H2)",
+    )
+
+    private val textSection = BlockInserterSection(
+        category = "text", name = "Text", blocks = listOf(paragraph, heading),
+    )
+    private val mediaSection = BlockInserterSection(
+        category = "media", name = "Media", blocks = listOf(image),
+    )
+    private val jetpackSection = BlockInserterSection(
+        category = "jetpack", name = "Jetpack", blocks = listOf(jetpackAi),
+    )
+    private val mostUsedSection = BlockInserterSection(
+        category = "gbk-most-used", name = null, blocks = listOf(paragraph),
+    )
+    private val searchOnlySection = BlockInserterSection(
+        category = "gbk-search-only", name = null, blocks = listOf(headingH2),
+    )
+
+    @Test
+    fun `browsableSections strips every gbk- prefixed section`() {
+        val payload = BlockInserterPayload(
+            sections = listOf(mostUsedSection, textSection, searchOnlySection, jetpackSection),
+        )
+
+        val browsable = browsableSections(payload)
+
+        assertEquals(listOf(textSection, jetpackSection), browsable)
+    }
+
+    @Test
+    fun `buildTabs puts Recent first then preserves payload section order`() {
+        val tabs = buildTabs(listOf(textSection, mediaSection, jetpackSection))
+
+        assertEquals(
+            listOf(
+                BlockPickerTab.Recent,
+                BlockPickerTab.Category(textSection),
+                BlockPickerTab.Category(mediaSection),
+                BlockPickerTab.Category(jetpackSection),
+            ),
+            tabs,
+        )
+    }
+
+    @Test
+    fun `buildTabs returns just Recent when there are no browsable sections`() {
+        assertEquals(listOf(BlockPickerTab.Recent), buildTabs(emptyList()))
+    }
+
+    @Test
+    fun `recentBlocks uses the most-used section when present`() {
+        val payload = BlockInserterPayload(
+            sections = listOf(mostUsedSection, textSection),
+        )
+        val allBlocks = allBrowsableBlocks(browsableSections(payload))
+
+        assertEquals(listOf(paragraph), recentBlocks(payload, allBlocks))
+    }
+
+    @Test
+    fun `recentBlocks falls back to all blocks when most-used is missing`() {
+        val payload = BlockInserterPayload(sections = listOf(textSection, mediaSection))
+        val allBlocks = allBrowsableBlocks(browsableSections(payload))
+
+        assertEquals(listOf(paragraph, heading, image), recentBlocks(payload, allBlocks))
+    }
+
+    @Test
+    fun `blocksForTab returns recent for the Recent tab`() {
+        val recent = listOf(paragraph, image)
+
+        assertSame(recent, blocksForTab(BlockPickerTab.Recent, recent))
+    }
+
+    @Test
+    fun `blocksForTab returns the section's blocks for a Category tab`() {
+        val tab = BlockPickerTab.Category(jetpackSection)
+
+        // The Jetpack AI block is unreachable under the old hardcoded-allowlist
+        // path; this regression test pins it to the Jetpack tab.
+        assertEquals(listOf(jetpackAi), blocksForTab(tab, recentBlocks = emptyList()))
+    }
+
+    @Test
+    fun `allBrowsableBlocks dedupes by id across sections`() {
+        // The JS bridge shouldn't emit the same block twice, but a block that
+        // ends up in two sections (e.g. a contextual section reuse) shouldn't
+        // double-count in the all-blocks fallback used by Recent.
+        val duplicateSection = textSection.copy(blocks = listOf(paragraph))
+
+        val all = allBrowsableBlocks(listOf(textSection, duplicateSection))
+
+        assertEquals(listOf(paragraph, heading), all)
+    }
+
+    @Test
+    fun `browsableSections is empty when only synthetic sections are present`() {
+        val payload = BlockInserterPayload(sections = listOf(mostUsedSection, searchOnlySection))
+
+        assertTrue(browsableSections(payload).isEmpty())
+    }
+
+    private fun block(
+        id: String,
+        name: String = id,
+        title: String? = null,
+        category: String? = null,
+    ) = BlockType(
+        id = id,
+        name = name,
+        title = title,
+        category = category,
+    )
+}


### PR DESCRIPTION
## What?

- Replaced `BlockPickerTab`'s hardcoded block-ID allowlist with tabs derived from `BlockInserterPayload.sections`.
- Tab labels come from each section's `name` (already localized by the JS bridge via `getBlockCategories()`); `Recent` keeps its hardcoded string resource.

Fixes #523.

## Why?

`BlockPickerTab` carried a hand-curated `Set<String>` of block IDs per tab and filtered the inserter to that allowlist:

```kotlin
val ids = tab.blockIds ?: return allBlocks
return allBlocks.filter { it.name.substringAfterLast('/') in ids }
```

Anything outside the union of those sets disappeared — every plugin block, plus core blocks (`core/group`, `core/details`, `core/footnotes`, `core/social-links`, …) that didn't make the design handoff. Now that consumers are starting to enable plugins in production (e.g. `setPlugins(true)` in wordpress-mobile/WordPress-Android), this gate is the visible reason Jetpack blocks never appeared in the inserter despite being correctly registered, returned by `getInserterItems()`, and serialized into the payload. The comment above the enum already acknowledged the allowlist was a stub:

> Hardcoded block-id groupings from the design handoff. Production will likely derive these from the payload, but the design freezes the taxonomy shown in the tabs so we pin it here to match Variation B exactly.

This PR makes production match what the comment described.

## How?

The JS bridge already ships exactly what we need: `payload.sections` carries one section per WordPress block category, each with a localized `name` and the blocks in that category (core categories first, plugin categories appended). The Kotlin side just had to use it.

### 1. New `BlockPickerTabs.kt`

Pure helpers, no Compose, fully unit-testable:

- `BlockPickerTab` is now a sealed class — `Recent` (special-cased) and `Category(section)`.
- **`browsableSections(payload)`**: strips every section whose category starts with `gbk-` (the prefix the JS bridge uses for synthetic sections — `gbk-most-used`, `gbk-contextual`, `gbk-search-only`). Forward-compatible with any new synthetic section.
- **`buildTabs(sections)`**: `Recent` followed by one `Category` per browsable section. Payload order is preserved, so the JS side controls the tab taxonomy.
- **`blocksForTab(tab, recentBlocks)`**: recent for `Recent`, the section's blocks for `Category`. No allowlist, no `substringAfterLast('/')` namespace stripping.
- `recentBlocks` and `dedupeById` moved here unchanged so they're testable alongside the rest.

### 2. `BlockPickerDialog.kt`

- Removed the `BlockPickerTab` enum, `filterByTab`, `flattenBlocks`, `dedupeById`, and the `SEARCH_ONLY_CATEGORY` / `MOST_USED_CATEGORY` private constants.
- `BlockPickerSheet` derives the tab list from the payload and threads it through `SheetContent` → `CategoryTabs`.
- `tabLabel` renders `Recent` from a string resource and `Category` labels from `section.name` (defensive fallback to `section.category`, though the JS bridge always populates `name` for non-synthetic sections).

### 3. `strings.xml`

Removed unused per-tab labels (`gbk_block_inserter_tab_text`, `…_media`, `…_design`, `…_widgets`, `…_theme`, `…_embeds`). Tab labels come from the payload now. `gbk_block_inserter_tab_recent` stays.

## What We Explored

- **A catch-all "More" tab** (option 2 in #523) — option 1 makes it unnecessary. The JS bridge buckets every block into a category section (blocks with no `category` fall back to `'common'`, unknown categories get appended with `name = capitalize(slug)`), so every browsable block lives in some non-synthetic section. No overflow to catch.
- **Dropping the stale `core/table` entry** from `BLOCK_ORDER_BY_CATEGORY.text` in `src/utils/blocks.js` — was bundled in earlier, then split out. Tracked as a separate cleanup; the Android fix stands alone without it.
- **Surfacing `gbk-search-only` blocks in search** — pre-existing behavior outside the scope of this fix.

## Testing Instructions

Run the Android demo app against `jetpack.wpmt.co`, open the inserter, and confirm the AI block is reachable.

## Related issues

- Fixes #523