### PR TITLE
fix: restore text selection highlight on Android

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -12,26 +12,16 @@ $baseline-interactive-font-size: 17px;
 	margin: 0;
 }
 
-// Restore the text selection highlight within the block canvas.
-//
 // Gutenberg hides `::selection` on the block list container behind a
-// Safari-only selector hack. Our production CSS minification splits that hack's
-// selector list apart, leaving behind a plain rule that Chromium honors--and
-// since Chromium 134 ships CSS highlight inheritance, the transparent
-// background propagates to every descendant, erasing the highlight throughout
-// the canvas on Android.
+// Safari-only selector hack, which our CSS minification flattens into a plain
+// rule Chromium honors. Since Chromium 134 ships highlight inheritance, that
+// transparent background reaches every descendant and erases the selection
+// highlight on Android.
 //
-// Overriding at the container preserves the inheritance chain, so Gutenberg's
-// own `::selection` rules--multi-block selection, dragging, non-editable rich
-// text--continue to apply to their descendants. Excluded on iOS, where the
-// upstream hack still serves its intended purpose.
-//
-// `revert` rolls the declaration back to the user agent origin, restoring the
-// platform's own selection color rather than pinning a fixed one. That keeps
-// the canvas consistent with the post title and code editor, which sit outside
-// the container and are unaffected.
-//
-// See: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-list/content.scss
+// Reverting at the container--rather than on descendants--keeps the inheritance
+// chain intact for Gutenberg's other `::selection` rules. Left alone on iOS,
+// where the hack still works as intended.
+// https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-list/content.scss
 body.gutenberg-kit:not(.is-ios) .block-editor-block-list__layout::selection {
 	background-color: revert;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -12,6 +12,30 @@ $baseline-interactive-font-size: 17px;
 	margin: 0;
 }
 
+// Restore the text selection highlight within the block canvas.
+//
+// Gutenberg hides `::selection` on the block list container behind a
+// Safari-only selector hack. Our production CSS minification splits that hack's
+// selector list apart, leaving behind a plain rule that Chromium honors--and
+// since Chromium 134 ships CSS highlight inheritance, the transparent
+// background propagates to every descendant, erasing the highlight throughout
+// the canvas on Android.
+//
+// Overriding at the container preserves the inheritance chain, so Gutenberg's
+// own `::selection` rules--multi-block selection, dragging, non-editable rich
+// text--continue to apply to their descendants. Excluded on iOS, where the
+// upstream hack still serves its intended purpose.
+//
+// `revert` rolls the declaration back to the user agent origin, restoring the
+// platform's own selection color rather than pinning a fixed one. That keeps
+// the canvas consistent with the post title and code editor, which sit outside
+// the container and are unaffected.
+//
+// See: https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-list/content.scss
+body.gutenberg-kit:not(.is-ios) .block-editor-block-list__layout::selection {
+	background-color: revert;
+}
+
 .gutenberg-kit-root {
 	display: flex;
 	flex-direction: column;

--- a/src/index.scss
+++ b/src/index.scss
@@ -14,13 +14,15 @@ $baseline-interactive-font-size: 17px;
 
 // Gutenberg hides `::selection` on the block list container behind a
 // Safari-only selector hack, which our CSS minification flattens into a plain
-// rule Chromium honors. Since Chromium 134 ships highlight inheritance, that
-// transparent background reaches every descendant and erases the selection
-// highlight on Android.
+// rule every engine honors. Since Chromium 134 ships highlight inheritance,
+// that transparent background reaches every descendant and erases the
+// selection highlight on Android.
 //
-// Reverting at the container--rather than on descendants--keeps the inheritance
-// chain intact for Gutenberg's other `::selection` rules. Left alone on iOS,
-// where the hack still works as intended.
+// Reverting at the container--not on descendants--keeps the inheritance chain
+// intact for Gutenberg's other `::selection` rules. The leading `body` is
+// required; without it this ties upstream's `[data-has-multi-selection]`
+// variant and loses on source order. Excluded on iOS only because WebKit has
+// yet to ship highlight inheritance--if it does, drop `:not(.is-ios)`.
 // https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-list/content.scss
 body.gutenberg-kit:not(.is-ios) .block-editor-block-list__layout::selection {
 	background-color: revert;


### PR DESCRIPTION
Fixes [CMM-2186](https://linear.app/a8c/issue/CMM-2186/android-text-selection-isnt-highlighted).

## What?

Restores the text selection highlight in the block canvas on Android. One CSS rule.

## Why?

Selecting text on Android showed the selection handles but no highlight background. iOS was unaffected.

Gutenberg hides `::selection` on the block list container behind a [Safari-only selector hack](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-list/content.scss), which relies on `_:future` being an unknown pseudo-class so the whole selector list is invalid outside WebKit. **Our production CSS minification splits that selector list apart**, leaving behind a plain rule Chromium honors:

```css
:root .block-editor-block-list__layout::selection,…{background-color:#0000}
```

Chromium 134 then shipped [CSS highlight inheritance](https://developer.chrome.com/blog/selection-styling), so that transparent background propagates to every descendant — erasing the highlight across the whole canvas. WebKit hasn't shipped highlight inheritance, so on iOS the rule still affects only the container, exactly as the hack intends. Hence Android-only.

Note this means **the bug only reproduces in production builds** — the dev server doesn't minify CSS, so the hack stays intact there.

## How?

Overrides the declaration at the same container the broken rule targets, rather than on descendants. That preserves the inheritance chain, so Gutenberg's own `::selection` rules (multi-block selection, dragging, non-editable rich text) still reach their descendants unchanged.

`revert` rolls back to the user agent origin, restoring the platform's native selection color instead of pinning a fixed one — which also keeps the canvas consistent with the post title and code editor, which sit outside the container and were never broken.

Specificity `(0,3,2)` beats both leaked rules regardless of source order; the leading `body` is load-bearing. `revert` shipped in Chrome 84 and the bug needs Chromium ≥134, so it can't silently fail back to invisible selection.

## Testing Instructions

The bug does **not** reproduce on the dev server. Use a production build.

1. `make build`, run the Android demo app on WebView ≥ 134.
2. Select text in a paragraph — highlight is visible.
3. Select across bold/italic/link spans, and in a nested block (Group/Columns) — highlight is continuous.
4. Multi-select blocks — still shows the block overlay, not per-text highlight.
5. Drag a block — no stray highlight.
6. On iOS, confirm selection appearance is unchanged from `trunk`.

Verified locally in Chromium 145 by extracting the real rules from the built bundle and measuring rendered pixels:

| case | highlight |
| --- | --- |
| native default | `rgb(224,224,224)` 5021px |
| leaked rule only (bug) | **none** |
| leaked + this fix | `rgb(224,224,224)` 5021px |
| leaked + this fix, `is-ios` | none (upstream hack still governs) |

Row 3 is pixel-identical to row 1. Multi-selected / `.is-dragging` / `[contenteditable=false]` descendants all confirmed still suppressed.

### Accessibility Testing Instructions

Selection highlight is a visual affordance for sighted users; this restores the platform default rather than introducing a custom color, so contrast matches the OS. No change to focus order or semantics.

## Follow-up (not in this PR)

The root cause is that our CSS minification mangles upstream's Safari hack. That could silently affect other hack-guarded upstream rules. Worth a separate issue — rebuilding with `build.cssMinify: false` restores the hack, confirming the culprit.
