### PR TITLE
fix(release): strip semver prerelease suffix from framework CFBundleVersion

### DIFF
--- a/build_xcframework.sh
+++ b/build_xcframework.sh
@@ -39,6 +39,19 @@ if [[ -z "${MARKETING_VERSION}" ]]; then
     echo "Error: could not read the version field from package.json (is 'jq' installed and is this the repo root?)" >&2
     exit 1
 fi
+
+# CFBundleVersion allows at most three period-separated non-negative integers,
+# so a SemVer prerelease like `0.19.0-alpha.0` is rejected (altool 90058). No
+# substitution helps — prerelease identifiers are alphanumeric by spec — so
+# strip the prerelease (`-...`) and build-metadata (`+...`) suffixes and stamp
+# the `major.minor.patch` core. CFBundleShortVersionString keeps the full
+# version, which Apple accepts.
+#
+# Reusing a core version across an alpha and its final release is safe:
+# artifacts are identified by git SHA and by CDN URL plus SwiftPM checksum,
+# never by this key.
+BUNDLE_VERSION="${MARKETING_VERSION%%[-+]*}"
+
 BUILD_DIR="$(pwd)/build"
 DERIVED_DATA_PATH="${BUILD_DIR}/DerivedData"
 
@@ -173,7 +186,7 @@ build_framework() {
     <key>CFBundleShortVersionString</key>
     <string>${MARKETING_VERSION}</string>
     <key>CFBundleVersion</key>
-    <string>${MARKETING_VERSION}</string>
+    <string>${BUNDLE_VERSION}</string>
     <key>MinimumOSVersion</key>
     <string>${MINIMUM_IOS_VERSION}</string>
 </dict>
@@ -279,8 +292,14 @@ verify_framework_plist() {
         echo "Error: ${plist}: CFBundleShortVersionString='${short_version}' does not match package.json version '${MARKETING_VERSION}'" >&2
         exit 1
     fi
-    if [[ "${bundle_version}" != "${MARKETING_VERSION}" ]]; then
-        echo "Error: ${plist}: CFBundleVersion='${bundle_version}' does not match package.json version '${MARKETING_VERSION}'" >&2
+    if [[ "${bundle_version}" != "${BUNDLE_VERSION}" ]]; then
+        echo "Error: ${plist}: CFBundleVersion='${bundle_version}' does not match expected '${BUNDLE_VERSION}' (derived from package.json version '${MARKETING_VERSION}')" >&2
+        exit 1
+    fi
+    # Assert Apple's grammar directly, not just agreement with package.json: a
+    # value can track the release perfectly and still be rejected on upload.
+    if [[ ! "${bundle_version}" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]; then
+        echo "Error: ${plist}: CFBundleVersion='${bundle_version}' must be at most three period-separated non-negative integers (altool 90058)" >&2
         exit 1
     fi
     if [[ "${min_os}" != "${MINIMUM_IOS_VERSION}" ]]; then


### PR DESCRIPTION
## What?

`CFBundleVersion` in the `GutenbergKitResources` framework `Info.plist` was stamped with the raw `package.json` version, so prerelease versions produced an invalid value.

## Why?

Alpha releases of GutenbergKit break WordPress-iOS's TestFlight upload. `altool` rejects the build:

> This bundle is invalid. The value for key CFBundleVersion [0.19.0-alpha.0] in the Info.plist file must be a period-separated list of at most three non-negative integers. (90058)

`CFBundleVersion` has a stricter grammar than `CFBundleShortVersionString`: at most three period-separated non-negative integers. `make release VERSION_TYPE=prerelease` produces `-alpha.N` versions routinely, so every alpha reproduces this.

The suffix cannot be reshaped to fit — SemVer prerelease identifiers are alphanumeric by spec, so `0.19.0.alpha.0` is equally invalid. It has to be dropped.

Failing build: https://buildkite.com/automattic/wordpress-ios/builds/33627

## How?

-   Derive `BUNDLE_VERSION` by stripping the prerelease (`-…`) and build-metadata (`+…`) suffixes, and stamp that into `CFBundleVersion`. `CFBundleShortVersionString` keeps the full version, which Apple accepts and which preserves the exact release in the shipped framework.
-   Assert Apple's grammar in `verify_framework_plist`. The gate previously only checked the plist matched `package.json`, so an illegal-but-matching value passed here and failed three hops downstream — precisely what the gate exists to prevent.

Reusing a core version across an alpha and its final release is safe: artifacts are identified by git SHA (`package_xcframework.sh`) and resolved by CDN URL plus SwiftPM checksum (`Package.swift`), never by this key.

## Testing Instructions

1. Set `version` in `package.json` to `0.19.0-alpha.0` (do not commit it — the artifact name is keyed on `HEAD`).
2. Run `make build-resources-xcframework`.
3. Confirm the build succeeds, then print the stamped values for every slice:

```bash
X=$(ls -d build/GutenbergKitResources-*.xcframework | head -1)
for s in "$X"/ios-*; do
  P="$s/GutenbergKitResources.framework/Info.plist"
  echo "$(basename "$s")"
  echo "  short:  $(plutil -extract CFBundleShortVersionString raw -o - "$P")"
  echo "  bundle: $(plutil -extract CFBundleVersion raw -o - "$P")"
done
```

Expected output — `bundle` drops the prerelease suffix, `short` keeps it:

```
ios-arm64
  short:  0.19.0-alpha.0
  bundle: 0.19.0
ios-arm64_x86_64-simulator
  short:  0.19.0-alpha.0
  bundle: 0.19.0
```

4. Restore `package.json` to `0.19.0`, rebuild, and confirm a non-prerelease version stamps `0.19.0` for both keys.

### Accessibility Testing Instructions

N/A — no user-facing UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

