### PR TITLE
fix: stamp required version keys into GutenbergKitResources framework Info.plist

### DIFF
--- a/build_xcframework.sh
+++ b/build_xcframework.sh
@@ -16,7 +16,28 @@
 set -euo pipefail
 
 SCHEME="GutenbergKitResources"
-MINIMUM_IOS_VERSION="17.0"
+# Minimum iOS version, read from Package.swift's declared platform so the
+# framework's MinimumOSVersion (and the dylib link target below) can't drift
+# from the package. SwiftPM normalizes `.v17` to "17.0" — the exact format
+# App Store Connect expects for MinimumOSVersion.
+MINIMUM_IOS_VERSION="$(swift package dump-package | jq -er '.platforms[] | select(.platformName == "ios") | .version' 2>/dev/null || true)"
+if [[ -z "${MINIMUM_IOS_VERSION}" ]]; then
+    echo "Error: could not read the iOS deployment target from Package.swift (is 'jq' installed and the Swift toolchain configured? check DEVELOPER_DIR / xcode-select -p)" >&2
+    exit 1
+fi
+# Marketing version stamped into the framework's Info.plist, sourced from
+# package.json so it always tracks the release. Fail closed rather than
+# stamping a placeholder: a silently-wrong version is exactly the drift we
+# want to prevent. App Store Connect rejects any embedded framework whose
+# Info.plist lacks CFBundleShortVersionString.
+# The `|| ''` collapses a missing/empty/undefined `version` to the empty
+# string so the guard below catches it — `node -p` would otherwise print the
+# literal "undefined" and stamp it as the version, the exact drift we prevent.
+MARKETING_VERSION="$(node -p "require('./package.json').version || ''" 2>/dev/null || true)"
+if [[ -z "${MARKETING_VERSION}" ]]; then
+    echo "Error: could not read the version field from package.json (is node on PATH, and is this the repo root?)" >&2
+    exit 1
+fi
 BUILD_DIR="$(pwd)/build"
 DERIVED_DATA_PATH="${BUILD_DIR}/DerivedData"
 
@@ -130,7 +151,9 @@ build_framework() {
     cp "${generated_maps}/${SCHEME}.modulemap" "${framework_path}/Modules/module.modulemap"
     cp "${generated_maps}/${SCHEME}-Swift.h" "${framework_path}/Headers/${SCHEME}-Swift.h"
 
-    # Minimal Info.plist
+    # Framework Info.plist. CFBundleShortVersionString, CFBundleVersion, and
+    # MinimumOSVersion are required by App Store Connect for any framework
+    # embedded in a submitted app — altool rejects the upload without them.
     cat > "${framework_path}/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -140,10 +163,18 @@ build_framework() {
     <string>${SCHEME}</string>
     <key>CFBundleIdentifier</key>
     <string>org.wordpress.GutenbergKitResources</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
     <key>CFBundleName</key>
     <string>${SCHEME}</string>
     <key>CFBundlePackageType</key>
     <string>FMWK</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${MARKETING_VERSION}</string>
+    <key>CFBundleVersion</key>
+    <string>${MARKETING_VERSION}</string>
+    <key>MinimumOSVersion</key>
+    <string>${MINIMUM_IOS_VERSION}</string>
 </dict>
 </plist>
 PLIST
@@ -223,6 +254,42 @@ copy_dsyms_for_sdk() {
     cp -r "${dsyms_path}" "${XCFRAMEWORK_PATH}/${slice}/"
 }
 
+# Reads a top-level Info.plist value, printing empty string if the key is
+# absent so callers can distinguish "missing" from a real value.
+plist_value() {
+    plutil -extract "$1" raw -o - "$2" 2>/dev/null || true
+}
+
+# Guards against the framework's Info.plist drifting out of sync with the
+# rest of the release. Runs against the actual shipped slice so a dropped or
+# stale key fails GutenbergKit's own CI here, rather than a consumer's App
+# Store upload three hops downstream (see altool errors 90057 / 90360).
+verify_framework_plist() {
+    local plist="$1"
+
+    plutil -lint "${plist}" >/dev/null
+
+    local short_version bundle_version min_os
+    short_version="$(plist_value CFBundleShortVersionString "${plist}")"
+    bundle_version="$(plist_value CFBundleVersion "${plist}")"
+    min_os="$(plist_value MinimumOSVersion "${plist}")"
+
+    if [[ "${short_version}" != "${MARKETING_VERSION}" ]]; then
+        echo "Error: ${plist}: CFBundleShortVersionString='${short_version}' does not match package.json version '${MARKETING_VERSION}'" >&2
+        exit 1
+    fi
+    if [[ "${bundle_version}" != "${MARKETING_VERSION}" ]]; then
+        echo "Error: ${plist}: CFBundleVersion='${bundle_version}' does not match package.json version '${MARKETING_VERSION}'" >&2
+        exit 1
+    fi
+    if [[ "${min_os}" != "${MINIMUM_IOS_VERSION}" ]]; then
+        echo "Error: ${plist}: MinimumOSVersion='${min_os}' does not match expected '${MINIMUM_IOS_VERSION}'" >&2
+        exit 1
+    fi
+
+    echo "  OK: ${plist} (v${short_version}, min iOS ${min_os})"
+}
+
 # Build for both platforms
 build_framework "iphoneos" "generic/platform=iOS"
 copy_resource_bundles "iphoneos"
@@ -246,6 +313,22 @@ xcodebuild -create-xcframework \
 # Copy dSYMs into xcframework slices
 copy_dsyms_for_sdk "iphoneos"
 copy_dsyms_for_sdk "iphonesimulator"
+
+# Verify every slice's framework Info.plist before the artifact leaves this step
+echo "--- Verifying framework Info.plist"
+verified_count=0
+for slice_dir in "${XCFRAMEWORK_PATH}"/ios-*; do
+    [ -d "${slice_dir}" ] || continue
+    verify_framework_plist "${slice_dir}/${SCHEME}.framework/Info.plist"
+    verified_count=$((verified_count + 1))
+done
+# Fail closed if the glob matched nothing: without nullglob the loop above
+# would run zero iterations and exit 0, letting an empty or malformed
+# XCFramework pass the very gate meant to catch it.
+if [[ "${verified_count}" -eq 0 ]]; then
+    echo "Error: no framework slices found to verify in ${XCFRAMEWORK_PATH}" >&2
+    exit 1
+fi
 
 echo ""
 echo "XCFramework: ${XCFRAMEWORK_PATH}"

--- a/build_xcframework.sh
+++ b/build_xcframework.sh
@@ -26,16 +26,17 @@ if [[ -z "${MINIMUM_IOS_VERSION}" ]]; then
     exit 1
 fi
 # Marketing version stamped into the framework's Info.plist, sourced from
-# package.json so it always tracks the release. Fail closed rather than
-# stamping a placeholder: a silently-wrong version is exactly the drift we
-# want to prevent. App Store Connect rejects any embedded framework whose
-# Info.plist lacks CFBundleShortVersionString.
-# The `|| ''` collapses a missing/empty/undefined `version` to the empty
-# string so the guard below catches it — `node -p` would otherwise print the
-# literal "undefined" and stamp it as the version, the exact drift we prevent.
-MARKETING_VERSION="$(node -p "require('./package.json').version || ''" 2>/dev/null || true)"
+# package.json so it always tracks the release. Read with jq (already required
+# above) so this script needs no separate Node dependency and both version
+# reads stay consistent. Fail closed rather than stamping a placeholder: a
+# silently-wrong version is exactly the drift we want to prevent. App Store
+# Connect rejects any embedded framework whose Info.plist lacks
+# CFBundleShortVersionString.
+# `.version // empty` collapses a missing/null/empty `version` to empty output
+# so the guard below catches it, rather than stamping a literal "null".
+MARKETING_VERSION="$(jq -er '.version // empty' package.json 2>/dev/null || true)"
 if [[ -z "${MARKETING_VERSION}" ]]; then
-    echo "Error: could not read the version field from package.json (is node on PATH, and is this the repo root?)" >&2
+    echo "Error: could not read the version field from package.json (is 'jq' installed and is this the repo root?)" >&2
     exit 1
 fi
 BUILD_DIR="$(pwd)/build"


### PR DESCRIPTION
## What?

`GutenbergKitResources.framework`'s `Info.plist` was missing `CFBundleShortVersionString` and `MinimumOSVersion`, which App Store Connect requires on every embedded framework. This adds those keys (plus `CFBundleVersion`), sources every value from a single manifest, and adds a post-build check so the plist can't silently drift again.

## Why?

`build_xcframework.sh` hand-writes the framework `Info.plist` with only four keys — `CFBundleExecutable`, `CFBundleIdentifier`, `CFBundleName`, `CFBundlePackageType`. `codesign` (`fastlane xcframework_sign`) doesn't validate version keys, so the deficient framework passes signing, zips, and publishes to the CDN unnoticed. **altool is the first tool in the chain that validates embedded-framework plists** — so the failure only surfaces at a _consuming_ app's TestFlight upload, three hops downstream:

- missing `CFBundleShortVersionString` → altool **90057**
- missing `MinimumOSVersion` → altool **90360**

This blocked a wordpress-ios TestFlight upload: [build 33156](https://buildkite.com/automattic/wordpress-ios/builds/33156).

Note: this fix is forward-only — the XCFramework already on the CDN still carries the bad plist, so it won't unblock a consumer on its own. It needs a new GutenbergKit release carrying this change, then a consumer bump to pick it up.

## How?

### 1. Stamp the required keys

The heredoc now also emits `CFBundleShortVersionString`, `CFBundleVersion`, `MinimumOSVersion`, and `CFBundleInfoDictionaryVersion`. `CFBundleVersion` wasn't in altool's error list, but a framework carrying `CFBundleShortVersionString` without it is malformed by convention — cheaper to include now than to eat a second upload round-trip.

### 2. Single source of truth, fail-closed

- `CFBundleShortVersionString` / `CFBundleVersion` ← `package.json` `version`
- `MinimumOSVersion` ← `Package.swift`'s declared iOS platform, via `swift package dump-package | jq` (SwiftPM normalizes `.v17` → `"17.0"`, the exact format the key wants)

Both **abort the build** if the value can't be read, rather than stamping a silently-wrong placeholder — a wrong-but-present version is exactly the drift we want to prevent. `MINIMUM_IOS_VERSION` is no longer hardcoded, so the dylib link target (`-target arch-apple-ios${MINIMUM_IOS_VERSION}`) tracks `Package.swift` too.

### 3. Verify before the artifact leaves the step

After `create-xcframework`, `verify_framework_plist` runs against every shipped slice and `exit 1`s unless: `plutil -lint` passes, `CFBundleShortVersionString` matches `package.json`, `CFBundleVersion` is present, and `MinimumOSVersion` matches. A dropped or stale key now reddens GutenbergKit's own `build-xcframework` job instead of a downstream App Store upload.

## Testing Instructions

1. `make build-resources-xcframework` (or `./build_xcframework.sh`).
2. Confirm the new `--- Verifying framework Info.plist` step prints `OK:` for each slice and the script exits `0`.
3. Inspect a slice's plist and confirm the keys resolve:
   ```
   plutil -p build/GutenbergKitResources-*.xcframework/ios-*/GutenbergKitResources.framework/Info.plist
   ```
   Expect `CFBundleShortVersionString` = the `package.json` version and `MinimumOSVersion` = `17.0`.
4. Negative check: temporarily edit `package.json`'s `version`, rebuild, and confirm the verification step fails the build with a `CFBundleShortVersionString ... does not match` error.

### Accessibility Testing Instructions

N/A — build tooling only, no UI change.
