### PR TITLE
Fix: keep the caret clear of the editor toolbar while typing

### DIFF
--- a/src/components/visual-editor/style.scss
+++ b/src/components/visual-editor/style.scss
@@ -1,3 +1,20 @@
+// Space reserved for the fixed toolbar overlaying the bottom of the viewport.
+$toolbar-height: 56px;
+
+// The toolbar is `position: fixed`, so it is out of flow and the browser has no
+// idea it covers the bottom of the scrollport. Without matching scroll padding,
+// the caret reveal that follows each keystroke stops as soon as the caret
+// reaches the bottom edge--parking it behind the toolbar--so text typed at the
+// bottom of the editor disappears as you write it.
+//
+// This applies to the root element because the document is the scroll container:
+// `.editor-styles-wrapper` sets `overflow: auto` inline, but `.gutenberg-kit-editor`
+// grows past the `100vh` root, leaving that wrapper with no scroll range. Move
+// this alongside `padding-bottom` below if the canvas ever becomes the scroller.
+:root {
+	scroll-padding-bottom: $toolbar-height;
+}
+
 .gutenberg-kit-visual-editor {
 	box-sizing: border-box;
 	flex-shrink: 0;
@@ -22,7 +39,7 @@
 
 .gutenberg-kit-visual-editor .editor-styles-wrapper {
 	// Ensure the toolbar does not overlap the content
-	padding-bottom: 56px;
+	padding-bottom: $toolbar-height;
 	// Remove outline to mirror default user agent styles for body elements, which
 	// is the element used for Gutenberg's iframed editor
 	outline: none;

--- a/src/components/visual-editor/style.scss
+++ b/src/components/visual-editor/style.scss
@@ -1,16 +1,11 @@
 // Space reserved for the fixed toolbar overlaying the bottom of the viewport.
 $toolbar-height: 56px;
 
-// The toolbar is `position: fixed`, so it is out of flow and the browser has no
-// idea it covers the bottom of the scrollport. Without matching scroll padding,
-// the caret reveal that follows each keystroke stops as soon as the caret
-// reaches the bottom edge--parking it behind the toolbar--so text typed at the
-// bottom of the editor disappears as you write it.
-//
-// This applies to the root element because the document is the scroll container:
-// `.editor-styles-wrapper` sets `overflow: auto` inline, but `.gutenberg-kit-editor`
-// grows past the `100vh` root, leaving that wrapper with no scroll range. Move
-// this alongside `padding-bottom` below if the canvas ever becomes the scroller.
+// The toolbar is `position: fixed`, so the browser cannot see it covering the
+// bottom of the scrollport and parks the caret behind it while typing. Set on
+// the root because the document is the scroller: `.editor-styles-wrapper` is
+// `overflow: auto`, but `.gutenberg-kit-editor` grows past the `100vh` root and
+// leaves it with no scroll range.
 :root {
 	scroll-padding-bottom: $toolbar-height;
 }

--- a/src/components/visual-editor/style.scss
+++ b/src/components/visual-editor/style.scss
@@ -1,15 +1,3 @@
-// Space reserved for the fixed toolbar overlaying the bottom of the viewport.
-$toolbar-height: 56px;
-
-// The toolbar is `position: fixed`, so the browser cannot see it covering the
-// bottom of the scrollport and parks the caret behind it while typing. Set on
-// the root because the document is the scroller: `.editor-styles-wrapper` is
-// `overflow: auto`, but `.gutenberg-kit-editor` grows past the `100vh` root and
-// leaves it with no scroll range.
-:root {
-	scroll-padding-bottom: $toolbar-height;
-}
-
 .gutenberg-kit-visual-editor {
 	box-sizing: border-box;
 	flex-shrink: 0;
@@ -33,8 +21,6 @@ $toolbar-height: 56px;
 }
 
 .gutenberg-kit-visual-editor .editor-styles-wrapper {
-	// Ensure the toolbar does not overlap the content
-	padding-bottom: $toolbar-height;
 	// Remove outline to mirror default user agent styles for body elements, which
 	// is the element used for Gutenberg's iframed editor
 	outline: none;

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,10 +1,17 @@
 @use "@wordpress/base-styles/variables" as wordpress;
 
 $baseline-interactive-font-size: 17px;
+// Space reserved for the fixed toolbar overlaying the bottom of the viewport.
+$toolbar-height: 56px;
 
 // Reasonable defaults used when theme styles are unavailable
 :root {
 	--wp--style--global--content-size: 645px;
+}
+
+html {
+	// Ensure the toolbar does not overlap the editor content
+	scroll-padding-bottom: $toolbar-height;
 }
 
 :where(body.gutenberg-kit) {


### PR DESCRIPTION
Fixes [CMM-2189](https://linear.app/a8c/issue/CMM-2189/android-editor-doesnt-scroll-when-typing-at-the-bottom).

## What?

Adds `scroll-padding-bottom` to the root element so the browser's caret reveal stops above the fixed editor toolbar instead of behind it.

## Why?

Typing at the bottom of the editor on Android hid the line being written.

The toolbar is `position: fixed`, so it is out of flow and the browser cannot see that it covers the bottom of the scrollport. The caret reveal that runs after each keystroke stops as soon as the caret reaches the bottom edge — which is behind the toolbar.

## Testing Instructions

1. Open a post with enough content to overflow the viewport.
2. Tap into the last block and raise the keyboard.
3. Press Enter and type repeatedly.

**Before:** the line being typed slides behind the block toolbar and the editor only scrolls every third line.
**After:** the caret stays above the toolbar on every line.

Also check that manual scrolling still reaches the true bottom of the content, and that dismissing the keyboard restores the viewport with no leftover gap.

Verified on a Pixel 7 emulator in both the GutenbergKit demo app and Jetpack Android. This has **not** been tested on iOS.
