### PR TITLE
fix: guard native inserter against non-string pattern categories

### DIFF
--- a/src/utils/blocks.js
+++ b/src/utils/blocks.js
@@ -374,9 +374,13 @@ export function formatPatternsForNativeInserter( patterns ) {
 			title: pattern.title,
 			content: pattern.content,
 			blockTypes: pattern.blockTypes ?? [],
+			// User/synced patterns can momentarily expose numeric term IDs
+			// instead of slug strings, so filter to strings before calling
+			// `startsWith`.
 			categories:
 				pattern.categories?.filter(
-					( cat ) => ! cat.startsWith( '_' )
+					( cat ) =>
+						typeof cat === 'string' && ! cat.startsWith( '_' )
 				) ?? [],
 			description: pattern.description ?? null,
 			keywords: pattern.keywords ?? [],

--- a/src/utils/blocks.test.js
+++ b/src/utils/blocks.test.js
@@ -198,6 +198,33 @@ describe( 'formatPatternsForNativeInserter', () => {
 		expect( pattern.categories ).toEqual( [ 'gallery', 'query' ] );
 	} );
 
+	it( 'drops non-string categories without throwing', () => {
+		// User/synced patterns can momentarily expose raw numeric term IDs
+		// (instead of slug strings) while core-data resolves the id→slug
+		// lookup table. Those must not reach `startsWith`.
+		expect( () =>
+			formatPatternsForNativeInserter( [
+				{
+					name: 'core/block/42',
+					title: 'Synced',
+					content: '',
+					categories: [ 'gallery', 7, '_internal', null ],
+				},
+			] )
+		).not.toThrow();
+
+		const [ pattern ] = formatPatternsForNativeInserter( [
+			{
+				name: 'core/block/42',
+				title: 'Synced',
+				content: '',
+				categories: [ 'gallery', 7, '_internal', null ],
+			},
+		] );
+
+		expect( pattern.categories ).toEqual( [ 'gallery' ] );
+	} );
+
 	it( 'produces patterns that conform to the Pattern shape', () => {
 		const patterns = formatPatternsForNativeInserter( [
 			{


### PR DESCRIPTION
## What?

Guard against a race condition whenever opening the native block inserter quickly after editor launch. Fixes #552. Fix CMM-2168.

## Why?

The race condition led to an editor crash, forcing users to close and re-open the editor.

`formatPatternsForNativeInserter` called `cat.startsWith( '_' )` on every entry of a pattern's `categories`, assuming each was a slug string. For user/synced patterns this assumption can briefly break while `mapUserPattern` in `@wordpress/block-editor` builds `categories` by mapping each numeric `wp_pattern_category` term ID through the `__experimentalUserPatternCategories` lookup table, falling back to the **raw numeric ID** when that table hasn't resolved yet.

If the native inserter is opened during that gap, a category is still a number, and `number.startsWith` is `undefined` → crash (Sentry `JETPACK-IOS-1KAQ`). Waiting a moment lets the lookup table resolve, which is why the crash is timing-dependent.

## How?

Filter `categories` to strings before calling `startsWith`. This ensures yet-to-be-resolved pattern entities with category ID numbers rather than string slugs are filtered out before performing string actions.

## Testing Instructions

1. Copy and apply the reproduction diff **below** ensuring the race condition state: `pbpaste | git apply`.
1. Open the GutenbergKit editor and open the native block inserter.
1. With the fix: the inserter opens normally.
1. Temporarily drop the fix: `git checkout HEAD~1 -- src/utils/blocks.js`.
1. Open the native block inserter.
1. Without the fix: the editor displays a "The editor has encountered an unexpected error" message.
1. Restore the fix: `git checkout HEAD -- src/utils/blocks.js`.

<details><summary>Reproduction diff</summary>

```diff
diff --git a/src/components/native-inserter/index.jsx b/src/components/native-inserter/index.jsx
index bc348fcd..65f8d92d 100644
--- a/src/components/native-inserter/index.jsx
+++ b/src/components/native-inserter/index.jsx
@@ -367,7 +367,36 @@ export default function NativeBlockInserterButton( { open, onToggle } ) {
 			categories
 		);

-		const formattedPatterns = formatPatternsForNativeInserter( patterns );
+		// TEMPORARY REPRO SHIM for JETPACK-IOS-1KAQ — DO NOT COMMIT.
+		// Forces a numeric term ID into a pattern's categories (as
+		// `mapUserPattern` does before the id→slug table resolves),
+		// nullifying the race. Synthesizes a pattern if none exist so the
+		// crash is deterministic on the first inserter open. Remove with
+		// `git checkout src/components/native-inserter/index.jsx`.
+		const reproPatterns =
+			patterns && patterns.length
+				? patterns.map( ( p, i ) =>
+						i === 0
+							? {
+									...p,
+									categories: [
+										...( p.categories ?? [] ),
+										7,
+									],
+							  }
+							: p
+				  )
+				: [
+						{
+							name: 'repro/jetpack-ios-1kaq',
+							title: 'Repro',
+							content:
+								'<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->',
+							categories: [ 7 ], // numeric term ID, as during the race
+						},
+				  ];
+		const formattedPatterns =
+			formatPatternsForNativeInserter( reproPatterns );
 		const formattedPatternCategories =
 			formatPatternCategoriesForNativeInserter( patternCategories );

@@ -424,11 +453,9 @@ export default function NativeBlockInserterButton( { open, onToggle } ) {
 			label={ __( 'Add block' ) }
 			icon={ plus }
 			onClick={ () => {
-				// Skip the redux toggle and present the native inserter
-				// directly. Flipping `isInserterOpened` in editorStore would
-				// briefly render Gutenberg's web inserter behind the native
-				// dialog before it covers, causing a visible flash.
-				prepareAndShowInserter();
+				// Temporarily reinstate React renderer control to showcase the editor
+				// error message displayed by the ErrorBoundary component
+				onToggle( true );
 			} }
 			onMouseDown={ ( e ) => {
 				e.preventDefault();

```

</details>

### Accessibility Testing Instructions

N/A — no UI changes. This removes a crash on an existing flow.

## Screenshots or screencast

<img width="300" alt="image" src="https://github.com/user-attachments/assets/613dc2f0-0c0d-437f-babe-0ab610e1e937" />
