### PR TITLE
fix(demo-ios): reference GutenbergKit as a local Swift package

### DIFF
--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.pbxproj
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		0CE8E7842C339B0600B9DC67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0CE8E7872C339B0600B9DC67 /* GutenbergApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenbergApp.swift; sourceTree = "<group>"; };
 		0CE8E7892C339B0600B9DC67 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		0CE8E7922C339B1B00B9DC67 /* GutenbergKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = GutenbergKit; path = ../..; sourceTree = "<group>"; };
 		246852682EAACCA100ED1F09 /* AuthenticationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManager.swift; sourceTree = "<group>"; };
 		246852692EAACCA100ED1F09 /* ConfigurationStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationStorage.swift; sourceTree = "<group>"; };
 		AA0000012F00000000000001 /* GutenbergUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GutenbergUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -69,7 +68,6 @@
 		0C4F59822BEFF4970028BD96 = {
 			isa = PBXGroup;
 			children = (
-				0CE8E7922C339B1B00B9DC67 /* GutenbergKit */,
 				0CE8E7882C339B0600B9DC67 /* Sources */,
 				0C83424D2C339B7F00CAA762 /* Resources */,
 				0CE8E78A2C339B0600B9DC67 /* PreviewContent */,
@@ -212,6 +210,7 @@
 			mainGroup = 0C4F59822BEFF4970028BD96;
 			packageReferences = (
 				0C4F59A02BEFF4980028BD96 /* XCRemoteSwiftPackageReference "wordpress-rs" */,
+				245D6BE52EDFCD640076D742 /* XCLocalSwiftPackageReference "../.." */,
 			);
 			productRefGroup = 0C4F598C2BEFF4970028BD96 /* Products */;
 			projectDirPath = "";
@@ -557,6 +556,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		245D6BE52EDFCD640076D742 /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../..;
+		};
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
 		0C4F59A02BEFF4980028BD96 /* XCRemoteSwiftPackageReference "wordpress-rs" */ = {

--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "a8d9099ea14692b5a05469f935a234e28952c8e9499519d8e1f7800b52964342",
+  "pins" : [
+    {
+      "identity" : "svgview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/SVGView.git",
+      "state" : {
+        "revision" : "6465962facdd25cb96eaebc35603afa2f15d2c0d",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swiftsoup",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scinfu/SwiftSoup.git",
+      "state" : {
+        "revision" : "ead56133a693d0184d8c2db1a6d6394410cacfd6",
+        "version" : "2.13.6"
+      }
+    },
+    {
+      "identity" : "wordpress-rs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/wordpress-rs",
+      "state" : {
+        "branch" : "alpha-20260313",
+        "revision" : "cde2fda82257f4ac7b81543d5b831bb267d4e52c"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
## What?

Stops the iOS demo app from rewriting the library's root `Package.resolved` every time the project is opened in Xcode.

## Why?

Opening `ios/Demo-iOS/Gutenberg.xcodeproj` added a `wordpress-rs` pin to the repo-root `Package.resolved`; resolving the Swift package on its own removed it again. The result was a recurring diff that had to be discarded by hand.

The root cause is in the demo project: it referenced the repo root as a plain folder (`PBXFileReference` with `path = ../..`) rather than as a package. Xcode treats a folder-referenced local package as an *editable root package*, so it wrote the demo app's merged dependency graph — including `wordpress-rs`, which is a demo-app dependency and not a `GutenbergKit` library dependency — into the library's own lockfile.

## How?

Declare the root as an `XCLocalSwiftPackageReference` and drop the folder reference. The demo app's graph now resolves into a demo-scoped lockfile under `project.xcworkspace/xcshareddata/swiftpm/`, leaving the library's `Package.resolved` untouched.

That demo lockfile is committed so the demo app and its E2E tests resolve reproducibly. It pins SwiftSoup 2.13.6 while the root pins 2.8.8 — expected, since these are now independent graphs and both satisfy `from: "2.7.5"`.

## Testing Instructions

1. Open `ios/Demo-iOS/Gutenberg.xcodeproj` in Xcode and let packages resolve.
2. Run `git status` — the root `Package.resolved` should be unmodified.
3. Confirm the demo app builds and runs.

To see the previous behavior, repeat step 1 on `trunk`: the root `Package.resolved` gains a `wordpress-rs` pin.

Verified locally with DerivedData and the demo lockfile deleted beforehand, so the result is not a warm-cache artifact:

- Pre-fix, resolving added 9 lines to the root `Package.resolved`.
- Post-fix, a cold resolve leaves it untouched.
- `xcodebuild build -scheme Gutenberg` succeeds, and the built app contains `GutenbergKit_GutenbergKitResources.bundle`, confirming the local package links.