### PR TITLE
fix: remove stale exclude from GutenbergKit target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,6 @@ let package = Package(
             name: "GutenbergKit",
             dependencies: ["SwiftSoup", "SVGView", "GutenbergKitResources"],
             path: "ios/Sources/GutenbergKit",
-            exclude: ["Gutenberg"],
             packageAccess: false
         ),
         .target(


### PR DESCRIPTION
## What?

Removes an `exclude:` entry in `Package.swift` that points at a directory which no longer exists.

## Why?

SwiftPM emits a warning on every package resolve, visible in Xcode against the `GutenbergKit` package:

```
Invalid Exclude '.../ios/Sources/GutenbergKit/Gutenberg': File not found.
```

The exclude dates from when the built web bundle was copied into the `GutenbergKit` target directory, where it stopped SwiftPM from treating thousands of bundled JS/CSS files as target sources. #376 moved the bundle to `ios/Sources/GutenbergKitResources/Gutenberg/`, where it is declared as a `.copy` resource, but the exclude was left behind.

## How?

Delete the `exclude: ["Gutenberg"]` line.

## Testing Instructions

1. Open the package (or the iOS demo app) in Xcode and let packages resolve.
2. Confirm the `Invalid Exclude` warning no longer appears on the `GutenbergKit` package.
3. Confirm the library still builds.

Verified locally:

- `swift package describe` reports the warning before the change and not after.
- The `GutenbergKit` target's source list is unchanged at 66 files, confirming the exclude was inert and no sources were pulled in or dropped.
- `swift build` and `xcodebuild build -scheme GutenbergKit` both succeed with no `Invalid Exclude` warning.
- `swift test` passes: 898 tests across 46 suites.
- Confirmed nothing in the Makefile, build scripts, or CI writes to the old path.