### PR TITLE
fix(android): submit the add site dialog from the keyboard

### DIFF
--- a/android/app/src/main/java/com/example/gutenbergkit/ui/dialogs/ConfigurationDialogs.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/ui/dialogs/ConfigurationDialogs.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
@@ -14,8 +15,13 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.example.gutenbergkit.R
@@ -27,6 +33,12 @@ fun AddConfigurationDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.add_wordpress_site)) },
@@ -37,9 +49,13 @@ fun AddConfigurationDialog(
                 label = { Text(stringResource(R.string.site_url)) },
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Uri
+                    keyboardType = KeyboardType.Uri,
+                    imeAction = ImeAction.Go
                 ),
-                modifier = Modifier.fillMaxWidth()
+                keyboardActions = KeyboardActions(onGo = { onConfirm() }),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester)
             )
         },
         confirmButton = {

--- a/android/app/src/main/java/com/example/gutenbergkit/ui/dialogs/ConfigurationDialogs.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/ui/dialogs/ConfigurationDialogs.kt
@@ -33,16 +33,18 @@ fun AddConfigurationDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    val focusRequester = remember { FocusRequester() }
-
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
-
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.add_wordpress_site)) },
         text = {
+            // Scoped to the dialog's subcomposition so the focus target is
+            // attached by the time focus is requested.
+            val focusRequester = remember { FocusRequester() }
+
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+
             OutlinedTextField(
                 value = siteUrlInput,
                 onValueChange = onSiteUrlChange,


### PR DESCRIPTION
## What?

Pressing Return in the Android demo app's "Add WordPress site" dialog did nothing, and the URL field did not take focus when the dialog opened.

## Why?

Adding a site in the emulator required reaching for the mouse: tap the field to focus it, type the URL, then tap "Add" — Return was silently ignored. The field set a `keyboardType` but no `imeAction`, so Compose defaulted the single-line field to `ImeAction.Default` with no `keyboardActions` handler to receive it, leaving the Return key nothing to dispatch to. On a physical device the "Add" button makes this easy to miss; in the emulator, where the host keyboard is the natural input, the gap is obvious.

## How?

- Declare `ImeAction.Go` on the URL field and route it to the existing `onConfirm` callback. `Go` matches the semantics of a URL field and renders as a "Go" key on the software keyboard. Reusing `onConfirm` rather than duplicating the submit logic means the existing `isNotBlank()` guard in `MainActivity` still applies, so an empty field is a no-op, and keyboard and button submission can't drift apart.
- Focus the field with a `FocusRequester` in a `LaunchedEffect(Unit)`, keyed to the composable's lifetime so focus is requested on entry and not re-requested on recomposition while typing.

## Testing Instructions

1. Run the demo app in an emulator.
2. Tap the "Add new site" card.
3. Confirm the URL field is focused with the caret visible, without tapping it.
4. Type a site URL using the host keyboard and press Return.
5. Confirm the dialog submits and site discovery begins.
6. Reopen the dialog and confirm the field is focused again.
7. With the field empty, press Return and confirm nothing happens and the dialog stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
