### PR TITLE
chore(release): 0.18.1

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergKitVersion.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergKitVersion.kt
@@ -10,5 +10,5 @@ object GutenbergKitVersion {
     /**
      * The current version of GutenbergKit.
      */
-    const val VERSION = "0.18.0"
+    const val VERSION = "0.18.1"
 }

--- a/ios/Sources/GutenbergKit/Sources/GutenbergKitVersion.swift
+++ b/ios/Sources/GutenbergKit/Sources/GutenbergKitVersion.swift
@@ -4,5 +4,5 @@
 /// GutenbergKit version information.
 public enum GutenbergKitVersion {
     /// The current version of GutenbergKit.
-    public static let version = "0.18.0"
+    public static let version = "0.18.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gutenberg-kit",
-	"version": "0.18.0",
+	"version": "0.18.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gutenberg-kit",
-			"version": "0.18.0",
+			"version": "0.18.1",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@wordpress/a11y": "^4.38.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "gutenberg-kit",
 	"private": true,
 	"homepage": "https://github.com/wordpress-mobile/GutenbergKit",
-	"version": "0.18.0",
+	"version": "0.18.1",
 	"type": "module",
 	"scripts": {
 		"clean": "npm run clean:dist && npm run clean:l10n",


### PR DESCRIPTION
## What?

Bumps `0.18.0` → `0.18.1` to cut a patch release that ships #551 — version bump only, no other changes.

## Why?

`v0.18.0` predates #551, which stamps `CFBundleShortVersionString` and `MinimumOSVersion` into the `GutenbergKitResources.framework` `Info.plist`. Without those keys, apps embedding GutenbergKit **fail to upload to TestFlight** (`altool` 90057 / 90360). The fix is on `trunk` but unreleased, so no SPM consumer can pin a tag that contains it. This is the bump that lets us tag `v0.18.1`.

## How?

`npm --no-git-tag-version version patch` + `npm run generate-version` — four files, version fields only:

-   `package.json` / `package-lock.json` → `0.18.1`
-   `ios/Sources/GutenbergKit/Sources/GutenbergKitVersion.swift` → `version = "0.18.1"` — compiled into the `GutenbergKit` library from source (even in `.release` mode), so it has to be committed at the tagged commit
-   `android/.../GutenbergKitVersion.kt` → `VERSION = "0.18.1"`

**No rebuilt web bundle**, unlike the `0.18.0` bump. The CI `Build XCFramework` step downloads a freshly-built `dist/` and `copy-dist-ios` overwrites the committed `Gutenberg/` bundle before packaging — _"ship the just-built dist rather than whatever was committed at HEAD"_ (`Makefile`) — and `build_xcframework.sh` stamps the framework version from `package.json`. So the committed bundle isn't load-bearing for the tag, and it's byte-identical to `v0.18.0` regardless (#551 only touched `build_xcframework.sh`). Trunk stays `resourcesMode = .local`; its committed bundle keeps reporting `0.18.0` in JS error metadata until the next full build — cosmetic, trunk-only, invisible to tag consumers.

## Testing Instructions

Publish is the manual Buildkite flow (`docs/releases.md`), pinned to this PR's **merge** commit:

-   [ ] Merge to `trunk`
-   [ ] Trigger `automattic/gutenbergkit` → Branch `trunk`, Commit = merge SHA, `NEW_VERSION=v0.18.1`
-   [ ] `Validate Swift release` passes (no pre-existing tag/Release)
-   [ ] `v0.18.1` tag + GitHub Release published, XCFramework on CDN
-   [ ] Downstream app embedding `v0.18.1` uploads to TestFlight cleanly (verifies the 90057/90360 regression is gone)

Related: #551
