### PR TITLE
refactor(ios): use wordpress-rs connectivity error helpers

### DIFF
--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.pbxproj
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.pbxproj
@@ -573,8 +573,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/wordpress-rs";
 			requirement = {
-				kind = revision;
-				revision = d70c99e1ff38772353bd8f6a81879320990a560e;
+				kind = exactVersion;
+				version = 0.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.pbxproj
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.pbxproj
@@ -573,8 +573,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/wordpress-rs";
 			requirement = {
-				branch = "pr-build/1488";
-				kind = branch;
+				kind = revision;
+				revision = d70c99e1ff38772353bd8f6a81879320990a560e;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.pbxproj
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.pbxproj
@@ -573,8 +573,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/wordpress-rs";
 			requirement = {
-				kind = exactVersion;
-				version = 0.6.0;
+				branch = "pr-build/1488";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "revision" : "2525759228b0b5ba0379671354399cf8ede8d0a3",
-        "version" : "0.6.0"
+        "branch" : "pr-build/1488",
+        "revision" : "290cfaca4171591b0d0579485e1ab8990536580f"
       }
     }
   ],

--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "pr-build/1488",
-        "revision" : "290cfaca4171591b0d0579485e1ab8990536580f"
+        "revision" : "d70c99e1ff38772353bd8f6a81879320990a560e"
       }
     }
   ],

--- a/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Demo-iOS/Gutenberg.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "revision" : "d70c99e1ff38772353bd8f6a81879320990a560e"
+        "revision" : "ce52fb236c0e9acef1ae60e8d4fba0f5fbd11b7d",
+        "version" : "0.7.0"
       }
     }
   ],

--- a/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
+++ b/ios/Demo-iOS/Sources/Views/SitePreparationView.swift
@@ -274,7 +274,7 @@ class SitePreparationViewModel {
                         try await self.loadPostTypes()
                         let newConfiguration = try await self.loadConfiguration(for: account)
                         self.editorConfiguration = Self.applyDemoAppDefaults(to: newConfiguration)
-                    } catch let error where Self.isUnreachableSiteError(error) {
+                    } catch let error as WpApiError where error.isSiteUnreachable {
                         throw AppError(errorDescription: "Could not connect to Local WordPress at localhost:8888.\n\nThe wp-env server may not be running. Start it with 'make wp-env-start'.")
                     }
                 case .account(let account):
@@ -303,7 +303,7 @@ class SitePreparationViewModel {
                         try await self.loadPostTypes()
                         let newConfiguration = try await self.loadConfiguration(for: account)
                         self.editorConfiguration = Self.applyDemoAppDefaults(to: newConfiguration)
-                    } catch let error where Self.isNetworkError(error) {
+                    } catch let error as WpApiError where error.isDeviceOffline {
                         self.postTypes = [.post, .page]
                         let fallback = Self.buildOfflineConfiguration(for: account)
                         self.editorConfiguration = Self.applyDemoAppDefaults(to: fallback)
@@ -320,28 +320,6 @@ class SitePreparationViewModel {
             .setNativeInserterEnabled(true)
             .setLocale(DemoAppLocale.current)
             .build()
-    }
-
-    /// Whether the site could not be reached at all — the host did not resolve
-    /// or refused the connection.
-    ///
-    /// wordpress-rs intercepts the underlying `URLError` and rewraps it as a
-    /// `WpApiError`, so matching `URLError` alone never fires for a site that
-    /// is simply not running.
-    private static func isUnreachableSiteError(_ error: Error) -> Bool {
-        if let wpError = error as? WpApiError,
-           case .RequestExecutionFailed(_, _, .nonExistentSiteError, _, _) = wpError {
-            return true
-        }
-        return error is URLError
-    }
-
-    private static func isNetworkError(_ error: Error) -> Bool {
-        if let wpError = error as? WpApiError,
-           case .RequestExecutionFailed(_, _, .deviceIsOfflineError, _, _) = wpError {
-            return true
-        }
-        return error is URLError
     }
 
     private static func buildOfflineConfiguration(for account: Account) -> EditorConfiguration {


### PR DESCRIPTION
## What?

Replaces the iOS demo app's hand-rolled connectivity error classifiers with the equivalents added to wordpress-rs.

Closes #578.

## Why?

`SitePreparationView` matched `WpApiError.RequestExecutionFailed` with five positional associated values to read a single nested reason — once for "site unreachable", once for "device offline". That is fragile: it breaks whenever `WpApiError` gains a case, and it duplicates knowledge that belongs to wordpress-rs, which creates the distinction in the first place.

Raised in [review feedback on #572](https://github.com/wordpress-mobile/GutenbergKit/pull/572#discussion_r3706841604): "We should probably lower this into wprs on either the Swift or Rust layers."

## How?

Both helpers are deleted and their call sites read the library property directly:

```swift
} catch let error as WpApiError where error.isSiteUnreachable {
```

A typed `catch` does the cast, so no wrapper is needed — and the demo app no longer defines its own vocabulary for a distinction the library already names.

The `error is URLError` fallback goes with them. Every throwing call in the enclosing `do` blocks goes through `WordPressAPI` — `apiRoot.get()` and `postTypes.listWithEditContext()` — so `WpRequestExecutor` has already rewrapped any `URLError` into a `WpApiError` by the time these run. The only remaining `URLSession` reference in the file is the `URLSessionConfiguration` passed _into_ `WordPressAPI`, so the fallback could never fire.

Depends on [Automattic/wordpress-rs#1488](https://github.com/Automattic/wordpress-rs/pull/1488), which adds `isSiteUnreachable` / `isDeviceOffline`.

### Follow-up: Android

#578 also covers bringing the Android demo app to parity — it currently discards the failure reason in `loadPostTypes` and substitutes a hardcoded `post` type, which is why the plain-permalink bug fixed in #572 went unnoticed there. That work is blocked on a wordpress-rs mapping inconsistency: the Kotlin executor maps a refused connection to `HttpError` while Swift maps it to `NonExistentSiteError`, so `isSiteUnreachable` currently answers differently per platform. Details in the "Known limitation" section of #1488.

## Testing Instructions

1. Open `ios/Demo-iOS/Gutenberg.xcodeproj` and let package resolution finish.
2. **Site unreachable** — with wp-env stopped and the network up, open the Local WordPress site. Expect the wp-env guidance: "Could not connect to Local WordPress at localhost:8888…".
3. **Device offline** — with a saved account, enable Airplane Mode and open its Editor Configuration. Expect the screen to load with the offline fallback applied: Network Fallback shows "Automatic", Post Type shows "Post", and Site URL shows the stored API root.
4. **The two are distinct** — with the network up, block the site's host in `/etc/hosts`, then open its Editor Configuration. Expect the error view with "A server with the specified hostname could not be found", _not_ the offline fallback. This confirms `isSiteUnreachable` and `isDeviceOffline` return opposite answers for the same error.

Verified on device: all three behave as described, and a full `xcodebuild` of the demo app succeeds.

### Accessibility Testing Instructions

N/A — no user interface changes. The error and fallback paths are unchanged; only how they are detected differs.
