### PR TITLE
fix: build REST URLs for sites using plain permalinks

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/EditorAssetsLibrary.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/EditorAssetsLibrary.kt
@@ -39,7 +39,7 @@ class EditorAssetsLibrary(
     suspend fun loadManifestContent(headers: Map<String, String> = emptyMap()): String =
         withContext(Dispatchers.IO) {
             val endpoint = configuration.editorAssetsEndpoint
-                ?: "${configuration.siteApiRoot}wpcom/v2/editor-assets"
+                ?: configuration.siteApiRoot.appendingRestPath("/wpcom/v2/editor-assets")
 
             val connection = URL(endpoint).openConnection() as HttpURLConnection
             try {

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/RESTAPIRepository.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/RESTAPIRepository.kt
@@ -23,7 +23,7 @@ class RESTAPIRepository(
 ) {
     private val json = Json { ignoreUnknownKeys = true }
 
-    private val apiRoot = configuration.siteApiRoot.trimEnd('/')
+    private val apiRoot = configuration.siteApiRoot
     private val namespace = configuration.siteApiNamespace.firstOrNull()?.let {
         it.trimEnd('/') + "/"
     }
@@ -225,16 +225,25 @@ class RESTAPIRepository(
      * the result is `$apiRoot/wp/v2/sites/123/types`.
      */
     private fun buildNamespacedUrl(path: String): String {
+        return apiRoot.appendingRestPath(namespacedPath(path))
+    }
+
+    /**
+     * Inserts the site API namespace after the version segment of [path], returning [path]
+     * unchanged when no namespace is configured.
+     */
+    private fun namespacedPath(path: String): String {
         if (namespace == null) {
-            return "$apiRoot$path"
+            return path
         }
 
         val parts = path.removePrefix("/").split("/", limit = 3)
-        if (parts.size < 3) {
-            return "$apiRoot$path"
+        if (parts.size < 2) {
+            return path
         }
 
-        return "$apiRoot/${parts[0]}/${parts[1]}/$namespace${parts[2]}"
+        val remainder = parts.getOrNull(2).orEmpty()
+        return "/${parts[0]}/${parts[1]}/$namespace$remainder"
     }
 
     companion object {

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/StringExtensions.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/StringExtensions.kt
@@ -29,7 +29,10 @@ fun String.encodeForEditor(): String {
  * ```
  *
  * This mirrors the behavior of `@wordpress/api-fetch`'s root URL middleware, which the web
- * layer uses, so native and web requests resolve to the same endpoints.
+ * layer uses, for the canonical `?rest_route=/` root, so native and web requests resolve to the
+ * same endpoints. For a root supplied without a trailing slash the two intentionally diverge:
+ * this keeps the leading slash on the route value, which WordPress's `rest_route` matching
+ * expects, whereas the middleware strips it.
  *
  * @param path The endpoint path to append. May or may not start with a slash.
  * @return The full endpoint URL.

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/StringExtensions.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/StringExtensions.kt
@@ -13,3 +13,41 @@ import java.net.URLEncoder
 fun String.encodeForEditor(): String {
     return URLEncoder.encode(this, "UTF-8").replace("+", "%20")
 }
+
+/**
+ * Appends a REST API endpoint path to this API root.
+ *
+ * Handles slash normalization between the root and the path, ensuring exactly one slash
+ * separates them.
+ *
+ * When the root is a query-based REST root — as used by sites with plain permalinks,
+ * e.g. `https://example.com/?rest_route=/` — the path is appended to the query value rather
+ * than the URL path, and any query string on [path] is merged with `&`:
+ *
+ * ```
+ * https://example.com/?rest_route=/ + /wp/v2/media -> https://example.com/?rest_route=/wp/v2/media
+ * ```
+ *
+ * This mirrors the behavior of `@wordpress/api-fetch`'s root URL middleware, which the web
+ * layer uses, so native and web requests resolve to the same endpoints.
+ *
+ * @param path The endpoint path to append. May or may not start with a slash.
+ * @return The full endpoint URL.
+ */
+fun String.appendingRestPath(path: String): String {
+    // A query-based root already carries the REST route in its query string, so the path is
+    // concatenated onto that value and its own query separator becomes `&`.
+    if (contains("?")) {
+        val merged = path.replaceFirst("?", "&")
+
+        // The route value must keep exactly one leading slash regardless of whether the root
+        // was supplied as `?rest_route=/` or `?rest_route=`.
+        return if (endsWith("/")) {
+            this + merged.removePrefix("/")
+        } else {
+            this + if (merged.startsWith("/")) merged else "/$merged"
+        }
+    }
+
+    return trimEnd('/') + if (path.startsWith("/")) path else "/$path"
+}

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/stores/EditorAssetsLibrary.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/stores/EditorAssetsLibrary.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.wordpress.gutenberg.EditorHTTPClient
 import org.wordpress.gutenberg.EditorHTTPClientProtocol
+import org.wordpress.gutenberg.appendingRestPath
 import org.wordpress.gutenberg.model.EditorAssetBundle
 import org.wordpress.gutenberg.model.EditorCachePolicy
 import org.wordpress.gutenberg.model.EditorConfiguration
@@ -265,14 +266,15 @@ class EditorAssetsLibrary(
     // MARK: - Helpers
 
     private fun editorAssetsUrl(configuration: EditorConfiguration): String {
-        val baseUrl = configuration.siteApiRoot.trimEnd('/')
         val namespace = configuration.siteApiNamespace.firstOrNull()
 
-        return if (namespace != null) {
-            "$baseUrl/wpcom/v2/${namespace}editor-assets?exclude=core,gutenberg"
-        } else {
-            "$baseUrl/wpcom/v2/editor-assets?exclude=core,gutenberg"
-        }
+        return configuration.siteApiRoot.appendingRestPath(
+            if (namespace != null) {
+                "/wpcom/v2/${namespace}editor-assets?exclude=core,gutenberg"
+            } else {
+                "/wpcom/v2/editor-assets?exclude=core,gutenberg"
+            }
+        )
     }
 
     /**

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/RESTAPIRepositoryTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/RESTAPIRepositoryTest.kt
@@ -341,6 +341,84 @@ class RESTAPIRepositoryTest {
         assertEquals(expectedURLs, capturedURLs.toSet())
     }
 
+    /**
+     * Sites using plain permalinks have no path-based REST root, so WordPress advertises the
+     * query form `https://example.com/?rest_route=/` instead.
+     */
+    @Test
+    fun `endpoints are appended to the route of a query-based API root`() = runBlocking {
+        val capturedURLs = mutableListOf<String>()
+        val capturingClient = createCapturingClient { capturedURLs.add(it) }
+
+        val configuration = EditorConfiguration.builder(
+            TEST_SITE_URL,
+            "https://example.com/?rest_route=/",
+            PostTypeDetails.post
+        ).setPlugins(true).setThemeStyles(true).setAuthHeader("Bearer test").build()
+
+        val cache = EditorURLCache(cacheRoot, EditorCachePolicy.Always)
+        val repository = RESTAPIRepository(configuration, capturingClient, cache)
+
+        repository.fetchPost(id = 1)
+        repository.fetchPostType("post")
+        repository.fetchActiveTheme()
+        repository.fetchPostTypes()
+
+        val expectedURLs = setOf(
+            "https://example.com/?rest_route=/wp/v2/posts/1&context=edit",
+            "https://example.com/?rest_route=/wp/v2/types/post&context=edit",
+            "https://example.com/?rest_route=/wp/v2/themes&context=edit&status=active",
+            "https://example.com/?rest_route=/wp/v2/types&context=view"
+        )
+
+        assertEquals(expectedURLs, capturedURLs.toSet())
+    }
+
+    @Test
+    fun `URLs are normalized when query-based API root has no trailing slash`() = runBlocking {
+        val capturedURLs = mutableListOf<String>()
+        val capturingClient = createCapturingClient { capturedURLs.add(it) }
+
+        val configuration = EditorConfiguration.builder(
+            TEST_SITE_URL,
+            "https://example.com/?rest_route=",  // No trailing slash
+            PostTypeDetails.post
+        ).setPlugins(true).setThemeStyles(true).setAuthHeader("Bearer test").build()
+
+        val cache = EditorURLCache(cacheRoot, EditorCachePolicy.Always)
+        val repository = RESTAPIRepository(configuration, capturingClient, cache)
+
+        repository.fetchPost(id = 1)
+
+        assertEquals(
+            setOf("https://example.com/?rest_route=/wp/v2/posts/1&context=edit"),
+            capturedURLs.toSet()
+        )
+    }
+
+    @Test
+    fun `namespace is inserted into a query-based API root`() = runBlocking {
+        val capturedURLs = mutableListOf<String>()
+        val capturingClient = createCapturingClient { capturedURLs.add(it) }
+
+        val configuration = EditorConfiguration.builder(
+            TEST_SITE_URL,
+            "https://example.com/?rest_route=/",
+            PostTypeDetails.post
+        ).setPlugins(true).setThemeStyles(true).setAuthHeader("Bearer test")
+            .setSiteApiNamespace(arrayOf("sites/123/")).build()
+
+        val cache = EditorURLCache(cacheRoot, EditorCachePolicy.Always)
+        val repository = RESTAPIRepository(configuration, capturingClient, cache)
+
+        repository.fetchPost(id = 1)
+
+        assertEquals(
+            setOf("https://example.com/?rest_route=/wp/v2/sites/123/posts/1&context=edit"),
+            capturedURLs.toSet()
+        )
+    }
+
     @Test
     fun `namespace is inserted into URLs`() = runBlocking {
         val capturedURLs = mutableListOf<String>()

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/StringExtensionsTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/StringExtensionsTest.kt
@@ -58,7 +58,7 @@ class StringExtensionsTest {
     }
 
     @Test
-    fun `normalizes a query-based API root without a trailing slash`() {
+    fun `keeps exactly one leading slash when the API root omits its trailing slash`() {
         assertEquals(
             "https://example.com/?rest_route=/wp/v2/media",
             "https://example.com/?rest_route=".appendingRestPath("/wp/v2/media")

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/StringExtensionsTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/StringExtensionsTest.kt
@@ -1,0 +1,75 @@
+package org.wordpress.gutenberg
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StringExtensionsTest {
+
+    // MARK: - Path-based API Roots
+
+    @Test
+    fun `appends path when API root has no trailing slash`() {
+        assertEquals(
+            "https://example.com/wp-json/wp/v2/media",
+            "https://example.com/wp-json".appendingRestPath("/wp/v2/media")
+        )
+    }
+
+    @Test
+    fun `appends path when API root has trailing slash`() {
+        assertEquals(
+            "https://example.com/wp-json/wp/v2/media",
+            "https://example.com/wp-json/".appendingRestPath("/wp/v2/media")
+        )
+    }
+
+    @Test
+    fun `appends path without a leading slash`() {
+        assertEquals(
+            "https://example.com/wp-json/wp/v2/media",
+            "https://example.com/wp-json".appendingRestPath("wp/v2/media")
+        )
+    }
+
+    @Test
+    fun `preserves the query string of an appended path`() {
+        assertEquals(
+            "https://example.com/wp-json/wp/v2/themes?context=edit&status=active",
+            "https://example.com/wp-json".appendingRestPath("/wp/v2/themes?context=edit&status=active")
+        )
+    }
+
+    // MARK: - Query-based API Roots (plain permalinks)
+
+    @Test
+    fun `appends path to the route of a query-based API root`() {
+        assertEquals(
+            "https://example.com/?rest_route=/wp/v2/media",
+            "https://example.com/?rest_route=/".appendingRestPath("/wp/v2/media")
+        )
+    }
+
+    @Test
+    fun `merges the path query string into a query-based API root`() {
+        assertEquals(
+            "https://example.com/?rest_route=/wp/v2/themes&context=edit&status=active",
+            "https://example.com/?rest_route=/".appendingRestPath("/wp/v2/themes?context=edit&status=active")
+        )
+    }
+
+    @Test
+    fun `normalizes a query-based API root without a trailing slash`() {
+        assertEquals(
+            "https://example.com/?rest_route=/wp/v2/media",
+            "https://example.com/?rest_route=".appendingRestPath("/wp/v2/media")
+        )
+    }
+
+    @Test
+    fun `appends path without a leading slash to a query-based API root`() {
+        assertEquals(
+            "https://example.com/?rest_route=/wp/v2/media",
+            "https://example.com/?rest_route=/".appendingRestPath("wp/v2/media")
+        )
+    }
+}

--- a/ios/Sources/GutenbergKit/Sources/Extensions/Foundation+Extensions.swift
+++ b/ios/Sources/GutenbergKit/Sources/Extensions/Foundation+Extensions.swift
@@ -56,7 +56,13 @@ extension URL {
     /// ```
     ///
     /// This mirrors the behavior of `@wordpress/api-fetch`'s root URL middleware, which the web
-    /// layer uses, so native and web requests resolve to the same endpoints.
+    /// layer uses, for the canonical `?rest_route=/` root, so native and web requests resolve to
+    /// the same endpoints. For a root supplied without a trailing slash the two intentionally
+    /// diverge: this keeps the leading slash on the route value, which WordPress's `rest_route`
+    /// matching expects, whereas the middleware strips it.
+    ///
+    /// File URLs are always treated as plain paths, so a query string in a local path is never
+    /// mistaken for a query-based REST root.
     ///
     /// - Parameter rawPath: The path to append. May or may not start with a slash.
     /// - Returns: A new URL with the path appended.
@@ -65,7 +71,7 @@ extension URL {
 
         // A query-based root already carries the REST route in its query string, so the path is
         // concatenated onto that value and its own query separator becomes `&`.
-        if urlString.contains("?") {
+        if !isFileURL && urlString.contains("?") {
             let path = rawPath.replacingFirstOccurrence(of: "?", with: "&")
 
             // The route value must keep exactly one leading slash regardless of whether the root

--- a/ios/Sources/GutenbergKit/Sources/Extensions/Foundation+Extensions.swift
+++ b/ios/Sources/GutenbergKit/Sources/Extensions/Foundation+Extensions.swift
@@ -47,10 +47,35 @@ extension URL {
     /// This method handles slash normalization between the base URL and the path being appended,
     /// ensuring exactly one slash separates them.
     ///
+    /// When the base URL is a query-based REST root — as used by sites with plain permalinks,
+    /// e.g. `https://example.com/?rest_route=/` — the path is appended to the query value rather
+    /// than the URL path, and any query string on `rawPath` is merged with `&`:
+    ///
+    /// ```
+    /// https://example.com/?rest_route=/ + /wp/v2/media -> https://example.com/?rest_route=/wp/v2/media
+    /// ```
+    ///
+    /// This mirrors the behavior of `@wordpress/api-fetch`'s root URL middleware, which the web
+    /// layer uses, so native and web requests resolve to the same endpoints.
+    ///
     /// - Parameter rawPath: The path to append. May or may not start with a slash.
     /// - Returns: A new URL with the path appended.
     func appending(rawPath: String) -> URL {
         let urlString = self.absoluteString
+
+        // A query-based root already carries the REST route in its query string, so the path is
+        // concatenated onto that value and its own query separator becomes `&`.
+        if urlString.contains("?") {
+            let path = rawPath.replacingFirstOccurrence(of: "?", with: "&")
+
+            // The route value must keep exactly one leading slash regardless of whether the root
+            // was supplied as `?rest_route=/` or `?rest_route=`.
+            if urlString.hasSuffix("/") {
+                return URL(string: urlString + path.trimmingPrefix("/"))!
+            }
+
+            return URL(string: urlString + (path.hasPrefix("/") ? path : "/" + path))!
+        }
 
         if urlString.hasSuffix("/") && rawPath.hasPrefix("/") {
             return URL(string: urlString + rawPath.trimmingPrefix("/"))!
@@ -99,6 +124,18 @@ extension Data {
 // MARK: - String Extensions
 
 extension String {
+    /// Replaces only the first occurrence of `target` with `replacement`.
+    ///
+    /// Used when merging a path's query string into a query-based REST root, where only the
+    /// leading `?` becomes `&` and any subsequent `&` separators are left untouched.
+    func replacingFirstOccurrence(of target: String, with replacement: String) -> String {
+        guard let range = self.range(of: target) else {
+            return self
+        }
+
+        return self.replacingCharacters(in: range, with: replacement)
+    }
+
     /// Calculates SHA1 from the given string and returns its hex representation.
       ///
       /// ```swift

--- a/ios/Sources/GutenbergKit/Sources/Stores/EditorAssetLibrary.swift
+++ b/ios/Sources/GutenbergKit/Sources/Stores/EditorAssetLibrary.swift
@@ -199,10 +199,10 @@ public actor EditorAssetLibrary {
         } else if let namespace = configuration.siteApiNamespace.first {
             // Insert namespace: /wpcom/v2/editor-assets -> /wpcom/v2/sites/123/editor-assets
             baseUrl = configuration.siteApiRoot
-                .appending(path: "/wpcom/v2/\(namespace)editor-assets")
+                .appending(rawPath: "/wpcom/v2/\(namespace)editor-assets")
         } else {
             baseUrl = configuration.siteApiRoot
-                .appending(path: "/wpcom/v2/editor-assets")
+                .appending(rawPath: "/wpcom/v2/editor-assets")
         }
         return baseUrl.appending(queryItems: [URLQueryItem(name: "exclude", value: "core,gutenberg")])
     }

--- a/ios/Tests/GutenbergKitTests/Extensions/FoundationTests.swift
+++ b/ios/Tests/GutenbergKitTests/Extensions/FoundationTests.swift
@@ -263,8 +263,8 @@ struct URLAppendingRawPathTests {
         == "https://example.com/?rest_route=/wp/v2/themes&context=edit&status=active")
   }
 
-  @Test("normalizes a query-based REST root without a trailing slash")
-  func normalizesQueryBasedRootWithoutTrailingSlash() {
+  @Test("keeps exactly one leading slash when the REST root omits its trailing slash")
+  func keepsOneLeadingSlashWhenRootOmitsTrailingSlash() {
     let base = URL(string: "https://example.com/?rest_route=")!
     let result = base.appending(rawPath: "/wp/v2/media")
     #expect(result.absoluteString == "https://example.com/?rest_route=/wp/v2/media")
@@ -275,6 +275,16 @@ struct URLAppendingRawPathTests {
     let base = URL(string: "https://example.com/?rest_route=/")!
     let result = base.appending(rawPath: "wp/v2/media")
     #expect(result.absoluteString == "https://example.com/?rest_route=/wp/v2/media")
+  }
+
+  @Test("treats a file URL containing a query character as a plain path")
+  func treatsFileURLWithQueryCharacterAsPlainPath() {
+    // `URL(fileURLWithPath:)` would percent-encode the `?`, so build the URL from a string to
+    // keep the literal character that the query-based REST root branch looks for. The appended
+    // path carries its own `?`, which that branch would rewrite to `&`.
+    let base = URL(string: "file:///tmp/assets/site?name")!
+    let result = base.appending(rawPath: "styles?v=2")
+    #expect(result.absoluteString == "file:///tmp/assets/site?name/styles?v=2")
   }
 
   // MARK: - Special Characters

--- a/ios/Tests/GutenbergKitTests/Extensions/FoundationTests.swift
+++ b/ios/Tests/GutenbergKitTests/Extensions/FoundationTests.swift
@@ -245,11 +245,36 @@ struct URLAppendingRawPathTests {
     #expect(result.absoluteString == "https://example.com/api/posts?context=edit&per_page=10")
   }
 
-  @Test("preserves query parameters in base URL when appending path")
-  func preservesBaseQueryParameters() {
-    let base = URL(string: "https://example.com/api?token=abc")!
-    let result = base.appending(rawPath: "posts")
-    #expect(result.absoluteString == "https://example.com/api?token=abc/posts")
+  // MARK: - Query-based REST Roots (plain permalinks)
+
+  @Test("appends path to the query value of a query-based REST root")
+  func appendsPathToQueryBasedRoot() {
+    let base = URL(string: "https://example.com/?rest_route=/")!
+    let result = base.appending(rawPath: "/wp/v2/media")
+    #expect(result.absoluteString == "https://example.com/?rest_route=/wp/v2/media")
+  }
+
+  @Test("merges the path's query string into a query-based REST root")
+  func mergesQueryIntoQueryBasedRoot() {
+    let base = URL(string: "https://example.com/?rest_route=/")!
+    let result = base.appending(rawPath: "/wp/v2/themes?context=edit&status=active")
+    #expect(
+      result.absoluteString
+        == "https://example.com/?rest_route=/wp/v2/themes&context=edit&status=active")
+  }
+
+  @Test("normalizes a query-based REST root without a trailing slash")
+  func normalizesQueryBasedRootWithoutTrailingSlash() {
+    let base = URL(string: "https://example.com/?rest_route=")!
+    let result = base.appending(rawPath: "/wp/v2/media")
+    #expect(result.absoluteString == "https://example.com/?rest_route=/wp/v2/media")
+  }
+
+  @Test("appends path without a leading slash to a query-based REST root")
+  func appendsPathWithoutLeadingSlashToQueryBasedRoot() {
+    let base = URL(string: "https://example.com/?rest_route=/")!
+    let result = base.appending(rawPath: "wp/v2/media")
+    #expect(result.absoluteString == "https://example.com/?rest_route=/wp/v2/media")
   }
 
   // MARK: - Special Characters

--- a/ios/Tests/GutenbergKitTests/Services/RESTAPIRepositoryTests.swift
+++ b/ios/Tests/GutenbergKitTests/Services/RESTAPIRepositoryTests.swift
@@ -292,6 +292,66 @@ struct RESTAPIRepositoryTests: MakesTestFixtures {
         let urls = mockClient.requestedURLs.map(\.absoluteString)
         #expect(urls.contains { $0.contains("sites/123/posts/1") })
     }
+
+    // MARK: - Query-based API Root Tests (plain permalinks)
+
+    /// Sites using plain permalinks have no path-based REST root, so WordPress advertises the
+    /// query form `https://example.com/?rest_route=/` instead.
+    @Test("endpoints are appended to the route of a query-based API root")
+    func endpointsAreAppendedToQueryBasedApiRoot() async throws {
+        let mockClient = EditorAssetLibraryMockHTTPClient()
+        let configuration = makeQueryRootConfiguration()
+        let repository = makeRepository(configuration: configuration, httpClient: mockClient)
+
+        // Using try? because the mock returns empty data that fails decoding.
+        // We only care about the URLs that were requested, not the responses.
+        _ = try? await repository.fetchPost(id: 1)
+        _ = try? await repository.fetchEditorSettings()
+        _ = try? await repository.fetchSettingsOptions()
+        _ = try? await repository.fetchActiveTheme()
+        _ = try? await repository.fetchPostTypes()
+
+        let urls = Set(mockClient.requestedURLs.map(\.absoluteString))
+        #expect(urls.contains("https://example.com/?rest_route=/wp/v2/posts/1&context=edit"))
+        #expect(
+            urls.contains("https://example.com/?rest_route=/wp-block-editor/v1/settings"))
+        #expect(urls.contains("https://example.com/?rest_route=/wp/v2/settings"))
+        #expect(
+            urls.contains(
+                "https://example.com/?rest_route=/wp/v2/themes&context=edit&status=active"))
+        #expect(urls.contains("https://example.com/?rest_route=/wp/v2/types&context=view"))
+    }
+
+    @Test("namespace is inserted into a query-based API root")
+    func namespaceIsInsertedIntoQueryBasedApiRoot() async throws {
+        let mockClient = EditorAssetLibraryMockHTTPClient()
+        let configuration = makeQueryRootConfiguration(siteApiNamespace: ["sites/123/"])
+        let repository = makeRepository(configuration: configuration, httpClient: mockClient)
+
+        // Using try? because the mock returns empty data that fails decoding.
+        // We only care about the URLs that were requested, not the responses.
+        _ = try? await repository.fetchPost(id: 1)
+        _ = try? await repository.fetchSettingsOptions()
+
+        let urls = Set(mockClient.requestedURLs.map(\.absoluteString))
+        #expect(
+            urls.contains("https://example.com/?rest_route=/wp/v2/sites/123/posts/1&context=edit"))
+        #expect(urls.contains("https://example.com/?rest_route=/wp/v2/sites/123/settings"))
+    }
+
+    private func makeQueryRootConfiguration(
+        siteApiNamespace: [String] = []
+    ) -> EditorConfiguration {
+        EditorConfigurationBuilder(
+            postType: .post,
+            siteURL: Self.testSiteURL,
+            siteApiRoot: URL(string: "https://example.com/?rest_route=/")!,
+            siteApiNamespace: siteApiNamespace
+        )
+        .setShouldUseThemeStyles(true)
+        .setAuthHeader("Bearer test-token")
+        .build()
+    }
 }
 
 // MARK: - URL Capturing Mock Client


### PR DESCRIPTION
## What?

Teaches the native REST URL builders to address sites that use **plain permalinks**, where the only REST root is the query form `https://site/?rest_route=/`.

Stacks on #572 (the wordpress-rs 0.6.0 bump), so it targets `build/bump-wordpress-rs-0.6.0` rather than `trunk`.

Fixes #563. Fixes CMM-2177. 

## Why?

A site with plain permalinks has no path-based REST root — `/wp-json/` depends on the rewrite rules that plain permalinks disable, so WordPress advertises `?rest_route=/` instead. Both hosts hand that root straight to GutenbergKit (`EditorConfiguration+Blog.swift` on iOS, `GutenbergKitSettingsBuilder.kt` on Android) after discovering it from the site's `https://api.w.org/` Link header, so it reaches every native URL builder verbatim.

Those builders appended the endpoint to the **path**, which produced malformed URLs for every native endpoint — editor settings, active theme, site settings, post types, the post itself, and editor assets.

Worth noting the iOS failure was **silent, not a 404**. Verified against a live plain-permalink site:

```
GET https://site/wp/v2/settings?rest_route=/   -> 200 {"name":…,"namespaces":[…]}   # the REST API index
GET https://site/?rest_route=/wp/v2/settings   -> 200 {"title":…,"date_format":…}   # the actual settings
```

The trailing `?rest_route=/` routes to the API root and the path is ignored, so the editor received the wrong resource and failed later at decode time with no indication the URL was wrong. On Android the two query-carrying endpoints did 404 outright.

WP.com sites are unaffected — they use the path-based `public-api.wordpress.com/` proxy.

## How?

Both platforms mirror the algorithm in `@wordpress/api-fetch`'s root URL middleware, which the web layer already uses (and which is why JS requests work today on these sites): when the root carries a query, append the endpoint to it and merge the path's own query string with `&`.

- **iOS** — `URL.appending(rawPath:)` (`Foundation+Extensions.swift`), the primitive every iOS REST URL bottoms out in. `EditorAssetLibrary` used stock `URL.appending(path:)`, which had the same defect, so it now routes through the same primitive.
- **Android** — new `String.appendingRestPath` (`StringExtensions.kt`), replacing the `trimEnd('/')`-plus-concat in `RESTAPIRepository` and both asset libraries. Namespace insertion is split into `namespacedPath()` so the path transform and the root join are separate concerns.

The fix lives in the **join primitive** rather than in namespace insertion deliberately: two of the three Android call sites (and the iOS asset library) build their URLs without going through namespacing, so they would otherwise stay broken.

Also aligns a pre-existing platform divergence in namespace insertion — iOS namespaced two-segment paths (`components.count >= 2`) where Android bailed (`parts.size < 3`); Android now matches iOS.

### Note for #357 / #561

#357 introduces `WordPressRESTURL.namespaced` (iOS) and `RestUrlBuilder.namespaced` (Android). This branch and that one merge without textual conflict, but two things need coordinating — details in https://github.com/wordpress-mobile/GutenbergKit/pull/357#issuecomment-5147477576:

- iOS composes cleanly (`WordPressRESTURL.namespaced` already calls `appending(rawPath:)` on every path), but Android's `RestUrlBuilder.namespaced` needs to delegate its join to `appendingRestPath`, or a clean merge silently reverts the Android fix.
- `mediaEndpointURL` needs `&` merging on both platforms before it works on a query root.

## Testing Instructions

Requires a self-hosted site set to **Settings ▸ Permalinks ▸ Plain**. Confirm it advertises the query-form root first:

```
curl -sI https://your-site.com/ | grep -i '^link'
```

The `rel="https://api.w.org/"` value should contain `?rest_route=/` rather than `/wp-json/`.

1. Build the demo app on either platform and add the site using an application password.
2. Open the Editor Configuration screen and confirm the API Root row shows the `?rest_route=` form.
3. Open a post in the editor.

Check that:

- The post's existing content loads (`/wp/v2/posts/{id}`).
- The editor picks up theme styles — colors and fonts match the site's theme rather than defaults (`/wp-block-editor/v1/settings` and `/wp/v2/themes`). **This is the highest-value check**: the themes endpoint is the only one carrying its own query string, so it's what exercises the `?`→`&` merge.
- The block inserter is populated (`/wp/v2/types`).
- Saving and publishing work.

Enable **Network Logging** in the site-preparation screen to inspect the request URLs directly — they should read `?rest_route=/wp/v2/…`, not `/wp/v2/…?rest_route=/`.

Also confirm no regression on a pretty-permalink site and a WP.com site.

### Accessibility Testing Instructions

N/A — no user interface changes.
