### PR TITLE
fix(ios): report why a picker item failed to import

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorLogging.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorLogging.swift
@@ -22,6 +22,9 @@ extension Logger {
 
     /// Logs editor navigation activity
     public static let navigation = Logger(subsystem: "GutenbergKit", category: "navigation")
+
+    /// Logs media import activity
+    static let media = Logger(subsystem: "GutenbergKit", category: "media")
 }
 
 public struct SignpostMonitor: Sendable {

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaFileManager.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaFileManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 import PhotosUI
 import SwiftUI
 import UniformTypeIdentifiers
@@ -27,7 +28,15 @@ actor MediaFileManager {
     ///
     /// - Returns: MediaInfo with a `gbk-media-file://` URL and detected media type
     func `import`(_ item: PhotosPickerItem) async throws -> MediaInfo {
-        guard let data = try await item.loadTransferable(type: Data.self) else {
+        let data: Data?
+        do {
+            data = try await item.loadTransferable(type: Data.self)
+        } catch {
+            Logger.media.error("Failed to load picker item \(item.supportedContentTypes): \(error)")
+            throw error
+        }
+        guard let data else {
+            Logger.media.error("Picker returned no data for item \(item.supportedContentTypes)")
             throw URLError(.unknown)
         }
         let contentType = item.supportedContentTypes.first


### PR DESCRIPTION
## What?

Logs why a photo picker item failed to import, and propagates the original error instead of replacing it.

## Why?

When the system cannot vend a picked item, the editor could only report a generic "failed to insert media" — even though the system supplies a specific reason.

`import(_:)` collapsed a missing item into `URLError(.unknown)`, and never logged the *thrown* error at all. Since `processSelectedPhotosPickerItems` surfaces `anyError?.localizedDescription`, that detail was gone by the time it reached the UI.

This came up while investigating a photo that fails to import on a device with Lockdown Mode enabled. The original code gave nothing to go on; with this logging, the console shows the underlying failure and the item's registered content types:

```
Failed to load picker item [public.jpeg, com.apple.private.photos.thumbnail.standard,
com.apple.private.photos.thumbnail.low]: Cannot load representation of type public.jpeg
  → NSCocoaErrorDomain 4099 "The connection to service ... was invalidated."
```

That output is what identified the failure as a system-level one — it reproduces in the legacy Gutenberg Mobile editor too, which shares no import code with GutenbergKit beyond `NSItemProvider`. This PR does not attempt to fix that underlying issue; it only makes such failures diagnosable.

## How?

Splits the `loadTransferable` call out of the `guard` so the thrown error can be logged and rethrown unchanged, and logs the empty-item case separately. Both go to a new `media` category on the existing `Logger` extension.

## Testing Instructions

Verify image uploads continue functioning 

1. Run the iOS demo app.
2. Insert an Image block and pick a photo from the library.
3. Confirm the image still imports and renders — this change does not alter the success path.

### Accessibility Testing Instructions

Not applicable — no user interface changes.
