### PR TITLE
fix: recover media uploads that fail server-side post-processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,7 @@ playwright-report/
 wp-env/mu-plugins/*
 !wp-env/mu-plugins/gutenbergkit-cors.php
 !wp-env/mu-plugins/gutenbergkit-jetpack-blocks.php
+!wp-env/mu-plugins/gutenbergkit-media-failure.php
 
 # Claude
 .claude/settings.local.json

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,10 @@ wp-env-clean: ## Stop wp-env and remove downloaded WordPress, plugin, and theme 
 wp-env-android-urls: ## Report whether WordPress emits emulator-reachable URLs, 10.0.2.2 instead of localhost (set via MODE=on|off)
 	@MODE=$(MODE) bash bin/wp-env-android.sh
 
+.PHONY: wp-env-media-failure
+wp-env-media-failure: ## Report the media upload failure simulation mode (MODE=off|recover|always to set it)
+	@MODE=$(MODE) bash bin/wp-env-media-failure.sh
+
 ################################################################################
 # Code Quality Targets
 ################################################################################

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ wp-env-android-urls: ## Report whether WordPress emits emulator-reachable URLs, 
 	@MODE=$(MODE) bash bin/wp-env-android.sh
 
 .PHONY: wp-env-media-failure
-wp-env-media-failure: ## Report the media upload failure simulation mode (MODE=off|recover|always to set it)
+wp-env-media-failure: ## Report the media upload failure simulation mode (set via MODE=off|recover|always)
 	@MODE=$(MODE) bash bin/wp-env-media-failure.sh
 
 ################################################################################

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/HttpServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/HttpServer.kt
@@ -125,6 +125,12 @@ enum class CorsPolicy {
                 "Access-Control-Allow-Origin" to "*",
                 "Access-Control-Allow-Methods" to "GET, POST, PUT, DELETE, OPTIONS",
                 "Access-Control-Allow-Headers" to "Authorization, Relay-Authorization, Content-Type",
+                // Only CORS-safelisted response headers are readable
+                // cross-origin by default. The editor needs to read
+                // `x-wp-upload-attachment-id` off a relayed media upload
+                // response to retry `post-process` and clean up an orphaned
+                // attachment, so it has to be exposed explicitly.
+                "Access-Control-Expose-Headers" to "x-wp-upload-attachment-id",
                 "Access-Control-Max-Age" to "86400"
             )
         }
@@ -179,6 +185,7 @@ private fun HttpResponse.addingHeadersIfAbsent(newHeaders: Map<String, String>):
  *     Access-Control-Allow-Origin: <origin>
  *     Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
  *     Access-Control-Allow-Headers: Authorization, Relay-Authorization, Content-Type
+ *     Access-Control-Expose-Headers: x-wp-upload-attachment-id
  *     Access-Control-Max-Age: 86400
  *
  * Without these headers, browsers will reject the preflight and block

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -321,11 +321,18 @@ internal class MediaUploadServer(
      * the editor retry `post-process` for an upload whose metadata generation
      * fataled server-side, rather than surfacing a permanent failure and leaving
      * an orphaned attachment behind.
+     *
+     * The response's own `Content-Type` wins over the JSON default, matched
+     * case-insensitively — HTTP header names are case-insensitive, and
+     * [HttpResponse] serializes every entry it is given, so a plain map merge
+     * would emit the name twice for a delegate that spells it `content-type`.
      */
     private fun relayResponse(response: MediaUploadResponse): HttpResponse {
+        val hasContentType = response.headers.keys.any { it.lowercase() == "content-type" }
+        val defaults = if (hasContentType) emptyMap() else mapOf("Content-Type" to "application/json")
         return HttpResponse(
             status = response.statusCode,
-            headers = mapOf("Content-Type" to "application/json") + response.headers,
+            headers = defaults + response.headers,
             body = response.body
         )
     }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -222,15 +222,55 @@ internal class MediaUploadServer(
     }
 
     private suspend fun handleRequest(request: HttpRequest): HttpResponse {
-        // Route: only POST /upload is handled. (OPTIONS preflight is answered by
-        // the HTTP library under its permissive CORS policy.) Match on the path
-        // alone — the target carries a query string (e.g. `?_embed`) that the
-        // upload handler relays on to WordPress.
-        if (request.method.uppercase() != "POST" || request.path != "/upload") {
-            return errorResponse(404, "Not found")
+        // Routes: POST /upload, and DELETE /media/<id> for the editor's orphan
+        // cleanup. (OPTIONS preflight is answered by the HTTP library under its
+        // permissive CORS policy.) Match on the path alone — the target carries
+        // a query string (e.g. `?_embed`, `?force=true`) relayed to WordPress.
+        val method = request.method.uppercase()
+
+        if (method == "POST" && request.path == "/upload") {
+            return handleUpload(request)
         }
 
-        return handleUpload(request)
+        if (method == "DELETE") {
+            attachmentIdFromPath(request.path)?.let { attachmentId ->
+                return handleDelete(attachmentId, request.query)
+            }
+        }
+
+        return errorResponse(404, "Not found")
+    }
+
+    /**
+     * The attachment ID in a `/media/<id>` path, or `null` if the path is not one.
+     *
+     * Deliberately narrow: this server relays media operations, not arbitrary
+     * REST requests, so only a numeric attachment ID under `/media/` matches.
+     */
+    private fun attachmentIdFromPath(path: String): String? {
+        val components = path.split("/").filter { it.isNotEmpty() }
+        if (components.size != 2 || components[0] != "media") return null
+        val id = components[1]
+        return if (id.isNotEmpty() && id.all { it.isDigit() }) id else null
+    }
+
+    /**
+     * Relays the editor's orphan cleanup to WordPress.
+     *
+     * Core's media upload middleware deletes the attachment when every
+     * `post-process` retry fails. A cross-origin editor cannot issue that
+     * request directly — api-fetch tunnels `DELETE` as a `POST` carrying
+     * `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
+     * browser blocks it at preflight. Relaying it here lets the cleanup run.
+     */
+    private suspend fun handleDelete(attachmentId: String, query: String): HttpResponse {
+        val uploader = defaultUploader ?: return errorResponse(500, "No uploader configured")
+        return try {
+            relayResponse(uploader.deleteMedia(attachmentId, query))
+        } catch (e: IOException) {
+            Log.e(TAG, "Media deletion failed", e)
+            errorResponse(500, e.message ?: "Deletion failed")
+        }
     }
 
     private suspend fun handleUpload(request: HttpRequest): HttpResponse {
@@ -494,8 +534,26 @@ internal open class DefaultMediaUploader(
      * namespacing (so it matches every other REST URL) and carrying the original
      * request query (e.g. `?_embed`) through to WordPress.
      */
-    private fun mediaEndpointUrl(query: String): String =
-        RestUrlBuilder.namespaced(siteApiRoot, siteApiNamespace.firstOrNull(), "/wp/v2/media") + query
+    private fun mediaEndpointUrl(query: String, attachmentId: String? = null): String {
+        val path = if (attachmentId != null) "/wp/v2/media/$attachmentId" else "/wp/v2/media"
+        return RestUrlBuilder.namespaced(siteApiRoot, siteApiNamespace.firstOrNull(), path) + query
+    }
+
+    /**
+     * Deletes an attachment, relaying WordPress's response verbatim.
+     *
+     * Carries the editor's query through unchanged — core's cleanup sends
+     * `?force=true`, without which WordPress trashes rather than deletes.
+     */
+    open suspend fun deleteMedia(attachmentId: String, query: String): MediaUploadResponse {
+        val request = okhttp3.Request.Builder()
+            .url(mediaEndpointUrl(query, attachmentId))
+            .addHeader("Authorization", authHeader)
+            .delete()
+            .build()
+
+        return performUpload(request)
+    }
 
     open suspend fun upload(
         file: File, mimeType: String, filename: String,

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -38,7 +38,17 @@ class MediaUploadResponse(
      * The raw response body — a WordPress REST attachment on success, or a
      * WordPress REST error object (`{ "code", "message", "data" }`) on failure.
      */
-    val body: ByteArray
+    val body: ByteArray,
+    /**
+     * The response headers to relay to the editor.
+     *
+     * `x-wp-upload-attachment-id` is the one that carries behavior: WordPress
+     * sets it on a failed upload whose attachment row was created before
+     * metadata generation fataled, and the editor's api-fetch middleware reads
+     * it to retry `post-process` and clean up the orphan. Dropping it turns a
+     * recoverable upload into a permanent failure.
+     */
+    val headers: Map<String, String> = emptyMap()
 )
 
 /**
@@ -264,13 +274,18 @@ internal class MediaUploadServer(
     }
 
     /**
-     * Relays WordPress's exact status and body to the editor so it sees the same
-     * attachment object (or error) as a direct upload.
+     * Relays WordPress's exact status, body, and relayable headers to the editor
+     * so it sees the same attachment object (or error) as a direct upload.
+     *
+     * The headers matter for recovery: `x-wp-upload-attachment-id` is what lets
+     * the editor retry `post-process` for an upload whose metadata generation
+     * fataled server-side, rather than surfacing a permanent failure and leaving
+     * an orphaned attachment behind.
      */
     private fun relayResponse(response: MediaUploadResponse): HttpResponse {
         return HttpResponse(
             status = response.statusCode,
-            headers = mapOf("Content-Type" to "application/json"),
+            headers = mapOf("Content-Type" to "application/json") + response.headers,
             body = response.body
         )
     }
@@ -559,7 +574,11 @@ internal open class DefaultMediaUploader(
                     // holding a connection permit.
                     val result = try {
                         response.use {
-                            MediaUploadResponse(it.code, it.body?.bytes() ?: ByteArray(0))
+                            MediaUploadResponse(
+                                it.code,
+                                it.body?.bytes() ?: ByteArray(0),
+                                relayableHeaders(it)
+                            )
                         }
                     } catch (e: IOException) {
                         if (!continuation.isCancelled) continuation.resumeWithException(e)
@@ -576,5 +595,23 @@ internal open class DefaultMediaUploader(
                 }
             })
         }
+    }
+
+    /** Picks the headers to relay out of an upstream response. */
+    private fun relayableHeaders(response: okhttp3.Response): Map<String, String> =
+        RELAYABLE_HEADER_NAMES.mapNotNull { name ->
+            response.header(name)?.let { name to it }
+        }.toMap()
+
+    companion object {
+        /**
+         * The upstream headers worth relaying to the editor.
+         *
+         * Deliberately an allowlist rather than a filtered passthrough: the body
+         * is re-sent with a recomputed length, so relaying upstream entity or
+         * transport headers wholesale would risk contradicting what the server
+         * actually sends.
+         */
+        private val RELAYABLE_HEADER_NAMES = listOf("x-wp-upload-attachment-id")
     }
 }

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -638,8 +638,22 @@ class MediaUploadServerTest {
     private data class RawHttpResponse(
         val statusLine: String,
         val headers: Map<String, String>,
-        val body: String
-    )
+        val body: String,
+        /** The header lines exactly as received, before collapsing into [headers]. */
+        val rawHeaderLines: List<String> = emptyList()
+    ) {
+        /**
+         * Every value sent for [name], in order. Unlike [headers], this preserves
+         * repeats — the only way to catch a header emitted twice.
+         */
+        fun rawHeaderValues(name: String): List<String> =
+            rawHeaderLines.mapNotNull { line ->
+                val colonIndex = line.indexOf(':')
+                if (colonIndex <= 0) return@mapNotNull null
+                if (!line.substring(0, colonIndex).trim().equals(name, ignoreCase = true)) return@mapNotNull null
+                line.substring(colonIndex + 1).trim()
+            }
+    }
 
     private fun sendRawRequest(
         method: String,
@@ -694,7 +708,7 @@ class MediaUploadServerTest {
             }
         }
 
-        return RawHttpResponse(statusLine, responseHeaders, responseBody)
+        return RawHttpResponse(statusLine, responseHeaders, responseBody, lines.drop(1))
     }
 
     private fun buildMultipartBody(

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -447,6 +447,29 @@ class MediaUploadServerTest {
     }
 
     @Test
+    fun `DefaultMediaUploader deletes an attachment carrying namespace and force query`() {
+        val mockWpServer = MockWebServer()
+        mockWpServer.enqueue(MockResponse().setResponseCode(200).setBody("""{"deleted":true}"""))
+        mockWpServer.start()
+
+        val uploader = DefaultMediaUploader(
+            httpClient = okhttp3.OkHttpClient(),
+            siteApiRoot = mockWpServer.url("/wp-json/").toString(),
+            authHeader = "Bearer test-token",
+            siteApiNamespace = listOf("sites/123")
+        )
+
+        val response = runBlocking { uploader.deleteMedia("42", "?force=true") }
+
+        assertEquals(200, response.statusCode)
+        val recorded = mockWpServer.takeRequest()
+        assertEquals("DELETE", recorded.method)
+        assertEquals("/wp-json/wp/v2/sites/123/media/42?force=true", recorded.path)
+
+        mockWpServer.shutdown()
+    }
+
+    @Test
     fun `DefaultMediaUploader normalizes an unslashed root and namespace`() {
         val mockWpServer = MockWebServer()
         mockWpServer.enqueue(MockResponse().setResponseCode(201).setBody("{}"))

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -414,6 +414,39 @@ class MediaUploadServerTest {
     }
 
     @Test
+    fun `DefaultMediaUploader relays the upload attachment ID header`() {
+        // WordPress sets this header on an upload whose attachment row was
+        // created before metadata generation fataled. The editor reads it to
+        // retry post-process and clean up the orphan, so it must survive the
+        // relay. Unrelated upstream headers are not relayed.
+        val mockWpServer = MockWebServer()
+        mockWpServer.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .setBody("""{"code":"rest_upload_error"}""")
+                .setHeader("x-wp-upload-attachment-id", "4242")
+                .setHeader("X-Powered-By", "PHP/8.2")
+        )
+        mockWpServer.start()
+
+        val uploader = DefaultMediaUploader(
+            httpClient = okhttp3.OkHttpClient(),
+            siteApiRoot = mockWpServer.url("/wp-json/").toString(),
+            authHeader = "Bearer test-token"
+        )
+
+        val file = tempFolder.newFile("orphan.jpg")
+        file.writeBytes("data".toByteArray())
+
+        val response = runBlocking { uploader.upload(file, "image/jpeg", "orphan.jpg", emptyList(), "") }
+
+        assertEquals(500, response.statusCode)
+        assertEquals(mapOf("x-wp-upload-attachment-id" to "4242"), response.headers)
+
+        mockWpServer.shutdown()
+    }
+
+    @Test
     fun `DefaultMediaUploader normalizes an unslashed root and namespace`() {
         val mockWpServer = MockWebServer()
         mockWpServer.enqueue(MockResponse().setResponseCode(201).setBody("{}"))

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -141,6 +141,34 @@ class MediaUploadServerTest {
     }
 
     @Test
+    fun `relays the uploader's own Content-Type instead of emitting it twice`() {
+        // HTTP header names are case-insensitive, so an uploader spelling it
+        // `content-type` must still override the JSON default rather than merge
+        // alongside it — HttpResponse serializes every entry it is given, which
+        // would put the name on the wire twice (mirrors the iOS behavior).
+        //
+        // Exercised through the delete relay because every response relayResponse
+        // handles — WordPress's own included — carries a `Content-Type`, so this is
+        // the ordinary path rather than an edge case.
+        val uploader = ContentTypeDeleteUploader()
+        server.stop()
+        server = MediaUploadServer(uploadDelegate = null, defaultUploader = uploader, cacheDir = tempFolder.root)
+
+        val response = sendRawRequest(
+            method = "DELETE",
+            path = "/media/42?force=true",
+            headers = mapOf("Relay-Authorization" to "Bearer ${server.token}"),
+            body = ByteArray(0)
+        )
+
+        assertTrue("Expected 200 but got: ${response.statusLine}", response.statusLine.contains("200"))
+        // Assert on the raw header lines, not the parsed map: the parser
+        // lowercases keys into a map, so a duplicated header would silently
+        // collapse and this test would pass against the very bug it covers.
+        assertEquals(listOf("text/plain"), response.rawHeaderValues("content-type"))
+    }
+
+    @Test
     fun `routes upload with a query string and relays the query`() {
         val delegate = ProcessOnlyDelegate()
         val mockUploader = MockDefaultUploader()
@@ -783,6 +811,23 @@ class MediaUploadServerTest {
             producedFile = newFile
             return ProcessedProxyFile.Processed(newFile, "video/mp4", "clip.mp4")
         }
+    }
+
+    /**
+     * A default uploader whose delete response carries its own `Content-Type`,
+     * lowercased, so the relay must override the JSON default rather than emit
+     * the header twice.
+     */
+    private class ContentTypeDeleteUploader : DefaultMediaUploader(
+        httpClient = okhttp3.OkHttpClient(),
+        siteApiRoot = "https://example.com/wp-json/",
+        authHeader = "Bearer mock"
+    ) {
+        override suspend fun deleteMedia(attachmentId: String, query: String) = MediaUploadResponse(
+            200,
+            "deleted".toByteArray(),
+            mapOf("content-type" to "text/plain")
+        )
     }
 
     private class MockDefaultUploader : DefaultMediaUploader(

--- a/bin/wp-env-media-failure.sh
+++ b/bin/wp-env-media-failure.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# wp-env-media-failure.sh — Read or set the media upload failure simulation mode.
+#
+# Drives the `gutenbergkit-media-failure` mu-plugin, which fatals during image
+# sub-size generation so the editor's post-process retry can be exercised
+# locally. See docs/code/local-wordpress.md.
+#
+# Usage:
+#   bash bin/wp-env-media-failure.sh                # Report the current mode
+#   MODE=recover bash bin/wp-env-media-failure.sh   # Fail once, then succeed
+#   MODE=always  bash bin/wp-env-media-failure.sh   # Fail every attempt
+#   MODE=off     bash bin/wp-env-media-failure.sh   # Normal uploads
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CREDENTIALS_FILE="$PROJECT_ROOT/.wp-env.credentials.json"
+
+# Addressed to localhost rather than the credentials file's siteUrl: after
+# `make wp-env-android` that URL points at 10.0.2.2, which only resolves inside
+# the emulator. The server is always reachable on localhost from the host.
+ENDPOINT="http://localhost:8888/wp-json/gutenbergkit/v1/media-failure"
+
+VALID_MODES="off recover always"
+MODE="${MODE:-}"
+
+# ---------------------------------------------------------------------------
+# Validate the requested mode before touching the network
+# ---------------------------------------------------------------------------
+
+if [ -n "$MODE" ]; then
+    case " $VALID_MODES " in
+        *" $MODE "*) ;;
+        *)
+            echo "Error: invalid MODE '$MODE'." >&2
+            echo "Valid modes: $VALID_MODES" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+
+if [ ! -f "$CREDENTIALS_FILE" ]; then
+    echo "Error: credentials not found at $CREDENTIALS_FILE" >&2
+    echo 'Run "make wp-env-start" to provision the local WordPress environment.' >&2
+    exit 1
+fi
+
+AUTH_HEADER=$(node -e "
+    const fs = require('fs');
+    try {
+        const c = JSON.parse(fs.readFileSync('$CREDENTIALS_FILE', 'utf8'));
+        if (!c.authHeader) process.exit(1);
+        process.stdout.write(c.authHeader);
+    } catch {
+        process.exit(1);
+    }
+") || {
+    echo "Error: could not read authHeader from $CREDENTIALS_FILE" >&2
+    echo 'The file may be malformed. Run "make wp-env-start RESET=1" to regenerate it.' >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Request
+# ---------------------------------------------------------------------------
+
+if [ -n "$MODE" ]; then
+    METHOD="POST"
+    URL="$ENDPOINT?mode=$MODE"
+else
+    METHOD="GET"
+    URL="$ENDPOINT"
+fi
+
+# Separate the body from the status code so each failure can be reported with
+# the fix that actually applies to it.
+RESPONSE=$(curl -sS -X "$METHOD" -H "Authorization: $AUTH_HEADER" \
+    -w $'\n%{http_code}' "$URL" 2>/dev/null) || {
+    echo "Error: could not reach wp-env at $ENDPOINT" >&2
+    echo 'Run "make wp-env-start" to start the local WordPress environment.' >&2
+    exit 1
+}
+
+STATUS="${RESPONSE##*$'\n'}"
+BODY="${RESPONSE%$'\n'*}"
+
+case "$STATUS" in
+    200) ;;
+    401|403)
+        echo "Error: credentials were rejected (HTTP $STATUS)." >&2
+        echo 'They are likely stale. Run "make wp-env-start RESET=1" to regenerate them.' >&2
+        exit 1
+        ;;
+    404)
+        echo "Error: the media-failure endpoint is not registered (HTTP 404)." >&2
+        echo 'Check that wp-env/mu-plugins/gutenbergkit-media-failure.php exists,' >&2
+        echo 'then restart with "make wp-env-start".' >&2
+        exit 1
+        ;;
+    *)
+        echo "Error: unexpected response (HTTP $STATUS) from $ENDPOINT" >&2
+        echo "$BODY" >&2
+        exit 1
+        ;;
+esac
+
+CURRENT=$(echo "$BODY" | node -e "
+    let input = '';
+    process.stdin.on('data', (chunk) => { input += chunk; });
+    process.stdin.on('end', () => {
+        try {
+            process.stdout.write(JSON.parse(input).mode ?? 'unknown');
+        } catch {
+            process.stdout.write('unknown');
+        }
+    });
+")
+
+if [ -n "$MODE" ]; then
+    echo "Media upload failure mode set to: $CURRENT"
+else
+    echo "Media upload failure mode: $CURRENT"
+fi
+
+case "$CURRENT" in
+    recover)
+        echo "Uploads fail once per attachment, then succeed on the post-process retry."
+        ;;
+    always)
+        echo "Uploads fail every attempt, exhausting all five retries before the orphan is deleted."
+        ;;
+esac

--- a/bin/wp-env-media-failure.sh
+++ b/bin/wp-env-media-failure.sh
@@ -51,16 +51,19 @@ if [ ! -f "$CREDENTIALS_FILE" ]; then
     exit 1
 fi
 
-AUTH_HEADER=$(node -e "
-    const fs = require('fs');
+# The path arrives as an argument rather than interpolated into the source: a
+# checkout under a path containing a quote or backslash would otherwise produce
+# a syntax error instead of the failure message below.
+AUTH_HEADER=$(node -e '
+    const fs = require("fs");
     try {
-        const c = JSON.parse(fs.readFileSync('$CREDENTIALS_FILE', 'utf8'));
+        const c = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
         if (!c.authHeader) process.exit(1);
         process.stdout.write(c.authHeader);
     } catch {
         process.exit(1);
     }
-") || {
+' "$CREDENTIALS_FILE") || {
     echo "Error: could not read authHeader from $CREDENTIALS_FILE" >&2
     echo 'The file may be malformed. Run "make wp-env-start RESET=1" to regenerate it.' >&2
     exit 1

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -144,6 +144,8 @@ The mode is stored as an option rather than per-request state, because the uploa
 
 **Note:** the plugin sets the 500 status itself. A real PHP fatal under FPM surfaces as a 500, but the Playground runtime wp-env uses returns 200, which the editor's `status >= 500` check would ignore.
 
+**Note:** a simulated fatal aborts the request before WordPress adds CORS headers, so a cross-origin editor reports these responses as CORS errors with provisional request headers rather than as a readable 500. That is expected for the upload and `post-process` responses — the editor only needs their status and the attachment ID header. It is why the plugin never fails a `DELETE`, including the `POST` + `X-Http-Method-Override: DELETE` form api-fetch actually sends: failing the orphan cleanup would make a correctly working retry look broken.
+
 **Only the native upload server path recovers locally.** Reading `X-WP-Upload-Attachment-ID` cross-origin requires the site to list it in `Access-Control-Expose-Headers`, and WordPress core's `rest_send_cors_headers()` does not. Uploads routed through the native upload server recover on both platforms, since that server exposes the header itself.
 
 A **direct** upload (native media upload disabled) never recovers on iOS, which loads the editor from `file://`. It does not recover against wp-env on Android either: `GutenbergView` derives the asset domain from the site's _host_, which drops the port, so the editor at `http://10.0.2.2` is cross-origin with the site at `http://10.0.2.2:8888`. Direct uploads are only same-origin — and therefore only recover — when the site runs on the scheme's default port, as production sites do.

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -140,12 +140,6 @@ The mode is stored server-side, so it persists across uploads and retries until 
 
 Then upload an image from a demo app and watch the network requests. In `recover` mode the upload 500s and the following `post-process` call succeeds, leaving a complete attachment; in `always` mode you should see five `post-process` attempts followed by a `DELETE`.
 
-The mode is stored as an option rather than per-request state, because the upload and each retry are separate requests — and an upload routed through the native upload server is relayed by URLSession/OkHttp, which carries no browser cookie.
-
-**Note:** the plugin sets the 500 status itself. A real PHP fatal under FPM surfaces as a 500, but the Playground runtime wp-env uses returns 200, which the editor's `status >= 500` check would ignore.
-
-**Note:** a simulated fatal aborts the request before WordPress adds CORS headers, so a cross-origin editor reports these responses as CORS errors with provisional request headers rather than as a readable 500. That is expected for the upload and `post-process` responses — the editor only needs their status and the attachment ID header. It is why the plugin never fails a `DELETE`, including the `POST` + `X-Http-Method-Override: DELETE` form api-fetch actually sends: failing the orphan cleanup would make a correctly working retry look broken.
-
 **Only the native upload server path recovers locally.** Reading `X-WP-Upload-Attachment-ID` cross-origin requires the site to list it in `Access-Control-Expose-Headers`, and WordPress core's `rest_send_cors_headers()` does not. Uploads routed through the native upload server recover on both platforms, since that server exposes the header itself.
 
 A **direct** upload (native media upload disabled) never recovers on iOS, which loads the editor from `file://`. It does not recover against wp-env on Android either: `GutenbergView` derives the asset domain from the site's _host_, which drops the port, so the editor at `http://10.0.2.2` is cross-origin with the site at `http://10.0.2.2:8888`. Direct uploads are only same-origin — and therefore only recover — when the site runs on the scheme's default port, as production sites do.
@@ -184,22 +178,6 @@ If the port belongs to an unrelated service, change the wp-env port in `.wp-env.
 ```
 
 The make targets read the port from wp-env, so a `port` key here — or the `WP_ENV_PORT` environment variable — applies to the port check and credential provisioning as well as to the server itself.
-
-Under the Playground runtime the culprit is often a previous wp-env server that outlived `make wp-env-stop`, which then makes every subsequent start fail with `EADDRINUSE`:
-
-```bash
-lsof -ti:8888              # confirm what holds the port
-pkill -f "wp-playground.js"
-```
-
-### Credentials rejected with HTTP 401
-
-The Playground runtime starts from a fresh database on each start, so an existing `.wp-env.credentials.json` no longer matches the site's application password. Regenerate it:
-
-```bash
-make wp-env-start RESET=1
-```
-
 ### Resetting the environment
 
 To start fresh, destroy the environment and recreate it:

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -144,7 +144,9 @@ The mode is stored as an option rather than per-request state, because the uploa
 
 **Note:** the plugin sets the 500 status itself. A real PHP fatal under FPM surfaces as a 500, but the Playground runtime wp-env uses returns 200, which the editor's `status >= 500` check would ignore.
 
-**Direct uploads on iOS cannot recover, by design of the platform rather than a bug here.** Reading `X-WP-Upload-Attachment-ID` cross-origin requires the site to list it in `Access-Control-Expose-Headers`, and WordPress core's `rest_send_cors_headers()` does not. Uploads routed through the native upload server recover on both platforms, since that server exposes the header itself. Android also recovers on direct uploads, because its editor is served from the site's own host and is therefore same-origin. Do not "fix" this by adding the header to the CORS mu-plugin — that would make local testing diverge from production.
+**Only the native upload server path recovers locally.** Reading `X-WP-Upload-Attachment-ID` cross-origin requires the site to list it in `Access-Control-Expose-Headers`, and WordPress core's `rest_send_cors_headers()` does not. Uploads routed through the native upload server recover on both platforms, since that server exposes the header itself.
+
+A **direct** upload (native media upload disabled) never recovers on iOS, which loads the editor from `file://`. It does not recover against wp-env on Android either: `GutenbergView` derives the asset domain from the site's _host_, which drops the port, so the editor at `http://10.0.2.2` is cross-origin with the site at `http://10.0.2.2:8888`. Direct uploads are only same-origin — and therefore only recover — when the site runs on the scheme's default port, as production sites do.
 
 ## WordPress Admin
 

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -120,23 +120,23 @@ Physical devices cannot reach `localhost`. You'll need to:
 
 When `wp_generate_attachment_metadata()` fatals server-side — commonly a PHP `memory_limit` or `max_execution_time` fatal on a large image — WordPress has already created the attachment row and sent an `X-WP-Upload-Attachment-ID` header. The editor reads that header off the resulting 5xx and retries `POST /wp/v2/media/<id>/post-process` up to five times, deleting the orphaned attachment if every attempt fails.
 
-`gutenbergkit-media-failure.php` reproduces that failure on demand so the retry can be exercised without a large image or a resource-starved host. Set the mode over the REST API (the `authHeader` value is in `.wp-env.credentials.json`):
+`gutenbergkit-media-failure.php` reproduces that failure on demand so the retry can be exercised without a large image or a resource-starved host:
 
 ```bash
-AUTH=$(python3 -c "import json;print(json.load(open('.wp-env.credentials.json'))['authHeader'])")
+# Report the current mode.
+make wp-env-media-failure
 
 # Fail once per attachment, then succeed: the retry recovers the upload.
-curl -s -X POST -H "Authorization: $AUTH" \
-  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=recover'
+make wp-env-media-failure MODE=recover
 
 # Fail every time: exhausts all five retries, then the orphan is deleted.
-curl -s -X POST -H "Authorization: $AUTH" \
-  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=always'
+make wp-env-media-failure MODE=always
 
 # Restore normal uploads.
-curl -s -X POST -H "Authorization: $AUTH" \
-  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=off'
+make wp-env-media-failure MODE=off
 ```
+
+The mode is stored server-side, so it persists across uploads and retries until changed. It does not survive restarting wp-env — the Playground runtime starts from a fresh database, so the mode returns to `off` (and credentials need `make wp-env-start RESET=1`).
 
 Then upload an image from a demo app and watch the network requests. In `recover` mode the upload 500s and the following `post-process` call succeeds, leaving a complete attachment; in `always` mode you should see five `post-process` attempts followed by a `DELETE`.
 
@@ -180,6 +180,21 @@ If the port belongs to an unrelated service, change the wp-env port in `.wp-env.
 ```
 
 The make targets read the port from wp-env, so a `port` key here — or the `WP_ENV_PORT` environment variable — applies to the port check and credential provisioning as well as to the server itself.
+
+Under the Playground runtime the culprit is often a previous wp-env server that outlived `make wp-env-stop`, which then makes every subsequent start fail with `EADDRINUSE`:
+
+```bash
+lsof -ti:8888              # confirm what holds the port
+pkill -f "wp-playground.js"
+```
+
+### Credentials rejected with HTTP 401
+
+The Playground runtime starts from a fresh database on each start, so an existing `.wp-env.credentials.json` no longer matches the site's application password. Regenerate it:
+
+```bash
+make wp-env-start RESET=1
+```
 
 ### Resetting the environment
 

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -45,6 +45,7 @@ The `.wp-env.json` file at the project root configures the environment:
 -   **Gutenberg plugin** is installed for the `/wp-block-editor/v1/settings` editor settings REST API endpoint.
 -   **Jetpack plugin** is installed with the blocks module auto-activated via a mu-plugin (`wp-env/mu-plugins/gutenbergkit-jetpack-blocks.php`), providing the `/wpcom/v2/editor-assets` endpoint and additional editor blocks.
 -   A **CORS mu-plugin** (`wp-env/mu-plugins/gutenbergkit-cors.php`) adds CORS headers to REST API responses, allowing requests from the Vite dev server, preview server, and native WebViews.
+-   A **media failure mu-plugin** (`wp-env/mu-plugins/gutenbergkit-media-failure.php`) can simulate a server-side image processing fatal on demand. Inactive by default — see [Simulating media upload failures](#simulating-media-upload-failures).
 -   **WP_DEBUG** and **WP_DEBUG_LOG** are enabled for development.
 
 ### Credential Provisioning
@@ -114,6 +115,36 @@ Physical devices cannot reach `localhost`. You'll need to:
 1. Find your machine's local IP address (e.g., `192.168.1.100`).
 2. Update the CORS mu-plugin to allow your IP.
 3. Manually create or edit `.wp-env.credentials.json` with the correct IP-based URLs.
+
+## Simulating Media Upload Failures
+
+When `wp_generate_attachment_metadata()` fatals server-side — commonly a PHP `memory_limit` or `max_execution_time` fatal on a large image — WordPress has already created the attachment row and sent an `X-WP-Upload-Attachment-ID` header. The editor reads that header off the resulting 5xx and retries `POST /wp/v2/media/<id>/post-process` up to five times, deleting the orphaned attachment if every attempt fails.
+
+`gutenbergkit-media-failure.php` reproduces that failure on demand so the retry can be exercised without a large image or a resource-starved host. Set the mode over the REST API (the `authHeader` value is in `.wp-env.credentials.json`):
+
+```bash
+AUTH=$(python3 -c "import json;print(json.load(open('.wp-env.credentials.json'))['authHeader'])")
+
+# Fail once per attachment, then succeed: the retry recovers the upload.
+curl -s -X POST -H "Authorization: $AUTH" \
+  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=recover'
+
+# Fail every time: exhausts all five retries, then the orphan is deleted.
+curl -s -X POST -H "Authorization: $AUTH" \
+  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=always'
+
+# Restore normal uploads.
+curl -s -X POST -H "Authorization: $AUTH" \
+  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=off'
+```
+
+Then upload an image from a demo app and watch the network requests. In `recover` mode the upload 500s and the following `post-process` call succeeds, leaving a complete attachment; in `always` mode you should see five `post-process` attempts followed by a `DELETE`.
+
+The mode is stored as an option rather than per-request state, because the upload and each retry are separate requests — and an upload routed through the native upload server is relayed by URLSession/OkHttp, which carries no browser cookie.
+
+**Note:** the plugin sets the 500 status itself. A real PHP fatal under FPM surfaces as a 500, but the Playground runtime wp-env uses returns 200, which the editor's `status >= 500` check would ignore.
+
+**Direct uploads on iOS cannot recover, by design of the platform rather than a bug here.** Reading `X-WP-Upload-Attachment-ID` cross-origin requires the site to list it in `Access-Control-Expose-Headers`, and WordPress core's `rest_send_cors_headers()` does not. Uploads routed through the native upload server recover on both platforms, since that server exposes the header itself. Android also recovers on direct uploads, because its editor is served from the site's own host and is therefore same-origin. Do not "fix" this by adding the header to the CORS mu-plugin — that would make local testing diverge from production.
 
 ## WordPress Admin
 

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadDelegate.swift
@@ -15,9 +15,19 @@ public struct MediaUploadResponse: Sendable {
     /// WordPress REST error object (`{ "code", "message", "data" }`) on failure.
     public let body: Data
 
-    public init(statusCode: Int, body: Data) {
+    /// The response headers to relay to the editor.
+    ///
+    /// `x-wp-upload-attachment-id` is the one that carries behavior: WordPress
+    /// sets it on a failed upload whose attachment row was created before
+    /// metadata generation fataled, and the editor's api-fetch middleware reads
+    /// it to retry `post-process` and clean up the orphan. Dropping it turns a
+    /// recoverable upload into a permanent failure.
+    public let headers: [String: String]
+
+    public init(statusCode: Int, body: Data, headers: [String: String] = [:]) {
         self.statusCode = statusCode
         self.body = body
+        self.headers = headers
     }
 }
 

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -87,15 +87,21 @@ final class MediaUploadServer: Sendable {
     private static func handleRequest(_ request: HTTPServer.Request, context: UploadContext) async -> HTTPResponse {
         let parsed = request.parsed
 
-        // Route: only POST /upload is handled. (OPTIONS preflight is answered by
-        // the HTTP library under its permissive CORS policy.) Match on the path
-        // alone — the target carries a query string (e.g. `?_embed`) that the
-        // upload handler relays on to WordPress.
-        guard parsed.method.uppercased() == "POST", parsed.path == "/upload" else {
-            return errorResponse(status: 404, message: "Not found")
+        // Routes: POST /upload, and DELETE /media/<id> for the editor's orphan
+        // cleanup. (OPTIONS preflight is answered by the HTTP library under its
+        // permissive CORS policy.) Match on the path alone — the target carries
+        // a query string (e.g. `?_embed`, `?force=true`) relayed to WordPress.
+        let method = parsed.method.uppercased()
+
+        if method == "POST", parsed.path == "/upload" {
+            return await handleUpload(request, context: context)
         }
 
-        return await handleUpload(request, context: context)
+        if method == "DELETE", let attachmentId = attachmentId(fromPath: parsed.path) {
+            return await handleDelete(attachmentId, query: parsed.query, context: context)
+        }
+
+        return errorResponse(status: 404, message: "Not found")
     }
 
     private static func handleUpload(_ request: HTTPServer.Request, context: UploadContext) async -> HTTPResponse {
@@ -188,6 +194,39 @@ final class MediaUploadServer: Sendable {
         }
         let response = try await defaultUploader.passthroughUpload(body: body, contentType: contentType, query: query)
         return relayResponse(response)
+    }
+
+    /// The attachment ID in a `/media/<id>` path, or `nil` if the path is not one.
+    ///
+    /// Deliberately narrow: this server relays media operations, not arbitrary
+    /// REST requests, so only a numeric attachment ID under `/media/` matches.
+    private static func attachmentId(fromPath path: String) -> String? {
+        let components = path.split(separator: "/", omittingEmptySubsequences: true)
+        guard components.count == 2, components[0] == "media" else { return nil }
+        let id = String(components[1])
+        guard !id.isEmpty, id.allSatisfy(\.isNumber) else { return nil }
+        return id
+    }
+
+    /// Relays the editor's orphan cleanup to WordPress.
+    ///
+    /// Core's media upload middleware deletes the attachment when every
+    /// `post-process` retry fails. A cross-origin editor cannot issue that
+    /// request directly — api-fetch tunnels `DELETE` as a `POST` carrying
+    /// `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
+    /// browser blocks it at preflight. Relaying it here lets the cleanup run.
+    private static func handleDelete(
+        _ attachmentId: String, query: String, context: UploadContext
+    ) async -> HTTPResponse {
+        guard let defaultUploader = context.defaultUploader else {
+            return errorResponse(status: 500, message: UploadError.noUploader.localizedDescription)
+        }
+        do {
+            let response = try await defaultUploader.deleteMedia(attachmentId: attachmentId, query: query)
+            return relayResponse(response)
+        } catch {
+            return uploadErrorResponse(error)
+        }
     }
 
     /// Relays WordPress's exact status, body, and relayable headers to the editor
@@ -447,8 +486,9 @@ class DefaultMediaUploader: @unchecked Sendable {
     /// The WordPress media endpoint URL, built through the shared
     /// ``WordPressRESTURL`` namespacing (so it matches every other REST URL) and
     /// carrying the original request query (e.g. `?_embed`) through to WordPress.
-    private func mediaEndpointURL(query: String) -> URL {
-        let base = WordPressRESTURL.namespaced(apiRoot: siteApiRoot, path: "/wp/v2/media", namespace: siteApiNamespace)
+    private func mediaEndpointURL(query: String, attachmentId: String? = nil) -> URL {
+        let path = attachmentId.map { "/wp/v2/media/\($0)" } ?? "/wp/v2/media"
+        let base = WordPressRESTURL.namespaced(apiRoot: siteApiRoot, path: path, namespace: siteApiNamespace)
         guard !query.isEmpty else { return base }
         // `query` is the raw request query in wire form (leading "?"). Set it via
         // `percentEncodedQuery` so a value that isn't URL-safe can't make
@@ -493,6 +533,23 @@ class DefaultMediaUploader: @unchecked Sendable {
         request.httpBodyStream = try body.makeInputStream()
 
         return try await performUpload(request)
+    }
+
+    /// Deletes an attachment, relaying WordPress's response verbatim.
+    ///
+    /// Carries the editor's query through unchanged — core's cleanup sends
+    /// `?force=true`, without which WordPress trashes rather than deletes.
+    func deleteMedia(attachmentId: String, query: String) async throws -> MediaUploadResponse {
+        var request = URLRequest(url: mediaEndpointURL(query: query, attachmentId: attachmentId))
+        request.httpMethod = "DELETE"
+
+        // Authorization is applied centrally by the HTTP client, as for uploads.
+        let (data, response) = try await httpClient.performRaw(request)
+        return MediaUploadResponse(
+            statusCode: response.statusCode,
+            body: data,
+            headers: Self.relayableHeaders(from: response)
+        )
     }
 
     /// Sends the assembled upload request to WordPress and relays the response.

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -236,10 +236,15 @@ final class MediaUploadServer: Sendable {
     /// the editor retry `post-process` for an upload whose metadata generation
     /// fataled server-side, rather than surfacing a permanent failure and
     /// leaving an orphaned attachment behind.
+    ///
+    /// The response's own `Content-Type` wins over the JSON default. `HTTPResponse`
+    /// serializes every header it is given, so appending the default unconditionally
+    /// would emit the name twice for a delegate that sets it.
     private static func relayResponse(_ response: MediaUploadResponse) -> HTTPResponse {
-        HTTPResponse(
+        let hasContentType = response.headers.keys.contains { $0.lowercased() == "content-type" }
+        return HTTPResponse(
             status: response.statusCode,
-            headers: [("Content-Type", "application/json")]
+            headers: (hasContentType ? [] : [("Content-Type", "application/json")])
                 + response.headers.map { ($0.key, $0.value) },
             body: response.body
         )

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -190,12 +190,18 @@ final class MediaUploadServer: Sendable {
         return relayResponse(response)
     }
 
-    /// Relays WordPress's exact status and body to the editor so it sees the same
-    /// attachment object (or error) as a direct upload.
+    /// Relays WordPress's exact status, body, and relayable headers to the editor
+    /// so it sees the same attachment object (or error) as a direct upload.
+    ///
+    /// The headers matter for recovery: `x-wp-upload-attachment-id` is what lets
+    /// the editor retry `post-process` for an upload whose metadata generation
+    /// fataled server-side, rather than surfacing a permanent failure and
+    /// leaving an orphaned attachment behind.
     private static func relayResponse(_ response: MediaUploadResponse) -> HTTPResponse {
         HTTPResponse(
             status: response.statusCode,
-            headers: [("Content-Type", "application/json")],
+            headers: [("Content-Type", "application/json")]
+                + response.headers.map { ($0.key, $0.value) },
             body: response.body
         )
     }
@@ -517,7 +523,30 @@ class DefaultMediaUploader: @unchecked Sendable {
         // the editor sees WordPress's real status and error body, exactly as a
         // direct upload would. `performRaw` does not throw on non-2xx.
         let (data, response) = try await httpClient.performRaw(request)
-        return MediaUploadResponse(statusCode: response.statusCode, body: data)
+        return MediaUploadResponse(
+            statusCode: response.statusCode,
+            body: data,
+            headers: Self.relayableHeaders(from: response)
+        )
+    }
+
+    /// The upstream headers worth relaying to the editor.
+    ///
+    /// Deliberately an allowlist rather than a filtered passthrough: the body is
+    /// re-sent with a recomputed length, so relaying upstream entity or
+    /// transport headers wholesale would risk contradicting what the server
+    /// actually sends.
+    private static let relayableHeaderNames = ["x-wp-upload-attachment-id"]
+
+    /// Picks the headers to relay out of an upstream response.
+    private static func relayableHeaders(from response: HTTPURLResponse) -> [String: String] {
+        var headers: [String: String] = [:]
+        for name in relayableHeaderNames {
+            if let value = response.value(forHTTPHeaderField: name) {
+                headers[name] = value
+            }
+        }
+        return headers
     }
 
     // MARK: - Streaming Multipart Body

--- a/ios/Sources/GutenbergKitHTTP/CORSPolicy.swift
+++ b/ios/Sources/GutenbergKitHTTP/CORSPolicy.swift
@@ -33,6 +33,12 @@ public enum CORSPolicy: Sendable {
                 ("Access-Control-Allow-Origin", "*"),
                 ("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS"),
                 ("Access-Control-Allow-Headers", "Authorization, Relay-Authorization, Content-Type"),
+                // Only CORS-safelisted response headers are readable
+                // cross-origin by default. The editor needs to read
+                // `x-wp-upload-attachment-id` off a relayed media upload
+                // response to retry `post-process` and clean up an orphaned
+                // attachment, so it has to be exposed explicitly.
+                ("Access-Control-Expose-Headers", "x-wp-upload-attachment-id"),
                 ("Access-Control-Max-Age", "86400"),
             ]
         }

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -604,6 +604,54 @@ struct DefaultMediaUploaderRelayTests {
     #expect(response.body == errorBody)
   }
 
+  @Test("relays the upload attachment ID header from a failed upload")
+  func relaysUploadAttachmentIdHeader() async throws {
+    // WordPress sets this header on an upload whose attachment row was created
+    // before metadata generation fataled. The editor reads it to retry
+    // post-process and clean up the orphan, so it must survive the relay.
+    let client = RelayStubHTTPClient(
+      statusCode: 500,
+      body: Data(#"{"code":"rest_upload_error"}"#.utf8),
+      headerFields: ["x-wp-upload-attachment-id": "4242"]
+    )
+    let uploader = DefaultMediaUploader(
+      httpClient: client, siteApiRoot: URL(string: "https://example.com/wp-json/")!)
+
+    let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "header-\(UUID().uuidString).jpg")
+    try Data("fake image".utf8).write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    let response = try await uploader.upload(
+      fileURL: tempFile, mimeType: "image/jpeg", filename: "photo.jpg", extraParts: [], query: ""
+    )
+
+    #expect(response.statusCode == 500)
+    #expect(response.headers["x-wp-upload-attachment-id"] == "4242")
+  }
+
+  @Test("omits unrelated upstream headers from the relay")
+  func omitsUnrelatedHeaders() async throws {
+    let client = RelayStubHTTPClient(
+      statusCode: 201,
+      body: Data("{}".utf8),
+      headerFields: ["X-Powered-By": "PHP/8.2", "Set-Cookie": "session=secret"]
+    )
+    let uploader = DefaultMediaUploader(
+      httpClient: client, siteApiRoot: URL(string: "https://example.com/wp-json/")!)
+
+    let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "unrelated-\(UUID().uuidString).jpg")
+    try Data("fake image".utf8).write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    let response = try await uploader.upload(
+      fileURL: tempFile, mimeType: "image/jpeg", filename: "photo.jpg", extraParts: [], query: ""
+    )
+
+    #expect(response.headers.isEmpty)
+  }
+
   @Test("carries the namespace and request query through to the media endpoint")
   func forwardsNamespaceAndQuery() async throws {
     let client = URLCapturingHTTPClient()
@@ -635,9 +683,11 @@ struct DefaultMediaUploaderRelayTests {
 private struct RelayStubHTTPClient: EditorHTTPClientProtocol {
   let statusCode: Int
   let body: Data
+  var headerFields: [String: String]?
 
   func perform(_ urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse) {
-    let response = HTTPURLResponse(url: urlRequest.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+    let response = HTTPURLResponse(
+      url: urlRequest.url!, statusCode: statusCode, httpVersion: nil, headerFields: headerFields)!
     guard (200...299).contains(statusCode) else {
       throw NSError(domain: "RelayStubHTTPClient", code: statusCode)
     }
@@ -645,7 +695,8 @@ private struct RelayStubHTTPClient: EditorHTTPClientProtocol {
   }
 
   func performRaw(_ urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse) {
-    let response = HTTPURLResponse(url: urlRequest.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+    let response = HTTPURLResponse(
+      url: urlRequest.url!, statusCode: statusCode, httpVersion: nil, headerFields: headerFields)!
     return (body, response)
   }
 

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -131,6 +131,32 @@ struct MediaUploadServerTests {
     #expect(mockUploader.lastQuery == "?_embed=wp:featuredmedia")
   }
 
+  @Test("relays the uploader's own Content-Type instead of emitting it twice")
+  func relayedContentTypeWins() async throws {
+    // `HTTPResponse` serializes every header it is given, so appending the JSON
+    // default unconditionally would put `Content-Type` on the wire twice.
+    // URLSession joins repeated headers with a comma, which is what a regression
+    // looks like here.
+    //
+    // Exercised through the delete relay because every response `relayResponse`
+    // handles — WordPress's own included — carries a `Content-Type`, so this is
+    // the ordinary path rather than an edge case.
+    let uploader = ContentTypeDeleteUploader()
+    let server = try await MediaUploadServer.start(defaultUploader: uploader)
+    defer { server.stop() }
+
+    let url = URL(string: "http://127.0.0.1:\(server.port)/media/42?force=true")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "DELETE"
+    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
+
+    let (_, response) = try await URLSession.shared.data(for: request)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(httpResponse.value(forHTTPHeaderField: "Content-Type") == "text/plain")
+  }
+
   @Test("calls delegate and returns upload result")
   func delegateProcessAndUpload() async throws {
     let delegate = MockUploadDelegate()
@@ -879,6 +905,22 @@ private final class MockDefaultUploader: DefaultMediaUploader, @unchecked Sendab
   private func mockResponse() -> MediaUploadResponse {
     let json = #"{"id":99,"source_url":"https://example.com/doc.pdf","media_type":"file"}"#
     return MediaUploadResponse(statusCode: 201, body: Data(json.utf8))
+  }
+}
+
+/// A default uploader whose delete response carries its own `Content-Type`, so the
+/// relay must override the JSON default rather than emit the header twice.
+private final class ContentTypeDeleteUploader: DefaultMediaUploader, @unchecked Sendable {
+  init() {
+    super.init(httpClient: MockHTTPClient(), siteApiRoot: URL(string: "https://example.com/wp-json/")!)
+  }
+
+  override func deleteMedia(attachmentId: String, query: String) async throws -> MediaUploadResponse {
+    MediaUploadResponse(
+      statusCode: 200,
+      body: Data("deleted".utf8),
+      headers: ["Content-Type": "text/plain"]
+    )
   }
 }
 

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -652,6 +652,22 @@ struct DefaultMediaUploaderRelayTests {
     #expect(response.headers.isEmpty)
   }
 
+  @Test("deletes an attachment, carrying the namespace and force query")
+  func deletesAttachment() async throws {
+    let client = URLCapturingHTTPClient()
+    let uploader = DefaultMediaUploader(
+      httpClient: client,
+      siteApiRoot: URL(string: "https://example.com/wp-json")!,
+      siteApiNamespace: ["sites/123"]
+    )
+
+    _ = try await uploader.deleteMedia(attachmentId: "42", query: "?force=true")
+
+    let url = try #require(client.lastURL)
+    #expect(
+      url.absoluteString == "https://example.com/wp-json/wp/v2/sites/123/media/42?force=true")
+  }
+
   @Test("carries the namespace and request query through to the media endpoint")
   func forwardsNamespaceAndQuery() async throws {
     let client = URLCapturingHTTPClient()

--- a/src/utils/api-fetch-post-process.test.js
+++ b/src/utils/api-fetch-post-process.test.js
@@ -99,6 +99,37 @@ describe( "core's media upload post-process middleware", () => {
 		global.fetch = originalFetch;
 	} );
 
+	it( 'retries post-process for an upload routed through the native server', async () => {
+		// Regression test for middleware ordering. The native middleware handles
+		// the upload without calling `next`, so core's middleware only ever sees
+		// it by running *above* — registered after. With the two swapped, this
+		// upload surfaces as a permanent failure and no post-process is issued.
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: SITE_API_ROOT,
+			authHeader: 'Bearer test-token',
+			siteApiNamespace: [],
+			namespaceExcludedPaths: [],
+			nativeUploadPort: 8080,
+			nativeUploadToken: 'relay-token',
+		} );
+
+		global.fetch = vi.fn( ( url ) => {
+			const path = String( url );
+			if ( path.includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 200, null, { id: 42 } ) );
+			}
+			// The native server relays WordPress's 500 plus the attachment ID.
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		await expect( apiFetch( uploadOptions() ) ).resolves.toEqual( {
+			id: 42,
+		} );
+
+		expect( fetchedPath( 0 ) ).toContain( 'localhost:8080/upload' );
+		expect( fetchedPath( 1 ) ).toContain( '/wp/v2/media/42/post-process' );
+	} );
+
 	it( 'retries post-process when the upload fails with an attachment ID', async () => {
 		global.fetch = vi.fn( ( url ) => {
 			if ( String( url ).includes( 'post-process' ) ) {

--- a/src/utils/api-fetch-post-process.test.js
+++ b/src/utils/api-fetch-post-process.test.js
@@ -21,6 +21,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import { configureApiFetch } from './api-fetch';
 import * as bridge from './bridge';
+import { error } from './logger';
 
 vi.mock( './bridge', async ( importOriginal ) => {
 	const actual = await importOriginal();
@@ -257,5 +258,31 @@ describe( "core's media upload post-process middleware", () => {
 		} );
 
 		expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not log an error for an upload that recovers', async () => {
+		// The initial 5xx is a handoff to core's post-process retry, not a
+		// failure. A silently-recovered upload must surface no error to the host.
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: SITE_API_ROOT,
+			authHeader: 'Bearer test-token',
+			siteApiNamespace: [],
+			namespaceExcludedPaths: [],
+			nativeUploadPort: 8080,
+			nativeUploadToken: 'relay-token',
+		} );
+
+		global.fetch = vi.fn( ( url ) => {
+			if ( String( url ).includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 200, null, { id: 42 } ) );
+			}
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		await expect( apiFetch( uploadOptions() ) ).resolves.toEqual( {
+			id: 42,
+		} );
+
+		expect( error ).not.toHaveBeenCalled();
 	} );
 } );

--- a/src/utils/api-fetch-post-process.test.js
+++ b/src/utils/api-fetch-post-process.test.js
@@ -1,0 +1,189 @@
+/**
+ * External dependencies
+ */
+import {
+	describe,
+	it,
+	expect,
+	beforeAll,
+	beforeEach,
+	afterEach,
+	vi,
+} from 'vitest';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { configureApiFetch } from './api-fetch';
+import * as bridge from './bridge';
+
+vi.mock( './bridge', async ( importOriginal ) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		getGBKit: vi.fn(),
+	};
+} );
+
+vi.mock( './logger', () => ( {
+	info: vi.fn(),
+	error: vi.fn(),
+	warn: vi.fn(),
+	debug: vi.fn(),
+} ) );
+
+const SITE_API_ROOT = 'https://example.com/wp-json/';
+
+/**
+ * A `Response`-like object carrying the upload attachment ID header, which is
+ * what core's middleware keys off to decide whether a failure is recoverable.
+ *
+ * @param {number}  status       The HTTP status.
+ * @param {?string} attachmentId The `x-wp-upload-attachment-id` header value.
+ * @param {Object}  body         The JSON body.
+ * @return {Response} The response.
+ */
+function makeResponse( status, attachmentId, body = {} ) {
+	const headers = { 'Content-Type': 'application/json' };
+	if ( attachmentId ) {
+		headers[ 'x-wp-upload-attachment-id' ] = attachmentId;
+	}
+	return new Response( JSON.stringify( body ), { status, headers } );
+}
+
+/** A media upload request, as `@wordpress/media-utils` issues it. */
+function uploadOptions() {
+	const body = new FormData();
+	body.append(
+		'file',
+		new File( [ 'data' ], 'photo.jpg', { type: 'image/jpeg' } )
+	);
+	return { path: '/wp/v2/media', method: 'POST', body };
+}
+
+/**
+ * The path of the Nth `fetch` call, normalized to a string.
+ *
+ * @param {number} index The zero-based call index.
+ * @return {string} The requested URL.
+ */
+function fetchedPath( index ) {
+	return String( global.fetch.mock.calls[ index ][ 0 ] );
+}
+
+describe( "core's media upload post-process middleware", () => {
+	let originalFetch;
+
+	beforeAll( () => {
+		bridge.getGBKit.mockReturnValue( { siteApiRoot: SITE_API_ROOT } );
+		configureApiFetch();
+	} );
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		originalFetch = global.fetch;
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: SITE_API_ROOT,
+			authHeader: 'Bearer test-token',
+			siteApiNamespace: [],
+			namespaceExcludedPaths: [],
+		} );
+	} );
+
+	afterEach( () => {
+		global.fetch = originalFetch;
+	} );
+
+	it( 'retries post-process when the upload fails with an attachment ID', async () => {
+		global.fetch = vi.fn( ( url ) => {
+			if ( String( url ).includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 200, null, { id: 42 } ) );
+			}
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		// A recovered upload resolves with the post-process result rather than
+		// surfacing the original 5xx to the block.
+		await expect( apiFetch( uploadOptions() ) ).resolves.toEqual( {
+			id: 42,
+		} );
+
+		expect( global.fetch ).toHaveBeenCalledTimes( 2 );
+		expect( fetchedPath( 1 ) ).toContain( '/wp/v2/media/42/post-process' );
+	} );
+
+	it( 'deletes the orphaned attachment after exhausting retries', async () => {
+		global.fetch = vi.fn( ( url ) => {
+			const path = String( url );
+			if ( path.includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 500, null ) );
+			}
+			if ( path.includes( 'force=true' ) ) {
+				return Promise.resolve(
+					makeResponse( 200, null, { deleted: true } )
+				);
+			}
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		await expect( apiFetch( uploadOptions() ) ).rejects.toBeDefined();
+
+		const paths = global.fetch.mock.calls.map( ( [ url ] ) =>
+			String( url )
+		);
+		// The initial upload, five post-process attempts, then the cleanup.
+		expect(
+			paths.filter( ( p ) => p.includes( 'post-process' ) )
+		).toHaveLength( 5 );
+		expect( paths.at( -1 ) ).toContain( '/wp/v2/media/42?force=true' );
+	} );
+
+	it( 'authenticates the post-process retry', async () => {
+		global.fetch = vi.fn( ( url ) => {
+			if ( String( url ).includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 200, null, { id: 42 } ) );
+			}
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		await expect( apiFetch( uploadOptions() ) ).resolves.toBeDefined();
+
+		// The retry is issued through `next`, so it must still pick up the auth
+		// header and the site API root from the middlewares below it.
+		const [ url, options ] = global.fetch.mock.calls[ 1 ];
+		expect( String( url ) ).toContain(
+			`${ SITE_API_ROOT }wp/v2/media/42/post-process`
+		);
+		expect( options.headers.Authorization ).toBe( 'Bearer test-token' );
+	} );
+
+	it( 'does not retry when the failure carries no attachment ID', async () => {
+		global.fetch = vi.fn( () =>
+			Promise.resolve( makeResponse( 500, null ) )
+		);
+
+		await expect( apiFetch( uploadOptions() ) ).rejects.toBeDefined();
+
+		expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'leaves a successful upload untouched', async () => {
+		global.fetch = vi.fn( () =>
+			Promise.resolve(
+				makeResponse( 201, null, { id: 42, source_url: 'x' } )
+			)
+		);
+
+		await expect( apiFetch( uploadOptions() ) ).resolves.toEqual( {
+			id: 42,
+			source_url: 'x',
+		} );
+
+		expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/src/utils/api-fetch-post-process.test.js
+++ b/src/utils/api-fetch-post-process.test.js
@@ -174,6 +174,47 @@ describe( "core's media upload post-process middleware", () => {
 		expect( paths.at( -1 ) ).toContain( '/wp/v2/media/42?force=true' );
 	} );
 
+	it( 'relays the orphan cleanup through the native server', async () => {
+		// End-to-end shape of the `always` case on a native-upload host: the
+		// upload fails, five post-process attempts fail, and the resulting
+		// DELETE goes to the loopback server rather than direct to WordPress —
+		// where a cross-origin editor's tunnelled DELETE would be blocked at
+		// preflight, leaving the orphan behind.
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: SITE_API_ROOT,
+			authHeader: 'Bearer test-token',
+			siteApiNamespace: [],
+			namespaceExcludedPaths: [],
+			nativeUploadPort: 8080,
+			nativeUploadToken: 'relay-token',
+		} );
+
+		global.fetch = vi.fn( ( url ) => {
+			const path = String( url );
+			if ( path.includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 500, null ) );
+			}
+			if ( path.includes( '/media/42' ) ) {
+				return Promise.resolve(
+					makeResponse( 200, null, { deleted: true } )
+				);
+			}
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		await expect( apiFetch( uploadOptions() ) ).rejects.toBeDefined();
+
+		const paths = global.fetch.mock.calls.map( ( [ url ] ) =>
+			String( url )
+		);
+		expect(
+			paths.filter( ( p ) => p.includes( 'post-process' ) )
+		).toHaveLength( 5 );
+		expect( paths.at( -1 ) ).toBe(
+			'http://localhost:8080/media/42?force=true'
+		);
+	} );
+
 	it( 'authenticates the post-process retry', async () => {
 		global.fetch = vi.fn( ( url ) => {
 			if ( String( url ).includes( 'post-process' ) ) {

--- a/src/utils/api-fetch-upload-middleware.test.js
+++ b/src/utils/api-fetch-upload-middleware.test.js
@@ -625,6 +625,66 @@ describe( 'nativeMediaUploadMiddleware', () => {
 		expect( next ).not.toHaveBeenCalled();
 	} );
 
+	// MARK: - Raw response passthrough
+
+	describe( 'parse: false', () => {
+		beforeEach( () => {
+			getGBKit.mockReturnValue( {
+				nativeUploadPort: 8080,
+				nativeUploadToken: 'token',
+			} );
+		} );
+
+		it( 'rejects with the Response so the attachment ID stays readable', async () => {
+			// Core's media upload middleware needs the `Response` itself to read
+			// `x-wp-upload-attachment-id` and retry post-process. Parsing the
+			// body here would hide the header.
+			const response = new Response( '{"code":"rest_upload_error"}', {
+				status: 500,
+				headers: { 'x-wp-upload-attachment-id': '4242' },
+			} );
+			global.fetch = vi.fn( () => Promise.resolve( response ) );
+
+			const options = makePostMediaOptions( makeFile() );
+			options.parse = false;
+
+			const thrown = await nativeMediaUploadMiddleware(
+				options,
+				makeNext()
+			).catch( ( error ) => error );
+
+			expect( thrown ).toBe( response );
+			expect( thrown.headers.get( 'x-wp-upload-attachment-id' ) ).toBe(
+				'4242'
+			);
+		} );
+
+		it( 'resolves with the Response on success', async () => {
+			const response = new Response( '{"id":1}', { status: 201 } );
+			global.fetch = vi.fn( () => Promise.resolve( response ) );
+
+			const options = makePostMediaOptions( makeFile() );
+			options.parse = false;
+
+			await expect(
+				nativeMediaUploadMiddleware( options, makeNext() )
+			).resolves.toBe( response );
+		} );
+
+		it( 'still parses the body when parse is not disabled', async () => {
+			global.fetch = vi.fn( () =>
+				Promise.resolve( new Response( '{"id":1}', { status: 201 } ) )
+			);
+
+			await expect(
+				nativeMediaUploadMiddleware(
+					makePostMediaOptions( makeFile() ),
+					makeNext()
+				)
+			).resolves.toEqual( { id: 1 } );
+		} );
+	} );
+
 	// MARK: - Signal forwarding
 
 	it( 'forwards abort signal to fetch', async () => {

--- a/src/utils/api-fetch-upload-middleware.test.js
+++ b/src/utils/api-fetch-upload-middleware.test.js
@@ -717,4 +717,103 @@ describe( 'nativeMediaUploadMiddleware', () => {
 			controller.signal
 		);
 	} );
+
+	// MARK: - Media deletion
+
+	describe( 'media deletion', () => {
+		beforeEach( () => {
+			getGBKit.mockReturnValue( {
+				nativeUploadPort: 8080,
+				nativeUploadToken: 'token',
+			} );
+		} );
+
+		it( 'routes an attachment deletion through the native server', async () => {
+			// api-fetch tunnels DELETE as POST + `X-HTTP-Method-Override`, which
+			// core's CORS allow-list omits, so a cross-origin editor cannot make
+			// this request directly. Relaying it keeps the orphan cleanup working.
+			global.fetch = vi.fn( () =>
+				Promise.resolve(
+					new Response( '{"deleted":true}', { status: 200 } )
+				)
+			);
+			const next = makeNext();
+
+			await expect(
+				nativeMediaUploadMiddleware(
+					{ method: 'DELETE', path: '/wp/v2/media/42?force=true' },
+					next
+				)
+			).resolves.toEqual( { deleted: true } );
+
+			expect( next ).not.toHaveBeenCalled();
+			const [ url, options ] = global.fetch.mock.calls[ 0 ];
+			expect( String( url ) ).toBe(
+				'http://localhost:8080/media/42?force=true'
+			);
+			expect( options.method ).toBe( 'DELETE' );
+			expect( options.headers[ 'Relay-Authorization' ] ).toBe(
+				'Bearer token'
+			);
+		} );
+
+		it( 'passes through a deletion of a non-media path', async () => {
+			global.fetch = vi.fn();
+			const next = makeNext();
+
+			nativeMediaUploadMiddleware(
+				{ method: 'DELETE', path: '/wp/v2/posts/42' },
+				next
+			);
+
+			expect( next ).toHaveBeenCalled();
+			expect( global.fetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'passes through the media collection path', async () => {
+			// `/wp/v2/media` has no attachment ID, so it is not a deletion this
+			// server relays.
+			global.fetch = vi.fn();
+			const next = makeNext();
+
+			nativeMediaUploadMiddleware(
+				{ method: 'DELETE', path: '/wp/v2/media' },
+				next
+			);
+
+			expect( next ).toHaveBeenCalled();
+			expect( global.fetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'passes through when the native server is not configured', async () => {
+			getGBKit.mockReturnValue( {} );
+			global.fetch = vi.fn();
+			const next = makeNext();
+
+			nativeMediaUploadMiddleware(
+				{ method: 'DELETE', path: '/wp/v2/media/42?force=true' },
+				next
+			);
+
+			expect( next ).toHaveBeenCalled();
+			expect( global.fetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'rejects with the parsed error body on failure', async () => {
+			global.fetch = vi.fn( () =>
+				Promise.resolve(
+					new Response( '{"code":"rest_cannot_delete"}', {
+						status: 403,
+					} )
+				)
+			);
+
+			const thrown = await nativeMediaUploadMiddleware(
+				{ method: 'DELETE', path: '/wp/v2/media/42?force=true' },
+				makeNext()
+			).catch( ( error ) => error );
+
+			expect( thrown ).toEqual( { code: 'rest_cannot_delete' } );
+		} );
+	} );
 } );

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -43,10 +43,13 @@ export function configureApiFetch() {
 	// when the server exposes it via CORS:
 	//
 	// - Through the native upload server, which exposes it: works on both
-	//   platforms.
+	//   platforms. This is the only path that recovers everywhere.
 	// - Direct to WordPress, which does not expose it (see
-	//   `rest_send_cors_headers()`): works on Android, whose editor is
-	//   same-origin with the site, and fails on iOS, which loads from `file://`.
+	//   `rest_send_cors_headers()`): never recovers on iOS, which loads from
+	//   `file://`. On Android it recovers only when the editor is genuinely
+	//   same-origin — `GutenbergView` derives the asset domain from the site's
+	//   host, which drops the port, so a site on a non-default port (any local
+	//   dev setup) is cross-origin and does not recover.
 	//
 	// There is no fallback: core sends the header before
 	// `wp_generate_attachment_metadata()`, so the fatal leaves no body to parse

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -31,6 +31,12 @@ export function configureApiFetch() {
 	apiFetch.use( apiPathModifierMiddleware );
 	apiFetch.use( tokenAuthMiddleware );
 	apiFetch.use( filterEndpointsMiddleware );
+	// `apiFetch.use` unshifts, so the last registration runs first. Core's media
+	// upload middleware is registered before the native one so that it runs
+	// after it, and below auth, namespacing, and the root URL so the
+	// `post-process` requests it issues through `next` stay authenticated and
+	// correctly addressed.
+	apiFetch.use( apiFetch.mediaUploadMiddleware );
 	apiFetch.use( nativeMediaUploadMiddleware );
 	apiFetch.use( stripDraftPostIdMiddleware );
 	apiFetch.use( transformOEmbedApiResponse );

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -38,6 +38,19 @@ export function configureApiFetch() {
 	// above auth, namespacing, and the root URL, so the `post-process` requests
 	// core issues through `next` are still authenticated and correctly
 	// addressed.
+	//
+	// Recovery needs `x-wp-upload-attachment-id`, readable only same-origin or
+	// when the server exposes it via CORS:
+	//
+	// - Through the native upload server, which exposes it: works on both
+	//   platforms.
+	// - Direct to WordPress, which does not expose it (see
+	//   `rest_send_cors_headers()`): works on Android, whose editor is
+	//   same-origin with the site, and fails on iOS, which loads from `file://`.
+	//
+	// There is no fallback: core sends the header before
+	// `wp_generate_attachment_metadata()`, so the fatal leaves no body to parse
+	// the ID from.
 	apiFetch.use( nativeMediaUploadMiddleware );
 	apiFetch.use( apiFetch.mediaUploadMiddleware );
 	apiFetch.use( stripDraftPostIdMiddleware );

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -32,7 +32,7 @@ export function configureApiFetch() {
 	apiFetch.use( tokenAuthMiddleware );
 	apiFetch.use( filterEndpointsMiddleware );
 	apiFetch.use( nativeMediaUploadMiddleware );
-	apiFetch.use( mediaUploadMiddleware );
+	apiFetch.use( stripDraftPostIdMiddleware );
 	apiFetch.use( transformOEmbedApiResponse );
 	apiFetch.use( siteIndexMiddleware );
 	apiFetch.use(
@@ -380,14 +380,14 @@ function uploadAbortError( signal ) {
 }
 
 /**
- * Middleware to modify media upload requests.
+ * Middleware that strips the placeholder post ID from media upload requests.
  *
  * This middleware intercepts requests to the media endpoint and conditionally
  * removes the 'post' field if its value is '-1', which is used for draft posts.
  *
  * @type {APIFetchMiddleware}
  */
-function mediaUploadMiddleware( options, next ) {
+function stripDraftPostIdMiddleware( options, next ) {
 	if (
 		options.path &&
 		MEDIA_UPLOAD_PATH.test( options.path ) &&

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -74,16 +74,23 @@ function corsMiddleware( options, next ) {
  */
 function apiPathModifierMiddleware( options, next ) {
 	const { siteApiNamespace, namespaceExcludedPaths } = getGBKit();
-	const namespaceRegex = new RegExp( `(${ siteApiNamespace.join( '|' ) })` );
+	// Self-hosted sites configure no namespace, so there is nothing to insert.
+	// This has to gate the rewrite explicitly: the namespace match below cannot
+	// stand in for it, and an empty namespace would otherwise interpolate
+	// `undefined` into the path.
 	const isEligiblePath =
 		options.path &&
+		siteApiNamespace.length > 0 &&
 		! namespaceExcludedPaths.some( ( path ) =>
 			options.path.startsWith( path )
 		);
 
+	// Escape the namespaces so each is matched literally rather than as a
+	// pattern.
 	const alreadyHasSiteNamespace =
-		namespaceRegex.test( options.path ) ||
-		/\/sites\/[^/]+\//.test( options.path );
+		new RegExp(
+			`(${ siteApiNamespace.map( escapeRegExp ).join( '|' ) })`
+		).test( options.path ) || /\/sites\/[^/]+\//.test( options.path );
 
 	if ( isEligiblePath && ! alreadyHasSiteNamespace ) {
 		// Insert the API namespace after the first two path segments.
@@ -94,6 +101,16 @@ function apiPathModifierMiddleware( options, next ) {
 	}
 
 	return next( options );
+}
+
+/**
+ * Escapes a string for literal use inside a regular expression.
+ *
+ * @param {string} value The string to escape.
+ * @return {string} The escaped string.
+ */
+function escapeRegExp( value ) {
+	return value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
 }
 
 /**

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -301,9 +301,10 @@ function nativeMediaUpload( options, port, token ) {
 			// failure.
 			if ( options.parse === false ) {
 				if ( ! response.ok ) {
-					logError(
-						`Native upload failed with status ${ response.status }`
-					);
+					// A handoff to core's post-process retry, not an outcome —
+					// core reads `x-wp-upload-attachment-id` off this response and
+					// may still recover. Stay silent (as `nativeMediaDelete` does)
+					// rather than reporting a failure that hasn't happened yet.
 					return Promise.reject( response );
 				}
 				return response;

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -95,10 +95,6 @@ function corsMiddleware( options, next ) {
  */
 function apiPathModifierMiddleware( options, next ) {
 	const { siteApiNamespace, namespaceExcludedPaths } = getGBKit();
-	// Self-hosted sites configure no namespace, so there is nothing to insert.
-	// This has to gate the rewrite explicitly: the namespace match below cannot
-	// stand in for it, and an empty namespace would otherwise interpolate
-	// `undefined` into the path.
 	const isEligiblePath =
 		options.path &&
 		siteApiNamespace.length > 0 &&

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -194,16 +194,11 @@ function filterEndpointsMiddleware( options, next ) {
 }
 
 /**
- * Middleware that routes media uploads through the native host's local HTTP
- * server for processing (e.g. image resizing) before uploading to WordPress.
+ * Middleware that routes media requests through the native host's local HTTP
+ * server: uploads for processing (e.g. image resizing) before they reach
+ * WordPress, and attachment deletions for the editor's orphan cleanup.
  *
  * Exported for testing only.
- *
- * When `nativeUploadPort` is configured in GBKit, this middleware intercepts
- * `POST /wp/v2/media` requests, forwards the file to the native server, and
- * returns the response in WordPress REST API attachment format so the existing
- * Gutenberg upload pipeline (blob previews, save locking, entity caching)
- * works unchanged.
  *
  * When the native server is not configured, requests pass through unmodified.
  *
@@ -224,27 +219,44 @@ function filterEndpointsMiddleware( options, next ) {
 export function nativeMediaUploadMiddleware( options, next ) {
 	const { nativeUploadPort, nativeUploadToken } = getGBKit();
 
-	if ( nativeUploadPort && nativeUploadToken ) {
-		const deletion = nativeMediaDelete(
-			options,
-			nativeUploadPort,
-			nativeUploadToken
-		);
-		if ( deletion ) {
-			return deletion;
-		}
+	if ( ! nativeUploadPort || ! nativeUploadToken ) {
+		return next( options );
 	}
 
+	// Each helper returns `null` when the request is not its concern, so an
+	// unhandled request falls through to the default path.
+	return (
+		nativeMediaDelete( options, nativeUploadPort, nativeUploadToken ) ??
+		nativeMediaUpload( options, nativeUploadPort, nativeUploadToken ) ??
+		next( options )
+	);
+}
+
+/**
+ * Routes a media upload through the native upload server.
+ *
+ * Returns `null` when the request is not a media upload, so the caller falls
+ * through to its normal handling.
+ *
+ * Intercepts `POST /wp/v2/media`, forwards the file to the native server, and
+ * returns the response in WordPress REST API attachment format so the existing
+ * Gutenberg upload pipeline (blob previews, save locking, entity caching) works
+ * unchanged.
+ *
+ * @param {Object} options The api-fetch options.
+ * @param {number} port    The native upload server port.
+ * @param {string} token   The native upload server bearer token.
+ * @return {?Promise} The relayed upload, or `null` if not applicable.
+ */
+function nativeMediaUpload( options, port, token ) {
 	if (
-		! nativeUploadPort ||
-		! nativeUploadToken ||
 		! options.method ||
 		options.method.toUpperCase() !== 'POST' ||
 		! options.path ||
 		! MEDIA_UPLOAD_PATH.test( options.path ) ||
 		! ( options.body instanceof FormData )
 	) {
-		return next( options );
+		return null;
 	}
 
 	// Only intercept a genuine file upload. `FormData.get('file')` returns a
@@ -254,11 +266,11 @@ export function nativeMediaUploadMiddleware( options, next ) {
 	// through to the default path — and guarantees `file.name` below is safe.
 	const file = options.body.get( 'file' );
 	if ( ! ( file instanceof File ) ) {
-		return next( options );
+		return null;
 	}
 
 	info(
-		`Routing upload of ${ file.name } through native server on port ${ nativeUploadPort }`
+		`Routing upload of ${ file.name } through native server on port ${ port }`
 	);
 
 	// Forward the original request body — the file plus every sibling field
@@ -270,10 +282,10 @@ export function nativeMediaUploadMiddleware( options, next ) {
 	// Use the two-argument form of `.then()` so the rejection handler catches
 	// *only* a connection-level failure of the `fetch()` itself — not errors
 	// thrown while handling a response (those must surface as real failures).
-	return fetch( `http://localhost:${ nativeUploadPort }/upload${ query }`, {
+	return fetch( `http://localhost:${ port }/upload${ query }`, {
 		method: 'POST',
 		headers: {
-			'Relay-Authorization': `Bearer ${ nativeUploadToken }`,
+			'Relay-Authorization': `Bearer ${ token }`,
 		},
 		body: options.body,
 		signal: options.signal,

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -32,12 +32,14 @@ export function configureApiFetch() {
 	apiFetch.use( tokenAuthMiddleware );
 	apiFetch.use( filterEndpointsMiddleware );
 	// `apiFetch.use` unshifts, so the last registration runs first. Core's media
-	// upload middleware is registered before the native one so that it runs
-	// after it, and below auth, namespacing, and the root URL so the
-	// `post-process` requests it issues through `next` stay authenticated and
-	// correctly addressed.
-	apiFetch.use( apiFetch.mediaUploadMiddleware );
+	// upload middleware is registered after the native one so that it runs
+	// before it, wrapping it: the native middleware handles an upload without
+	// calling `next`, so core's would never run at all from below. Both stay
+	// above auth, namespacing, and the root URL, so the `post-process` requests
+	// core issues through `next` are still authenticated and correctly
+	// addressed.
 	apiFetch.use( nativeMediaUploadMiddleware );
+	apiFetch.use( apiFetch.mediaUploadMiddleware );
 	apiFetch.use( stripDraftPostIdMiddleware );
 	apiFetch.use( transformOEmbedApiResponse );
 	apiFetch.use( siteIndexMiddleware );
@@ -251,6 +253,24 @@ export function nativeMediaUploadMiddleware( options, next ) {
 		signal: options.signal,
 	} ).then(
 		( response ) => {
+			// `parse: false` asks for raw `Response` semantics. Core's media
+			// upload middleware runs above this one and makes exactly that
+			// request so it can read `x-wp-upload-attachment-id` off a failed
+			// upload and retry `post-process`. Honor it by resolving or
+			// rejecting with the `Response` itself, leaving the parsing (and
+			// the recovery decision) to that middleware — parsing here would
+			// hide the header and turn a recoverable upload into a permanent
+			// failure.
+			if ( options.parse === false ) {
+				if ( ! response.ok ) {
+					logError(
+						`Native upload failed with status ${ response.status }`
+					);
+					return Promise.reject( response );
+				}
+				return response;
+			}
+
 			// The native server relays WordPress's response verbatim. On a
 			// non-2xx, mirror @wordpress/api-fetch: reject with the parsed WP
 			// error body ({ code, message, data }) so @wordpress/media-utils

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -18,6 +18,9 @@ import { info, error as logError } from './logger';
 /** Matches `POST /wp/v2/media` but not sub-paths like `/wp/v2/media/123`. */
 const MEDIA_UPLOAD_PATH = /^\/wp\/v2\/media(\?|$)/;
 
+/** Matches `/wp/v2/media/<id>`, capturing the attachment ID. */
+const MEDIA_ATTACHMENT_PATH = /^\/wp\/v2\/media\/(\d+)(\?|$)/;
+
 /**
  * Initializes the API fetch configuration and middleware.
  *
@@ -225,6 +228,17 @@ function filterEndpointsMiddleware( options, next ) {
 export function nativeMediaUploadMiddleware( options, next ) {
 	const { nativeUploadPort, nativeUploadToken } = getGBKit();
 
+	if ( nativeUploadPort && nativeUploadToken ) {
+		const deletion = nativeMediaDelete(
+			options,
+			nativeUploadPort,
+			nativeUploadToken
+		);
+		if ( deletion ) {
+			return deletion;
+		}
+	}
+
 	if (
 		! nativeUploadPort ||
 		! nativeUploadToken ||
@@ -372,6 +386,99 @@ export function nativeMediaUploadMiddleware( options, next ) {
 					),
 				};
 			}
+			throw {
+				code: 'fetch_error',
+				message: __(
+					'Could not get a valid response from the server.'
+				),
+			};
+		}
+	);
+}
+
+/**
+ * Routes a media attachment deletion through the native upload server.
+ *
+ * Returns `null` when the request is not a media deletion, so the caller falls
+ * through to its normal handling.
+ *
+ * Core's media upload middleware deletes the orphaned attachment when every
+ * `post-process` retry fails. That request cannot be made directly from a
+ * cross-origin editor: `@wordpress/api-fetch` tunnels `DELETE` as a `POST`
+ * carrying `X-HTTP-Method-Override`, and core's `rest_allowed_cors_headers`
+ * does not list that header, so the browser blocks it at preflight and the
+ * orphan survives. Relaying through the loopback server — which sets its own
+ * CORS policy — is what lets the cleanup complete.
+ *
+ * This runs before `X-HTTP-Method-Override` exists: api-fetch's `httpV1`
+ * middleware adds it further down the chain, so the method here is still a
+ * plain `DELETE`.
+ *
+ * @param {Object} options The api-fetch options.
+ * @param {number} port    The native upload server port.
+ * @param {string} token   The native upload server bearer token.
+ * @return {?Promise} The relayed deletion, or `null` if not applicable.
+ */
+function nativeMediaDelete( options, port, token ) {
+	if ( options.method?.toUpperCase() !== 'DELETE' || ! options.path ) {
+		return null;
+	}
+
+	const match = MEDIA_ATTACHMENT_PATH.exec( options.path );
+	if ( ! match ) {
+		return null;
+	}
+
+	const attachmentId = match[ 1 ];
+	const query = requestQuery( options.path );
+
+	info(
+		`Routing deletion of attachment ${ attachmentId } through native server`
+	);
+
+	return fetch(
+		`http://localhost:${ port }/media/${ attachmentId }${ query }`,
+		{
+			method: 'DELETE',
+			headers: { 'Relay-Authorization': `Bearer ${ token }` },
+			signal: options.signal,
+		}
+	).then(
+		( response ) => {
+			if ( options.parse === false ) {
+				if ( ! response.ok ) {
+					return Promise.reject( response );
+				}
+				return response;
+			}
+
+			if ( ! response.ok ) {
+				return response
+					.json()
+					.catch( () => invalidUploadResponseError() )
+					.then( ( body ) => {
+						logError( 'Native media deletion failed', body );
+						throw body;
+					} );
+			}
+
+			return response.json().catch( () => {
+				const error = invalidUploadResponseError();
+				logError(
+					'Native media deletion returned an invalid response',
+					error
+				);
+				throw error;
+			} );
+		},
+		( connectionError ) => {
+			if ( options.signal?.aborted ) {
+				throw uploadAbortError( options.signal );
+			}
+			logError(
+				'Native media deletion failed at the transport layer',
+				connectionError
+			);
 			throw {
 				code: 'fetch_error',
 				message: __(

--- a/src/utils/api-fetch.test.js
+++ b/src/utils/api-fetch.test.js
@@ -259,6 +259,69 @@ describe( 'api-fetch credentials handling', () => {
 		} );
 	} );
 
+	describe( 'apiPathModifierMiddleware', () => {
+		/** The URL of the first `fetch` call. */
+		function requestedUrl() {
+			return String( global.fetch.mock.calls[ 0 ][ 0 ] );
+		}
+
+		it( 'inserts the namespace when the path lacks it', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [ 'sites/123/' ],
+				namespaceExcludedPaths: [],
+			} );
+
+			await apiFetch( { path: '/wp/v2/posts' } ).catch( () => {} );
+
+			expect( requestedUrl() ).toContain( '/wp/v2/sites/123/posts' );
+		} );
+
+		it( 'leaves the path alone when it already carries the namespace', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [ 'sites/123/' ],
+				namespaceExcludedPaths: [],
+			} );
+
+			await apiFetch( { path: '/wp/v2/sites/123/posts' } ).catch(
+				() => {}
+			);
+
+			expect( requestedUrl() ).toContain( '/wp/v2/sites/123/posts' );
+			expect( requestedUrl() ).not.toContain( 'sites/123/sites/123' );
+		} );
+
+		it( 'leaves the path alone when no namespace is configured', async () => {
+			// An empty namespace previously built `new RegExp('()')`, which
+			// matches every string. Nothing should be inserted either way, but
+			// the guard must reach that outcome by reporting no namespace.
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [],
+				namespaceExcludedPaths: [],
+			} );
+
+			await apiFetch( { path: '/wp/v2/posts' } ).catch( () => {} );
+
+			expect( requestedUrl() ).toContain( '/wp/v2/posts' );
+			expect( requestedUrl() ).not.toContain( 'undefined' );
+		} );
+
+		it( 'skips paths excluded from namespacing', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [ 'sites/123/' ],
+				namespaceExcludedPaths: [ '/oembed' ],
+			} );
+
+			await apiFetch( { path: '/oembed/1.0/proxy' } ).catch( () => {} );
+
+			expect( requestedUrl() ).toContain( '/oembed/1.0/proxy' );
+			expect( requestedUrl() ).not.toContain( 'sites/123' );
+		} );
+	} );
+
 	it( 'should preserve other headers when adding Authorization', async () => {
 		bridge.getGBKit.mockReturnValue( {
 			siteApiRoot: 'https://example.com/wp-json/',

--- a/wp-env/mu-plugins/gutenbergkit-cors.php
+++ b/wp-env/mu-plugins/gutenbergkit-cors.php
@@ -9,12 +9,13 @@
  */
 function gutenbergkit_cors_allowed_origins() {
 	return array(
-		'http://localhost:5173',                    // Vite dev server
-		'http://localhost:4173',                    // Vite preview server
-		'http://10.0.2.2:5173',                    // Vite dev server (Android emulator)
-		'http://10.0.2.2:4173',                    // Vite preview server (Android emulator)
-		'https://appassets.androidplatform.net',   // Android production build (HTTPS site)
-		'http://appassets.androidplatform.net',    // Android production build (HTTP site)
+		'http://localhost:5173',                 // Vite dev server
+		'http://localhost:4173',                 // Vite preview server
+		'http://10.0.2.2',                       // wp-env site origin (Android emulator)
+		'http://10.0.2.2:5173',                  // Vite dev server (Android emulator)
+		'http://10.0.2.2:4173',                  // Vite preview server (Android emulator)
+		'https://appassets.androidplatform.net', // Android production build (HTTPS site)
+		'http://appassets.androidplatform.net',  // Android production build (HTTP site)
 	);
 }
 

--- a/wp-env/mu-plugins/gutenbergkit-media-failure.php
+++ b/wp-env/mu-plugins/gutenbergkit-media-failure.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Plugin Name: GutenbergKit Media Failure Simulator
+ * Description: Fatals during image sub-size generation so the editor's media upload post-process retry can be exercised locally. Development only.
+ *
+ * Reproduces the failure the retry recovers from: WordPress creates the
+ * attachment row and sends `X-WP-Upload-Attachment-ID`, then
+ * `wp_generate_attachment_metadata()` fatals — typically a PHP `memory_limit`
+ * or `max_execution_time` fatal on a large image. The editor reads that header
+ * off the 5xx and retries `POST /wp/v2/media/<id>/post-process`.
+ *
+ * Adapted from https://github.com/WordPress/gutenberg/pull/17858#issuecomment-540114688,
+ * with the random failure rate replaced by an explicit mode so both outcomes
+ * are reproducible:
+ *
+ *   recover  Fail once per attachment, then succeed. The retry recovers the
+ *            upload and the attachment completes.
+ *   always   Fail every time. Exhausts all five retries, after which the editor
+ *            DELETEs the orphaned attachment.
+ *   off      Normal uploads (the default).
+ *
+ * The mode is stored as an option rather than read per-request, because the
+ * upload and each post-process retry are separate requests — and an upload
+ * routed through the native upload server is relayed by URLSession/OkHttp,
+ * which carries no browser cookie. Set it over the REST API:
+ *
+ *   curl -u "$USER:$APP_PASSWORD" -X POST \
+ *     'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=recover'
+ *
+ * Or with WP-CLI:
+ *
+ *   npx wp-env run cli wp option update gbk_media_failure_mode recover
+ */
+
+const GBK_MEDIA_FAILURE_OPTION = 'gbk_media_failure_mode';
+const GBK_MEDIA_FAILURE_MODES  = array( 'off', 'recover', 'always' );
+
+/**
+ * Registers a route for flipping the failure mode without WP-CLI.
+ */
+function gbk_media_failure_register_route() {
+	register_rest_route(
+		'gutenbergkit/v1',
+		'/media-failure',
+		array(
+			'methods'             => array( 'GET', 'POST' ),
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'args'                => array(
+				'mode' => array(
+					'type'    => 'string',
+					'enum'    => GBK_MEDIA_FAILURE_MODES,
+					'default' => null,
+				),
+			),
+			'callback'            => function ( $request ) {
+				$mode = $request->get_param( 'mode' );
+
+				if ( null !== $mode ) {
+					update_option( GBK_MEDIA_FAILURE_OPTION, $mode );
+					// A stale per-attachment counter would make `recover` skip
+					// its failure on an attachment that already burned one.
+					gbk_media_failure_reset_counters();
+				}
+
+				return array( 'mode' => gbk_media_failure_mode() );
+			},
+		)
+	);
+}
+add_action( 'rest_api_init', 'gbk_media_failure_register_route' );
+
+/**
+ * Clears the per-attachment failure counters.
+ */
+function gbk_media_failure_reset_counters() {
+	global $wpdb;
+	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => '_gbk_media_failure_count' ) );
+}
+
+/**
+ * Returns the active failure mode.
+ */
+function gbk_media_failure_mode() {
+	$mode = get_option( GBK_MEDIA_FAILURE_OPTION, 'off' );
+
+	return in_array( $mode, GBK_MEDIA_FAILURE_MODES, true ) ? $mode : 'off';
+}
+
+/**
+ * Whether this sub-size generation pass should fatal.
+ *
+ * In `recover` mode the count is tracked per attachment, so a second upload
+ * fails once too rather than succeeding immediately because an earlier upload
+ * already burned the failure.
+ *
+ * @param int $attachment_id The attachment being processed.
+ */
+function gbk_media_failure_should_fail( $attachment_id ) {
+	switch ( gbk_media_failure_mode() ) {
+		case 'always':
+			return true;
+
+		case 'recover':
+			$key = '_gbk_media_failure_count';
+			// `get_post_meta` returns '' when unset, which casts to 0.
+			$attempts = (int) get_post_meta( $attachment_id, $key, true );
+			update_post_meta( $attachment_id, $key, $attempts + 1 );
+			return 0 === $attempts;
+
+		default:
+			return false;
+	}
+}
+
+/**
+ * Fatals during sub-size generation when the active mode calls for it.
+ *
+ * Hooks both filters core runs while building sub-sizes: the initial upload
+ * goes through `intermediate_image_sizes_advanced`, and the `post-process`
+ * retry goes through `wp_get_missing_image_subsizes`.
+ *
+ * @param array $sizes         The sizes to generate.
+ * @param mixed $metadata      Image metadata (unused).
+ * @param int   $attachment_id The attachment being processed.
+ */
+function gbk_media_failure_maybe_fail( $sizes, $metadata = null, $attachment_id = 0 ) {
+	if ( gbk_media_failure_should_fail( $attachment_id ) ) {
+		// Send the 500 explicitly before dying. A real PHP fatal under FPM
+		// surfaces as a 500, but the Playground runtime wp-env uses returns 200,
+		// which the editor's retry (`status >= 500`) would ignore. The status
+		// has to be set here because `X-WP-Upload-Attachment-ID` was already
+		// sent above this filter, so PHP has committed the response.
+		if ( ! headers_sent() ) {
+			http_response_code( 500 );
+		}
+
+		// Terminate the way a memory_limit or max_execution_time fatal does,
+		// after the attachment row exists and its ID header has been sent.
+		trigger_error( 'GutenbergKit simulated media failure', E_USER_ERROR );
+		exit;
+	}
+
+	return $sizes;
+}
+add_filter( 'intermediate_image_sizes_advanced', 'gbk_media_failure_maybe_fail', 10, 3 );
+add_filter( 'wp_get_missing_image_subsizes', 'gbk_media_failure_maybe_fail', 10, 3 );

--- a/wp-env/mu-plugins/gutenbergkit-media-failure.php
+++ b/wp-env/mu-plugins/gutenbergkit-media-failure.php
@@ -115,6 +115,31 @@ function gbk_media_failure_should_fail( $attachment_id ) {
 }
 
 /**
+ * Whether the current request is one this simulator should be able to fail.
+ *
+ * Only the upload and its `post-process` retries. A `DELETE` must be left alone
+ * even in `always` mode: core's `force=true` delete path also runs sub-size
+ * handling, so failing there fatals the editor's orphan cleanup — the very
+ * request that proves the retry gave up correctly. Worse, a fatal aborts the
+ * request before `rest_pre_serve_request` adds CORS headers, so the editor sees
+ * a CORS error rather than the 500, which reads like a bug in the editor rather
+ * than in this plugin.
+ */
+function gbk_media_failure_is_failable_request() {
+	$method = isset( $_SERVER['REQUEST_METHOD'] )
+		? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) )
+		: '';
+
+	// api-fetch tunnels DELETE through POST with an override header, so the
+	// bare method is not enough to identify a delete.
+	$override = isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] )
+		? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) )
+		: '';
+
+	return 'DELETE' !== $method && 'DELETE' !== $override;
+}
+
+/**
  * Fatals during sub-size generation when the active mode calls for it.
  *
  * Hooks both filters core runs while building sub-sizes: the initial upload
@@ -126,6 +151,10 @@ function gbk_media_failure_should_fail( $attachment_id ) {
  * @param int   $attachment_id The attachment being processed.
  */
 function gbk_media_failure_maybe_fail( $sizes, $metadata = null, $attachment_id = 0 ) {
+	if ( ! gbk_media_failure_is_failable_request() ) {
+		return $sizes;
+	}
+
 	if ( gbk_media_failure_should_fail( $attachment_id ) ) {
 		// Send the 500 explicitly before dying. A real PHP fatal under FPM
 		// surfaces as a 500, but the Playground runtime wp-env uses returns 200,


### PR DESCRIPTION
## What?

Registers `@wordpress/api-fetch`'s `mediaUploadMiddleware`, which retries `post-process` when a media upload fails server-side, and makes both the native upload path and the orphan cleanup work with it.

## Why?

Ref CMM-2151. Ref CMM-2274. 

When `wp_generate_attachment_metadata()` fatals server-side — commonly a PHP `memory_limit` or `max_execution_time` fatal on a large image — the upload surfaces as a permanent failure. The user is left with an orphaned gray attachment, and retrying duplicates it (the `-2`/`-3` filename suffixes seen in the field).

WordPress already supports recovering from this: it creates the attachment row, sends `X-WP-Upload-Attachment-ID`, and expects the client to retry `POST /wp/v2/media/<id>/post-process`. Gutenberg's [`mediaUploadMiddleware`](https://github.com/WordPress/gutenberg/blob/da0bf8d33d8817d52c5a61d4c2dae543f70ea93b/packages/api-fetch/src/middlewares/media-upload.ts#L21-L26) implements that. WordPress core [registers it](https://github.com/WordPress/wordpress-develop/blob/8b91cc16cc78b817386b406f50ced8df86fb466d/src/wp-includes/script-loader.php#L372), but GutenbergKit never did.

## How?

Renames the local middleware to `stripDraftPostIdMiddleware` and registers `apiFetch.mediaUploadMiddleware`. `apiFetch.use` unshifts, so registration order is the reverse of execution order: core's is registered after the native one so it runs before it, wrapping it — the native middleware handles an upload without calling `next`, so core's would never run at all from below. Both stay above auth, namespacing, and the root URL so the `post-process` requests core issues stay authenticated.

Two things then had to change for that retry to work in practice:

- `relayResponse` rebuilt the response with a hardcoded `Content-Type`, dropping `x-wp-upload-attachment-id`. It is now relayed via an allowlist and exposed through CORS, and `nativeMediaUploadMiddleware` honors `parse: false` by yielding the `Response` core inspects.
- The orphan cleanup was blocked at CORS preflight: api-fetch tunnels `DELETE` as a `POST` carrying `X-HTTP-Method-Override`, which core's `rest_allowed_cors_headers` omits. Media deletions now route through the loopback server, which permits `DELETE`. This was a pre-existing bug, independent of the retry work.

Also fixes the namespace guard: `new RegExp('(' + [].join('|') + ')')` is `/()/`, which matches every string, so `alreadyHasSiteNamespace` was unconditionally true for self-hosted sites. That was load-bearing — it suppressed a rewrite that would otherwise interpolate `undefined` into every path.

Adds a wp-env media failure simulator (`make wp-env-media-failure MODE=off|recover|always`) so the retry can be exercised locally. See `docs/code/local-wordpress.md`.

### Known limitation

Recovery requires reading `x-wp-upload-attachment-id`, which is only possible same-origin or when the server exposes it via CORS. The native upload server exposes it, so **uploads routed through it recover on both platforms**. A _direct_ upload depends on the site: core's `rest_send_cors_headers()` does not expose the header, so it recovers only where the editor is genuinely same-origin with the site. There is no client-side fallback — core sends the header before `wp_generate_attachment_metadata()`, so the fatal leaves no body to parse the ID from.

## Testing Instructions

Requires the local WordPress environment and a build with native media upload enabled.

1. `make wp-env-start` (add `RESET=1` if credentials are stale)
2. `make wp-env-media-failure MODE=recover`
3. Build and run a demo app, open the editor against **Local WordPress (wp-env)**, and insert an Image block with any image.
4. **Expect:** the upload 500s, a `post-process` request follows and succeeds, and the image renders with no error notice. The attachment has all sub-sizes and there is exactly one of it.
5. `make wp-env-media-failure MODE=always`, then upload again.
6. **Expect:** the upload 500s, five `post-process` attempts fail, then a `DELETE` to `localhost:<port>/media/<id>` returns 200 and the media library is left empty.
7. `make wp-env-media-failure MODE=off` when finished.

Verified end to end on both platforms in all four combinations (iOS and Android × `recover` and `always`).

### Accessibility Testing Instructions

Not applicable — no user interface changes.
