### PR TITLE
fix: prevent dropdown menus from overflowing the editor root

### DIFF
--- a/src/components/editor-toolbar/aria-helper.js
+++ b/src/components/editor-toolbar/aria-helper.js
@@ -13,7 +13,7 @@ const LIVE_REGION_ARIA_ROLES = new Set( [
 	'timer',
 ] );
 
-const hiddenElementsByDepth = [];
+const hiddenElementBatches = [];
 
 /**
  * Hides all elements in the body element from screen-readers except
@@ -32,10 +32,16 @@ const hiddenElementsByDepth = [];
  * `aria-modal="true"`.
  *
  * @param {...Element} modalElements The elements that should not be hidden.
+ *
+ * @return {Set<Element>} A handle identifying the elements hidden by this call,
+ *                        to be passed to `unmodalize`.
  */
 export function modalize( ...modalElements ) {
-	const hiddenElements = [];
-	hiddenElementsByDepth.push( hiddenElements );
+	// A Set, so overlapping ancestor chains do not record an element twice, and
+	// so `unmodalize` can remove this batch by identity regardless of the order
+	// in which overlapping modals close.
+	const hiddenElements = new Set();
+	hiddenElementBatches.push( hiddenElements );
 
 	const elements = modalElements.filter(
 		( element ) => element?.isConnected
@@ -68,10 +74,12 @@ export function modalize( ...modalElements ) {
 				}
 
 				sibling.setAttribute( 'aria-hidden', 'true' );
-				hiddenElements.push( sibling );
+				hiddenElements.add( sibling );
 			}
 		}
 	}
+
+	return hiddenElements;
 }
 /**
  * Determines if the passed element should not be hidden from screen readers.
@@ -92,15 +100,33 @@ export function elementShouldBeHidden( element ) {
 }
 
 /**
- * Accessibly reveals the elements hidden by the latest modal.
+ * Accessibly reveals the elements hidden by a modal.
+ *
+ * The batch to reveal is identified by the handle `modalize` returned, rather
+ * than assuming the most recent modal closes first. Modals do not always close
+ * in the reverse of the order they opened—the block inserter and the block
+ * settings menu can be open together—and React runs effect cleanups in
+ * hook-declaration order, not reverse-open order.
+ *
+ * @param {Set<Element>} handle The handle returned by `modalize`. Defaults to
+ *                              the most recent batch for backward
+ *                              compatibility.
  */
-export function unmodalize() {
-	const hiddenElements = hiddenElementsByDepth.pop();
-	if ( ! hiddenElements ) {
+export function unmodalize( handle = hiddenElementBatches.at( -1 ) ) {
+	const index = hiddenElementBatches.lastIndexOf( handle );
+	if ( index === -1 ) {
 		return;
 	}
 
-	for ( const element of hiddenElements ) {
-		element.removeAttribute( 'aria-hidden' );
+	hiddenElementBatches.splice( index, 1 );
+
+	for ( const element of handle ) {
+		// Keep the element hidden if another open modal still hides it.
+		const stillHidden = hiddenElementBatches.some( ( batch ) =>
+			batch.has( element )
+		);
+		if ( ! stillHidden ) {
+			element.removeAttribute( 'aria-hidden' );
+		}
 	}
 }

--- a/src/components/editor-toolbar/aria-helper.js
+++ b/src/components/editor-toolbar/aria-helper.js
@@ -78,16 +78,30 @@ export function modalize( ...modalElements ) {
 					continue;
 				}
 
-				sibling.setAttribute( 'aria-hidden', 'true' );
-				hiddenElements.add( sibling );
+				// Record the sibling even when another batch already hid it, so
+				// `unmodalize` reveals it only once every batch that hid it has
+				// been reversed. Leave `aria-hidden` present in that case, and
+				// never touch an element hidden by something other than a batch
+				// (e.g. authored markup)—`isBatchHidden` distinguishes the two.
+				if ( ! sibling.hasAttribute( 'aria-hidden' ) ) {
+					sibling.setAttribute( 'aria-hidden', 'true' );
+					hiddenElements.add( sibling );
+				} else if ( isBatchHidden( sibling ) ) {
+					hiddenElements.add( sibling );
+				}
 			}
 		}
 	}
 
 	return hiddenElements;
 }
+
 /**
  * Determines if the passed element should not be hidden from screen readers.
+ *
+ * A `aria-hidden` element that a batch already hid is still eligible, so an
+ * overlapping modal records it too; `modalize` guards the attribute write
+ * separately. An element hidden by anything else is left untouched.
  *
  * @param {Element} element The element that should be checked.
  *
@@ -98,10 +112,23 @@ export function elementShouldBeHidden( element ) {
 	return ! (
 		element.tagName === 'SCRIPT' ||
 		element.hasAttribute( 'hidden' ) ||
-		element.hasAttribute( 'aria-hidden' ) ||
+		( element.hasAttribute( 'aria-hidden' ) &&
+			! isBatchHidden( element ) ) ||
 		element.hasAttribute( 'aria-live' ) ||
 		( role && LIVE_REGION_ARIA_ROLES.has( role ) )
 	);
+}
+
+/**
+ * Determines whether an element's `aria-hidden` was set by an active batch,
+ * as opposed to authored markup or another mechanism.
+ *
+ * @param {Element} element The element to check.
+ *
+ * @return {boolean} Whether a current batch hid the element.
+ */
+function isBatchHidden( element ) {
+	return hiddenElementBatches.some( ( batch ) => batch.has( element ) );
 }
 
 /**
@@ -113,11 +140,9 @@ export function elementShouldBeHidden( element ) {
  * settings menu can be open together—and React runs effect cleanups in
  * hook-declaration order, not reverse-open order.
  *
- * @param {Set<Element>} handle The handle returned by `modalize`. Defaults to
- *                              the most recent batch for backward
- *                              compatibility.
+ * @param {Set<Element>} handle The handle returned by `modalize`.
  */
-export function unmodalize( handle = hiddenElementBatches.at( -1 ) ) {
+export function unmodalize( handle ) {
 	const index = hiddenElementBatches.lastIndexOf( handle );
 	if ( index === -1 ) {
 		return;

--- a/src/components/editor-toolbar/aria-helper.js
+++ b/src/components/editor-toolbar/aria-helper.js
@@ -1,6 +1,11 @@
 /**
  * This file was sourced from the Gutenberg project and converted from
- * TypeScript to JavaScript.
+ * TypeScript to JavaScript, then diverged from it. `modalize` walks each
+ * modal element's ancestor path rather than only `document.body`'s children,
+ * because our popovers render into slots nested within body-level containers
+ * rather than as direct body children. `unmodalize` reverses a batch by the
+ * handle `modalize` returns rather than popping the most recent one, because
+ * our modals do not always close in reverse-open order.
  *
  * @see https://github.com/WordPress/gutenberg/blob/3f0a805c568f92622faf4b71b24eeb5f39b5bca8/packages/components/src/modal/aria-helper.ts
  */

--- a/src/components/editor-toolbar/aria-helper.js
+++ b/src/components/editor-toolbar/aria-helper.js
@@ -17,28 +17,59 @@ const hiddenElementsByDepth = [];
 
 /**
  * Hides all elements in the body element from screen-readers except
- * the provided element and elements that should not be hidden from
- * screen-readers.
+ * the provided elements, their ancestors, and elements that should not be
+ * hidden from screen-readers.
+ *
+ * Elements are hidden by walking from each modal element up to the body and
+ * hiding the other children of every ancestor along the way. Hiding only the
+ * body's children would be insufficient, as a modal element is not
+ * necessarily a body child—popovers render into slots nested within
+ * body-level containers.
  *
  * The reason we do this is because `aria-modal="true"` currently is bugged
  * in Safari, and support is spotty in other browsers overall. In the future
  * we should consider removing these helper functions in favor of
  * `aria-modal="true"`.
  *
- * @param {Element} modalElement The element that should not be hidden.
+ * @param {...Element} modalElements The elements that should not be hidden.
  */
-export function modalize( modalElement ) {
-	const elements = Array.from( document.body.children );
+export function modalize( ...modalElements ) {
 	const hiddenElements = [];
 	hiddenElementsByDepth.push( hiddenElements );
-	for ( const element of elements ) {
-		if ( element === modalElement ) {
-			continue;
-		}
 
-		if ( elementShouldBeHidden( element ) ) {
-			element.setAttribute( 'aria-hidden', 'true' );
-			hiddenElements.push( element );
+	const elements = modalElements.filter(
+		( element ) => element?.isConnected
+	);
+	// Ancestors of a modal element must stay accessible, otherwise the modal
+	// element is hidden along with them.
+	const visibleElements = new Set();
+	for ( const modalElement of elements ) {
+		for (
+			let element = modalElement;
+			element && element !== document.body;
+			element = element.parentElement
+		) {
+			visibleElements.add( element );
+		}
+	}
+
+	for ( const modalElement of elements ) {
+		for (
+			let element = modalElement;
+			element?.parentElement && element !== document.body;
+			element = element.parentElement
+		) {
+			for ( const sibling of element.parentElement.children ) {
+				if (
+					visibleElements.has( sibling ) ||
+					! elementShouldBeHidden( sibling )
+				) {
+					continue;
+				}
+
+				sibling.setAttribute( 'aria-hidden', 'true' );
+				hiddenElements.push( sibling );
+			}
 		}
 	}
 }

--- a/src/components/editor-toolbar/index.jsx
+++ b/src/components/editor-toolbar/index.jsx
@@ -27,6 +27,7 @@ import { store as editorStore } from '@wordpress/editor';
 import './style.scss';
 import { useModalize } from './use-modalize';
 import { useModalDialogState } from '../editor/use-modal-dialog-state';
+import { OVERLAY_SLOT_NAME } from '../popover-slots/containers';
 import { getGBKit } from '../../utils/bridge';
 import NativeInserter from '../native-inserter';
 import { useScrollIndicators } from './use-scroll-indicators';
@@ -147,6 +148,12 @@ const EditorToolbar = ( { className } ) => {
 					onClose={ onCloseSettings }
 					onFocusOutside={ onFocusOutside }
 					role="dialog"
+					// Render outside the container clipping popovers to the
+					// viewport. This menu fills the viewport and never
+					// overflows, and WebKit renders a `position: fixed`
+					// element semi-transparent when an ancestor clips its
+					// overflow. See `../popover-slots`.
+					__unstableSlotName={ OVERLAY_SLOT_NAME }
 				>
 					<>
 						<div className="block-settings-menu__header">

--- a/src/components/editor-toolbar/test/aria-helper.test.js
+++ b/src/components/editor-toolbar/test/aria-helper.test.js
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+
+/**
+ * Internal dependencies
+ */
+import { modalize, unmodalize } from '../aria-helper';
+
+const ariaHidden = ( id ) =>
+	document.getElementById( id ).getAttribute( 'aria-hidden' );
+
+afterEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'modalize / unmodalize', () => {
+	it( 'hides siblings outside the modal element and reveals them on unmodalize', () => {
+		document.body.innerHTML = `
+			<div id="root">editor</div>
+			<div id="modal"><span id="modal-child">m</span></div>
+		`;
+		const handle = modalize( document.getElementById( 'modal' ) );
+
+		expect( ariaHidden( 'root' ) ).toBe( 'true' );
+		expect( ariaHidden( 'modal' ) ).toBe( null );
+
+		unmodalize( handle );
+		expect( ariaHidden( 'root' ) ).toBe( null );
+	} );
+
+	it( 'keeps shared siblings hidden until every overlapping modal is reversed', () => {
+		// Both modals keep the same two containers reachable and therefore hide
+		// the same siblings—the real call pattern once `useModalize` always
+		// modalizes the clip and overlay containers.
+		document.body.innerHTML = `
+			<div id="root">editor</div>
+			<div id="clip"></div>
+			<div id="overlay"></div>
+		`;
+		const clip = document.getElementById( 'clip' );
+		const overlay = document.getElementById( 'overlay' );
+
+		const first = modalize( clip, overlay );
+		const second = modalize( clip, overlay );
+
+		// The second modal records #root even though the first already hid it.
+		expect( ariaHidden( 'root' ) ).toBe( 'true' );
+		expect( second.has( document.getElementById( 'root' ) ) ).toBe( true );
+
+		// Closing the first modal while the second is open must NOT reveal #root.
+		unmodalize( first );
+		expect( ariaHidden( 'root' ) ).toBe( 'true' );
+
+		// Closing the last modal reveals it.
+		unmodalize( second );
+		expect( ariaHidden( 'root' ) ).toBe( null );
+	} );
+
+	it( 'reverses batches by identity regardless of close order', () => {
+		document.body.innerHTML = `
+			<div id="root">editor</div>
+			<div id="clip"></div>
+			<div id="overlay"></div>
+		`;
+		const clip = document.getElementById( 'clip' );
+		const overlay = document.getElementById( 'overlay' );
+
+		const first = modalize( clip, overlay );
+		const second = modalize( clip, overlay );
+
+		// Close in the SAME order they opened (not reverse); still correct.
+		unmodalize( first );
+		expect( ariaHidden( 'root' ) ).toBe( 'true' );
+		unmodalize( second );
+		expect( ariaHidden( 'root' ) ).toBe( null );
+	} );
+
+	it( 'never reveals an element hidden by authored markup, not a batch', () => {
+		document.body.innerHTML = `
+			<div id="root" aria-hidden="true">pre-hidden</div>
+			<div id="modal"><span id="modal-child">m</span></div>
+		`;
+		const handle = modalize( document.getElementById( 'modal' ) );
+
+		// #root was already aria-hidden and no batch owns it, so it is left
+		// alone and not recorded.
+		expect( handle.has( document.getElementById( 'root' ) ) ).toBe( false );
+
+		unmodalize( handle );
+		// Its authored aria-hidden survives.
+		expect( ariaHidden( 'root' ) ).toBe( 'true' );
+	} );
+
+	it( 'does not hide live regions or scripts', () => {
+		document.body.innerHTML = `
+			<div id="modal">m</div>
+			<div id="status" role="status">status</div>
+			<div id="live" aria-live="polite">live</div>
+		`;
+		const handle = modalize( document.getElementById( 'modal' ) );
+
+		expect( ariaHidden( 'status' ) ).toBe( null );
+		expect( ariaHidden( 'live' ) ).toBe( null );
+
+		unmodalize( handle );
+	} );
+
+	it( 'ignores an unknown handle', () => {
+		document.body.innerHTML = `<div id="root">editor</div><div id="modal">m</div>`;
+		const handle = modalize( document.getElementById( 'modal' ) );
+
+		unmodalize( new Set() ); // unknown handle: no-op
+		expect( ariaHidden( 'root' ) ).toBe( 'true' );
+
+		unmodalize( handle );
+		expect( ariaHidden( 'root' ) ).toBe( null );
+	} );
+} );

--- a/src/components/editor-toolbar/use-modalize.js
+++ b/src/components/editor-toolbar/use-modalize.js
@@ -18,9 +18,15 @@ import {
  * Conditionally hides the document from screen readers, except for the
  * element provided—or, by default, the containers popovers render into.
  *
- * Both popover containers are kept accessible rather than the individual open
- * popover. Only one modal popover is open at a time, and neither container
- * holds editor content, so hiding one of them gains nothing.
+ * With no `elementRef`, both popover containers are kept accessible rather than
+ * a single open popover: every editor popover renders into one of the two, and
+ * neither container holds editor content, so keeping both reachable is
+ * harmless. Pass `elementRef` to modalize around a specific element instead—
+ * e.g. a modal mounted outside those containers that should sit above them.
+ *
+ * Multiple modals may be open at once (the block inserter and the block
+ * settings menu, for example), so each call is reversed by the handle
+ * `modalize` returns rather than by close order. See `./aria-helper.js`.
  *
  * @param {boolean}   isModalVisible A boolean indicating whether the modal is visible.
  * @param {RefObject} elementRef     A reference to the DOM element to be modalized.
@@ -32,14 +38,12 @@ export function useModalize( isModalVisible, elementRef ) {
 		}
 
 		const element = elementRef?.current;
-		if ( element ) {
-			ariaHelper.modalize( element );
-		} else {
-			ariaHelper.modalize( getClipContainer(), getOverlayContainer() );
-		}
+		const handle = element
+			? ariaHelper.modalize( element )
+			: ariaHelper.modalize( getClipContainer(), getOverlayContainer() );
 
 		return () => {
-			ariaHelper.unmodalize();
+			ariaHelper.unmodalize( handle );
 		};
 	}, [ elementRef, isModalVisible ] );
 }

--- a/src/components/editor-toolbar/use-modalize.js
+++ b/src/components/editor-toolbar/use-modalize.js
@@ -38,6 +38,16 @@ const popoverFallbackContainerRef = { current: null };
  * `popoverFallbackContainerRef`. It then returns an object with the current
  * `popoverFallbackContainerRef`.
  *
+ * This relies on popovers rendering into Gutenberg's default fallback
+ * container, which is a direct child of the body and a sibling of `#root`.
+ * `modalize` hides every other body child from screen readers while keeping
+ * this container—and thus the active popover—accessible. Do not relocate
+ * popovers into a `Popover.Slot` inside the editor: a slot within `#root`
+ * would place popovers under an element that `modalize` marks inert, hiding
+ * their contents. This is also why the body clips popover overflow (with
+ * `.gutenberg-kit-root` owning vertical scroll) rather than the editor
+ * container. See `../../index.scss`.
+ *
  * @return {Object} An object containing the current `popoverFallbackContainerRef`.
  */
 function defaultPopover() {

--- a/src/components/editor-toolbar/use-modalize.js
+++ b/src/components/editor-toolbar/use-modalize.js
@@ -7,57 +7,39 @@ import { useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import * as ariaHelper from './aria-helper';
+import {
+	getClipContainer,
+	getOverlayContainer,
+} from '../popover-slots/containers';
 
 /** @typedef {import('@wordpress/element').RefObject} RefObject */
 
 /**
- * Conditionally applies the `aria-hidden` attribute to all direct decendents of
- * the body element, except for the element provided.
+ * Conditionally hides the document from screen readers, except for the
+ * element provided—or, by default, the containers popovers render into.
+ *
+ * Both popover containers are kept accessible rather than the individual open
+ * popover. Only one modal popover is open at a time, and neither container
+ * holds editor content, so hiding one of them gains nothing.
  *
  * @param {boolean}   isModalVisible A boolean indicating whether the modal is visible.
  * @param {RefObject} elementRef     A reference to the DOM element to be modalized.
  */
-export function useModalize( isModalVisible, elementRef = defaultPopover() ) {
+export function useModalize( isModalVisible, elementRef ) {
 	useEffect( () => {
-		if ( isModalVisible ) {
-			ariaHelper.modalize( elementRef.current );
-		} else {
-			ariaHelper.unmodalize();
+		if ( ! isModalVisible ) {
+			return;
 		}
+
+		const element = elementRef?.current;
+		if ( element ) {
+			ariaHelper.modalize( element );
+		} else {
+			ariaHelper.modalize( getClipContainer(), getOverlayContainer() );
+		}
+
+		return () => {
+			ariaHelper.unmodalize();
+		};
 	}, [ elementRef, isModalVisible ] );
-}
-
-const popoverFallbackContainerRef = { current: null };
-
-/**
- * Retrieves or initializes the fallback container for popovers.
- *
- * This function checks if the `popoverFallbackContainerRef` is already defined.
- * If not, it attempts to find an element with the class name
- * 'components-popover__fallback-container' in the document and assigns it to
- * `popoverFallbackContainerRef`. It then returns an object with the current
- * `popoverFallbackContainerRef`.
- *
- * This relies on popovers rendering into Gutenberg's default fallback
- * container, which is a direct child of the body and a sibling of `#root`.
- * `modalize` hides every other body child from screen readers while keeping
- * this container—and thus the active popover—accessible. Do not relocate
- * popovers into a `Popover.Slot` inside the editor: a slot within `#root`
- * would place popovers under an element that `modalize` marks inert, hiding
- * their contents. This is also why the body clips popover overflow (with
- * `.gutenberg-kit-root` owning vertical scroll) rather than the editor
- * container. See `../../index.scss`.
- *
- * @return {Object} An object containing the current `popoverFallbackContainerRef`.
- */
-function defaultPopover() {
-	if ( popoverFallbackContainerRef.current ) {
-		return popoverFallbackContainerRef;
-	}
-
-	popoverFallbackContainerRef.current = document.getElementById(
-		'popover-fallback-container'
-	);
-
-	return popoverFallbackContainerRef;
 }

--- a/src/components/editor-toolbar/use-modalize.js
+++ b/src/components/editor-toolbar/use-modalize.js
@@ -12,38 +12,33 @@ import {
 	getOverlayContainer,
 } from '../popover-slots/containers';
 
-/** @typedef {import('@wordpress/element').RefObject} RefObject */
-
 /**
- * Conditionally hides the document from screen readers, except for the
- * element provided—or, by default, the containers popovers render into.
+ * While a modal is visible, hides everything from screen readers except the
+ * containers popovers render into.
  *
- * With no `elementRef`, both popover containers are kept accessible rather than
- * a single open popover: every editor popover renders into one of the two, and
- * neither container holds editor content, so keeping both reachable is
- * harmless. Pass `elementRef` to modalize around a specific element instead—
- * e.g. a modal mounted outside those containers that should sit above them.
+ * Every editor popover renders into one of the two containers, and neither
+ * holds editor content, so keeping both reachable while hiding the rest of the
+ * document is what an open popover needs.
  *
  * Multiple modals may be open at once (the block inserter and the block
  * settings menu, for example), so each call is reversed by the handle
  * `modalize` returns rather than by close order. See `./aria-helper.js`.
  *
- * @param {boolean}   isModalVisible A boolean indicating whether the modal is visible.
- * @param {RefObject} elementRef     A reference to the DOM element to be modalized.
+ * @param {boolean} isModalVisible Whether the modal is visible.
  */
-export function useModalize( isModalVisible, elementRef ) {
+export function useModalize( isModalVisible ) {
 	useEffect( () => {
 		if ( ! isModalVisible ) {
 			return;
 		}
 
-		const element = elementRef?.current;
-		const handle = element
-			? ariaHelper.modalize( element )
-			: ariaHelper.modalize( getClipContainer(), getOverlayContainer() );
+		const handle = ariaHelper.modalize(
+			getClipContainer(),
+			getOverlayContainer()
+		);
 
 		return () => {
 			ariaHelper.unmodalize( handle );
 		};
-	}, [ elementRef, isModalVisible ] );
+	}, [ isModalVisible ] );
 }

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -33,8 +33,10 @@ export default function Layout( props ) {
 			     its own registry, leaving the slots below unreachable and
 			     sending popovers to Gutenberg's fallback container instead. */ }
 			<SlotFillProvider>
-				{ /* Rendered before the editor so the slots exist by the time
-				     popovers look for them. */ }
+				{ /* Rendered ahead of the editor for tidiness. Order is not
+				     load-bearing: slots register via `useLayoutEffect` and
+				     fills resolve through an observable, so Gutenberg
+				     re-parents a fill that happens to mount first. */ }
 				<PopoverSlots />
 				<OfflineIndicator />
 				<AutosaveMonitor autosave={ onEditorContentChanged } />

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -28,15 +28,7 @@ export default function Layout( props ) {
 
 	return (
 		<ErrorBoundary canCopyContent>
-			{ /* Share a single slot-fill registry between the popover slots and
-			     the editor's popovers. `BlockEditorProvider` otherwise creates
-			     its own registry, leaving the slots below unreachable and
-			     sending popovers to Gutenberg's fallback container instead. */ }
 			<SlotFillProvider>
-				{ /* Rendered ahead of the editor for tidiness. Order is not
-				     load-bearing: slots register via `useLayoutEffect` and
-				     fills resolve through an observable, so Gutenberg
-				     re-parents a fill that happens to mount first. */ }
 				<PopoverSlots />
 				<OfflineIndicator />
 				<AutosaveMonitor autosave={ onEditorContentChanged } />

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -3,6 +3,7 @@
  */
 import { ErrorBoundary, AutosaveMonitor } from '@wordpress/editor';
 import { SnackbarNotices } from '@wordpress/notices';
+import { SlotFillProvider } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import Editor from '../editor';
 import { onEditorContentChanged } from '../../utils/bridge';
 import EditorLoadNotice from '../editor-load-notice';
 import OfflineIndicator from '../offline-indicator';
+import PopoverSlots from '../popover-slots';
 import './style.scss';
 
 /**
@@ -26,15 +28,24 @@ export default function Layout( props ) {
 
 	return (
 		<ErrorBoundary canCopyContent>
-			<OfflineIndicator />
-			<AutosaveMonitor autosave={ onEditorContentChanged } />
-			<Editor { ...editorProps }>
-				<SnackbarNotices className="gutenberg-kit-layout__snackbar" />
-			</Editor>
-			<EditorLoadNotice
-				className="gutenberg-kit-layout__load-notice"
-				pluginLoadFailed={ pluginLoadFailed }
-			/>
+			{ /* Share a single slot-fill registry between the popover slots and
+			     the editor's popovers. `BlockEditorProvider` otherwise creates
+			     its own registry, leaving the slots below unreachable and
+			     sending popovers to Gutenberg's fallback container instead. */ }
+			<SlotFillProvider>
+				{ /* Rendered before the editor so the slots exist by the time
+				     popovers look for them. */ }
+				<PopoverSlots />
+				<OfflineIndicator />
+				<AutosaveMonitor autosave={ onEditorContentChanged } />
+				<Editor { ...editorProps }>
+					<SnackbarNotices className="gutenberg-kit-layout__snackbar" />
+				</Editor>
+				<EditorLoadNotice
+					className="gutenberg-kit-layout__load-notice"
+					pluginLoadFailed={ pluginLoadFailed }
+				/>
+			</SlotFillProvider>
 		</ErrorBoundary>
 	);
 }

--- a/src/components/popover-slots/containers.js
+++ b/src/components/popover-slots/containers.js
@@ -1,0 +1,56 @@
+/**
+ * Name of the slot rendering popovers that must not be clipped—namely the
+ * full-screen block settings menu. Pass it to a `Popover` via
+ * `__unstableSlotName`.
+ *
+ * @type {string}
+ */
+export const OVERLAY_SLOT_NAME = 'gutenberg-kit-overlay';
+
+/**
+ * Retrieves the container clipping popovers to the viewport.
+ *
+ * @return {HTMLElement} The clipping container element.
+ */
+export function getClipContainer() {
+	return getContainer( 'popover-clip-container' );
+}
+
+/**
+ * Retrieves the container rendering popovers that must not be clipped.
+ *
+ * @return {HTMLElement} The overlay container element.
+ */
+export function getOverlayContainer() {
+	return getContainer( 'popover-overlay-container' );
+}
+
+const containers = new Map();
+
+/**
+ * Retrieves a body-level popover container by ID, creating it when absent.
+ *
+ * The containers are declared in `index.html` so their styles apply before the
+ * editor mounts. They are created here as a fallback for environments that
+ * render the editor into a different document—e.g. tests.
+ *
+ * @param {string} id The container element ID.
+ *
+ * @return {HTMLElement} The container element.
+ */
+function getContainer( id ) {
+	if ( containers.get( id )?.isConnected ) {
+		return containers.get( id );
+	}
+
+	let container = document.getElementById( id );
+	if ( ! container ) {
+		container = document.createElement( 'div' );
+		container.id = id;
+		document.body.append( container );
+	}
+
+	containers.set( id, container );
+
+	return container;
+}

--- a/src/components/popover-slots/containers.js
+++ b/src/components/popover-slots/containers.js
@@ -25,32 +25,16 @@ export function getOverlayContainer() {
 	return getContainer( 'popover-overlay-container' );
 }
 
-const containers = new Map();
-
 /**
- * Retrieves a body-level popover container by ID, creating it when absent.
+ * Retrieves a body-level popover container by ID.
  *
  * The containers are declared in `index.html` so their styles apply before the
- * editor mounts. They are created here as a fallback for environments that
- * render the editor into a different document—e.g. tests.
+ * editor mounts.
  *
  * @param {string} id The container element ID.
  *
- * @return {HTMLElement} The container element.
+ * @return {HTMLElement|null} The container element, or null if absent.
  */
 function getContainer( id ) {
-	if ( containers.get( id )?.isConnected ) {
-		return containers.get( id );
-	}
-
-	let container = document.getElementById( id );
-	if ( ! container ) {
-		container = document.createElement( 'div' );
-		container.id = id;
-		document.body.append( container );
-	}
-
-	containers.set( id, container );
-
-	return container;
+	return document.getElementById( id );
 }

--- a/src/components/popover-slots/index.jsx
+++ b/src/components/popover-slots/index.jsx
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { createPortal } from '@wordpress/element';
+import { Popover } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import {
+	OVERLAY_SLOT_NAME,
+	getClipContainer,
+	getOverlayContainer,
+} from './containers';
+
+/**
+ * Renders the slots that receive the editor's popovers.
+ *
+ * Popovers otherwise render into Gutenberg's fallback container, a body child
+ * positioned relative to the viewport. A popover anchored near the right
+ * edge—such as the block toolbar's "Options" menu after the toolbar is
+ * scrolled—extends past the viewport and grows the document's scrollable
+ * width, letting the canvas be swiped horizontally to reveal the empty
+ * background behind it.
+ *
+ * Two slots are rendered rather than one because the two kinds of popovers
+ * have opposing requirements:
+ *
+ * - Dropdown popovers must be clipped to the viewport. They render into the
+ *   default slot, which lives in a fixed, `overflow: hidden` container. Being
+ *   out of flow, that container clips the overflow without contributing to
+ *   the document's scrollable size, so the document remains the scroll
+ *   container.
+ * - The full-screen block settings menu must not be clipped. WebKit renders a
+ *   `position: fixed` element semi-transparent when an ancestor clips its
+ *   overflow, so the settings menu opts into its own slot in an unclipped
+ *   container via `__unstableSlotName`. It fills the viewport and never
+ *   overflows, so it does not need clipping.
+ *
+ * Both containers are body children so `modalize` can keep the active popover
+ * accessible while marking the rest of the document inert. See
+ * `../editor-toolbar/use-modalize.js`.
+ *
+ * @return {Element} The rendered popover slots.
+ */
+export default function PopoverSlots() {
+	return (
+		<>
+			{ createPortal( <Popover.Slot />, getClipContainer() ) }
+			{ createPortal(
+				<Popover.Slot name={ OVERLAY_SLOT_NAME } />,
+				getOverlayContainer()
+			) }
+		</>
+	);
+}

--- a/src/components/popover-slots/style.scss
+++ b/src/components/popover-slots/style.scss
@@ -1,0 +1,29 @@
+// Clips popovers to the viewport so they cannot grow the document's
+// scrollable width. `position: fixed` takes the container out of flow, which
+// both sizes it to the viewport and keeps it from contributing to the
+// document's scrollable size—leaving the document as the scroll container.
+//
+// `overflow-x` on the body or the root element does not clip popovers: the
+// value propagates to the viewport rather than clipping out-of-flow
+// descendants. Clipping on `#root` misses them entirely, as popovers render
+// into a sibling of `#root` rather than a descendant.
+#popover-clip-container {
+	inset: 0;
+	overflow: hidden;
+	position: fixed;
+	// The container spans the viewport, so it must not intercept touches
+	// intended for the editor. Popovers within it restore pointer events.
+	pointer-events: none;
+	z-index: 1000000; // Mirrors Gutenberg's `.components-popover` z-index
+}
+
+#popover-clip-container .components-popover {
+	pointer-events: auto;
+}
+
+// Popovers that must not be clipped—see `./index.jsx`. Left out of flow by its
+// popovers alone, which are positioned absolutely or fixed.
+#popover-overlay-container {
+	position: relative;
+	z-index: 1000000; // Mirrors Gutenberg's `.components-popover` z-index
+}

--- a/src/components/popover-slots/style.scss
+++ b/src/components/popover-slots/style.scss
@@ -18,20 +18,26 @@
 	overflow: hidden;
 	position: fixed;
 	// The container spans the viewport, so it must not intercept touches
-	// intended for the editor. Popovers within it restore pointer events.
+	// intended for the editor. Its slot content restores pointer events.
 	pointer-events: none;
 	z-index: 1000001; // One above the overlay container
 }
 
-#popover-clip-container .components-popover {
+// Restore pointer events on the slot content, not only on `.components-popover`
+// roots—a fill may portal in sibling markup that is not itself a popover.
+#popover-clip-container > * {
 	pointer-events: auto;
 }
 
 // Popovers that must not be clipped—namely the full-screen block settings
-// menu. WebKit renders a `position: fixed` element semi-transparent when an
-// ancestor clips its overflow, so this container does not clip. The menu fills
-// the viewport and never overflows, so it does not need clipping. See
-// `./index.jsx`.
+// menu. This container does not clip, so it does not stack a WebKit
+// compositing bug: an `overflow: hidden` ancestor rendered the fixed,
+// full-screen settings menu semi-transparent. (The block inserter is also a
+// fixed, full-screen popover but renders into the clipped container above
+// without that artifact—so the trigger is narrower than any clipped fixed
+// element; the menu is kept clear of clipping as a precaution.) The menu fills
+// the viewport and never overflows, so clipping would gain nothing regardless.
+// See `./index.jsx`.
 #popover-overlay-container {
 	position: relative;
 	z-index: 1000000; // Mirrors Gutenberg's `.components-popover` z-index

--- a/src/components/popover-slots/style.scss
+++ b/src/components/popover-slots/style.scss
@@ -7,6 +7,12 @@
 // value propagates to the viewport rather than clipping out-of-flow
 // descendants. Clipping on `#root` misses them entirely, as popovers render
 // into a sibling of `#root` rather than a descendant.
+//
+// Stacks above the overlay container (below). Dropdowns opened from within the
+// full-screen block settings menu—color and typography controls, etc.—render
+// here, and the settings menu is opaque, so they must paint above it to be
+// visible. They are anchored on-screen within the menu and so stay within the
+// viewport clip.
 #popover-clip-container {
 	inset: 0;
 	overflow: hidden;
@@ -14,15 +20,18 @@
 	// The container spans the viewport, so it must not intercept touches
 	// intended for the editor. Popovers within it restore pointer events.
 	pointer-events: none;
-	z-index: 1000000; // Mirrors Gutenberg's `.components-popover` z-index
+	z-index: 1000001; // One above the overlay container
 }
 
 #popover-clip-container .components-popover {
 	pointer-events: auto;
 }
 
-// Popovers that must not be clipped—see `./index.jsx`. Left out of flow by its
-// popovers alone, which are positioned absolutely or fixed.
+// Popovers that must not be clipped—namely the full-screen block settings
+// menu. WebKit renders a `position: fixed` element semi-transparent when an
+// ancestor clips its overflow, so this container does not clip. The menu fills
+// the viewport and never overflows, so it does not need clipping. See
+// `./index.jsx`.
 #popover-overlay-container {
 	position: relative;
 	z-index: 1000000; // Mirrors Gutenberg's `.components-popover` z-index

--- a/src/index.html
+++ b/src/index.html
@@ -16,5 +16,7 @@
 			id="popover-fallback-container"
 			class="components-popover__fallback-container"
 		></div>
+		<div id="popover-clip-container"></div>
+		<div id="popover-overlay-container"></div>
 	</body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,12 @@
 		<div id="root" class="gutenberg-kit-root"></div>
 		<script type="module" src="/utils/wordpress-i18n.js"></script>
 		<script type="module" src="/index.js"></script>
+		<!--
+			Popovers render into the two containers below, but keep Gutenberg's
+			fallback container: a popover falls back to it when its slot is not
+			yet registered, and Gutenberg locates it by class name
+			(`components-popover__fallback-container`), recreating it if absent.
+		-->
 		<div
 			id="popover-fallback-container"
 			class="components-popover__fallback-container"

--- a/src/index.scss
+++ b/src/index.scss
@@ -28,10 +28,42 @@ body.gutenberg-kit:not(.is-ios) .block-editor-block-list__layout::selection {
 	background-color: revert;
 }
 
+// Prevent dropdown menus and other popovers from causing horizontal overflow
+// of the document. Popovers (e.g. the block toolbar's "Options" menu) render
+// into a fallback container appended to the body and are positioned relative to
+// the viewport. When anchored near the right edge—such as after scrolling the
+// block toolbar—they can extend past the viewport, growing the scrollable width
+// of the root element and letting the canvas be swiped horizontally to reveal
+// the empty background behind it.
+//
+// `contain: paint` clips this overflow at the body (which fills the viewport).
+// The popover lives in the fallback container—a direct child of the body—so
+// clipping must happen at the body; `overflow-x` on the body does not clip it
+// (the value propagates to the viewport rather than clipping out-of-flow
+// descendants), and clipping on `#root` misses it entirely since the fallback
+// container is a sibling of `#root`, not a descendant.
+//
+// We clip here rather than moving popovers into a `Popover.Slot` inside the
+// editor. Popovers must remain in the default fallback container so the
+// modalize helper can mark every other body child inert while keeping the
+// active popover accessible when the block inspector or inserter is open. See
+// `editor-toolbar/use-modalize.js` and `editor-toolbar/aria-helper.js`. A slot
+// inside `#root` would place popovers under an element that gets marked inert,
+// hiding their contents from screen readers.
+body.gutenberg-kit {
+	contain: paint;
+}
+
 .gutenberg-kit-root {
 	display: flex;
 	flex-direction: column;
 	height: 100vh;
+
+	// `contain: paint` on the body would otherwise clip content taller than the
+	// viewport instead of letting it scroll. Give this fixed-height container
+	// its own vertical scroll so that overflowing editor content scrolls here
+	// rather than relying on the (now paint-contained) document to scroll.
+	overflow-y: auto;
 }
 
 .gutenberg-kit {

--- a/src/index.scss
+++ b/src/index.scss
@@ -28,42 +28,10 @@ body.gutenberg-kit:not(.is-ios) .block-editor-block-list__layout::selection {
 	background-color: revert;
 }
 
-// Prevent dropdown menus and other popovers from causing horizontal overflow
-// of the document. Popovers (e.g. the block toolbar's "Options" menu) render
-// into a fallback container appended to the body and are positioned relative to
-// the viewport. When anchored near the right edge—such as after scrolling the
-// block toolbar—they can extend past the viewport, growing the scrollable width
-// of the root element and letting the canvas be swiped horizontally to reveal
-// the empty background behind it.
-//
-// `contain: paint` clips this overflow at the body (which fills the viewport).
-// The popover lives in the fallback container—a direct child of the body—so
-// clipping must happen at the body; `overflow-x` on the body does not clip it
-// (the value propagates to the viewport rather than clipping out-of-flow
-// descendants), and clipping on `#root` misses it entirely since the fallback
-// container is a sibling of `#root`, not a descendant.
-//
-// We clip here rather than moving popovers into a `Popover.Slot` inside the
-// editor. Popovers must remain in the default fallback container so the
-// modalize helper can mark every other body child inert while keeping the
-// active popover accessible when the block inspector or inserter is open. See
-// `editor-toolbar/use-modalize.js` and `editor-toolbar/aria-helper.js`. A slot
-// inside `#root` would place popovers under an element that gets marked inert,
-// hiding their contents from screen readers.
-body.gutenberg-kit {
-	contain: paint;
-}
-
 .gutenberg-kit-root {
 	display: flex;
 	flex-direction: column;
 	height: 100vh;
-
-	// `contain: paint` on the body would otherwise clip content taller than the
-	// viewport instead of letting it scroll. Give this fixed-height container
-	// its own vertical scroll so that overflowing editor content scrolls here
-	// rather than relying on the (now paint-contained) document to scroll.
-	overflow-y: auto;
 }
 
 .gutenberg-kit {


### PR DESCRIPTION
## What?

Opening a block toolbar dropdown menu (e.g. the "Options" more menu) can add horizontal overflow to the editor's root element, letting the canvas be swiped sideways to reveal the empty background behind it.

## Why?

Ref CMM-997.

The editor is not iframed on mobile, so the whole editor lives in a single document. Block toolbar popovers render into a fallback container appended to `<body>` and are positioned relative to the viewport. When a popover is anchored near the right edge—such as after scrolling the block toolbar so the toggle sits at the far right—it extends past the viewport. Because nothing clips horizontal overflow on `<html>`/`<body>`/`#root`, this grows the scrollable width of the root element, and the canvas can be swiped horizontally to reveal the empty background behind the editor styles wrapper.

Measured with the menu open on a 375px-wide viewport: the popover's right edge lands at 419px (44px past the viewport), `html.scrollWidth` grows to 419 while `clientWidth` stays 375, and only `<html>` becomes horizontally scrollable.

## How?

Render popovers into slots within body-level containers, split by whether the popover needs clipping:

- **Dropdown popovers** use the default slot, placed in a `position: fixed; inset: 0; overflow: hidden` container. Being out of flow, it clips the overflow without contributing to the document's scrollable size, so the document remains the scroll container. The container spans the viewport, so it sets `pointer-events: none` and its slot content restores `pointer-events: auto`.
- **The full-screen block settings menu** opts into its own slot in an unclipped container via `__unstableSlotName`. It fills the viewport and never overflows, so it does not need clipping. It is also kept clear of a clipping ancestor as a precaution: with an earlier clipping approach the menu rendered semi-transparent in WebKit (editor content bleeding through). The exact trigger is narrower than "any `position: fixed` element under a clipped ancestor"—the block inserter is also fixed and full-screen and renders into the clipped container with no such artifact (verified on device)—but the menu gains nothing from clipping, so keeping it in an unclipped slot sidesteps the risk entirely.

Both containers are body children, so `modalize` can keep the active popover accessible while marking the rest of the document inert. The clip container is stacked one above the overlay container (`z-index`). Dropdowns opened from within the settings menu—color and typography controls, etc.—render into the default (clipped) slot; stacking the clip container above the opaque menu keeps them visible. They are anchored on-screen within the menu, so clipping them to the viewport is harmless. Routing them into the overlay slot instead is not possible: they arrive through the `InspectorControls` slot-fill, which renders them in the fill's own React context—outside any slot-name provider wrapped around `BlockInspector`—so a context override does not reach them.

A few supporting changes:

- **`modalize` now walks the ancestor path.** It previously hid only `document.body`'s children, which assumed the modal element was itself a body child—true for the fallback container, not for a popover nested in a slot. It now walks from each modal element up to the body, hiding the other children of every ancestor, collecting ancestors first so they are never hidden. It accepts multiple modal elements, and returns a handle so `unmodalize` reverses that specific batch by identity rather than assuming modals close in reverse-open order—the inserter and settings menu can be open at once, and React runs effect cleanups in hook-declaration order.
- **The layout is wrapped in a `SlotFillProvider`** so the slots and the editor's popovers share one registry. `BlockEditorProvider` renders `<SlotFillProvider passthrough>`, which creates its own registry when no provider exists above it, leaving the slots unreachable and silently sending popovers back to the fallback container.

Copying additional context from https://github.com/wordpress-mobile/GutenbergKit/pull/562#discussion_r3685373688 for posterity: 

> These styles [`src/components/popover-slots/style.scss` and the corresponding `Popover.Slot`s are the crux of the solution to the overflow problem. All other changes are adapting existing logic for compatibility with the new DOM structure. 
> 
> Essentially, we now have two separate "slots" in which popovers are rendered: one for popovers that need clipping to avoid horizontal body overflow receive (`#popover-clip-container`); another for all others that do not and operate the same as before (`#popover-overlay-container`). 
> 
> The problem is unique to GutenbergKit, in comparison to web editor, in that the former pursues relying upon `body` element scrolling to preserve iOS' tap-status-bar-to-scroll-to-top behavior. The web does not pursue this—instead relying upon children element scrolling—and can easily forcibly clip `body` overflow without concern for breaking the ability scrolling post content. Tapping the status bar when using the web editor does not scroll to the top. 

### Alternatives considered

`contain: paint` on the body (the previous approach in this PR) clips the overflow, but it also stops the document from scrolling content taller than the viewport. Restoring vertical scroll on `.gutenberg-kit-root` moves the scroll off the document, which **breaks iOS status-bar-tap scroll-to-top**—that gesture only drives the web view's main scroll view. Both rules are reverted here, so the document is the scroll container again.

`overflow-x: hidden`/`clip` on `html`/`body` does not clip out-of-flow popovers at all (the value propagates to the viewport), and clipping on `#root` misses them entirely since the fallback container is a sibling of `#root`, not a descendant.

## Testing Instructions

1. Run the iOS demo app and open an editor with theme styles (e.g. a site with a non-white editor background).
2. Focus the first empty placeholder Paragraph block.
3. Scroll the block toolbar to the end to reveal the more menu (three-dots) toggle, and tap it to open the menu.
4. Scroll the block toolbar back to its beginning so the expanded menu is at least partially off screen.
5. Swipe horizontally (right to left) on the editor canvas beneath the focused block.
6. Confirm the canvas stays put and no empty/background band is revealed on the right. (On `trunk`, the canvas shifts left and reveals the root element's background.)

Please also confirm the following, as they cover the constraints this approach had to satisfy:

7. Open the block settings menu (cog). Confirm it renders fully opaque, with no editor content bleeding through.
8. Within the open settings menu, tap the Text and Background color swatches, the Color and Typography options (three-dots) menus, and the font-size custom-size control. Confirm each dropdown appears on top of the menu.
9. Add enough content to overflow the viewport and confirm it scrolls, then **tap the status bar and confirm the editor scrolls to the top**.
10. Open the block inserter and the block settings menu and confirm both still dismiss via outside tap and close button.

### Accessibility Testing Instructions

Popovers now render into slots rather than Gutenberg's fallback container, and `modalize` was refactored to match, so the inert behaviour from #145 is worth re-checking with VoiceOver:

1. Open the block inserter (or the block settings menu) with VoiceOver enabled.
2. Confirm the popover's contents are reachable and announced.
3. Confirm swiping past the popover does not reach the editor canvas or toolbar behind it.
4. Dismiss the popover and confirm the editor content becomes reachable again.

Verified in the DOM: with a popover open, `#root` is `aria-hidden="true"` while both popover containers, the popover's ancestor chain, and the `aria-live` regions are untouched; dismissing removes every attribute that was added.

## Screenshots or screencast

<!-- Before/after screencasts to be attached. -->


Before | After |
-- | -- 
<video src="https://github.com/user-attachments/assets/a9c4af1f-a0a3-45ec-99bb-9e67557edb57" /> | <video src="https://github.com/user-attachments/assets/0199ec84-2738-4441-835d-c54c93e5e916" />
