### PR TITLE
build: stabilize the wp-env utilities

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -7,6 +7,7 @@
 	"mappings": {
 		"wp-content/mu-plugins": "./wp-env/mu-plugins"
 	},
+	"testsEnvironment": false,
 	"config": {
 		"WP_DEBUG": true,
 		"WP_DEBUG_LOG": true,

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,13 @@ preview: npm-dependencies ## Preview the production build locally
 
 .PHONY: wp-env-start
 wp-env-start: npm-dependencies ## Start the local WordPress environment
-	npm run wp-env start -- --runtime=playground
+	@bash bin/wp-env-guard.sh; \
+	status=$$?; \
+	if [ $$status -eq 0 ]; then \
+		npm run wp-env start -- --runtime=playground; \
+	elif [ $$status -ne 10 ]; then \
+		exit $$status; \
+	fi
 	@bash bin/wp-env-setup.sh
 
 .PHONY: wp-env-stop
@@ -209,6 +215,9 @@ wp-env-stop: ## Stop the local WordPress environment
 wp-env-clean: ## Stop wp-env and remove all data (fresh start)
 	npm run wp-env destroy
 	@rm -f .wp-env.credentials.json
+# `destroy` stops only the server named by its PID file, so report anything left
+# holding the port rather than letting the next start fail on it.
+	@bash bin/wp-env-guard.sh > /dev/null || true
 
 .PHONY: wp-env-android
 wp-env-android: ## Remap wp-env site URLs for the Android emulator and restart

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ wp-env-stop: ## Stop the local WordPress environment
 	npm run wp-env stop
 
 .PHONY: wp-env-clean
-wp-env-clean: ## Stop wp-env and remove all data (fresh start)
+wp-env-clean: ## Stop wp-env and remove downloaded WordPress, plugin, and theme files
 	npm run wp-env destroy
 	@rm -f .wp-env.credentials.json
 # `destroy` stops only the server named by its PID file, so report anything left

--- a/Makefile
+++ b/Makefile
@@ -219,15 +219,9 @@ wp-env-clean: ## Stop wp-env and remove all data (fresh start)
 # holding the port rather than letting the next start fail on it.
 	@bash bin/wp-env-guard.sh > /dev/null || true
 
-.PHONY: wp-env-android
-wp-env-android: ## Remap wp-env site URLs for the Android emulator and restart
-	@cp wp-env/android-url-override.php wp-env/mu-plugins/gutenbergkit-android-urls.php
-	@$(MAKE) wp-env-start
-
-.PHONY: wp-env-android-reset
-wp-env-android-reset: ## Remove the Android emulator URL remap and restart
-	@rm -f wp-env/mu-plugins/gutenbergkit-android-urls.php
-	@$(MAKE) wp-env-start
+.PHONY: wp-env-android-urls
+wp-env-android-urls: ## Report whether WordPress emits emulator-reachable URLs, 10.0.2.2 instead of localhost (set via MODE=on|off)
+	@MODE=$(MODE) bash bin/wp-env-android.sh
 
 ################################################################################
 # Code Quality Targets

--- a/Makefile
+++ b/Makefile
@@ -197,9 +197,9 @@ preview: npm-dependencies ## Preview the production build locally
 ################################################################################
 
 .PHONY: wp-env-start
-wp-env-start: npm-dependencies ## Start the local WordPress environment (RESET=1 to regenerate credentials)
+wp-env-start: npm-dependencies ## Start the local WordPress environment
 	npm run wp-env start -- --runtime=playground
-	@RESET=$(RESET) bash bin/wp-env-setup.sh
+	@bash bin/wp-env-setup.sh
 
 .PHONY: wp-env-stop
 wp-env-stop: ## Stop the local WordPress environment
@@ -213,12 +213,12 @@ wp-env-clean: ## Stop wp-env and remove all data (fresh start)
 .PHONY: wp-env-android
 wp-env-android: ## Remap wp-env site URLs for the Android emulator and restart
 	@cp wp-env/android-url-override.php wp-env/mu-plugins/gutenbergkit-android-urls.php
-	@RESET=1 $(MAKE) wp-env-start
+	@$(MAKE) wp-env-start
 
 .PHONY: wp-env-android-reset
 wp-env-android-reset: ## Remove the Android emulator URL remap and restart
 	@rm -f wp-env/mu-plugins/gutenbergkit-android-urls.php
-	@RESET=1 $(MAKE) wp-env-start
+	@$(MAKE) wp-env-start
 
 ################################################################################
 # Code Quality Targets

--- a/bin/wp-env-android.sh
+++ b/bin/wp-env-android.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# wp-env-android.sh — Read or set the Android emulator URL remap.
+#
+# Drives the `gutenbergkit-android-urls` mu-plugin, which rewrites localhost
+# and 127.0.0.1 to 10.0.2.2 in WordPress's URL output so media, block assets,
+# and REST links resolve inside the Android emulator.
+#
+# This is separate from the credentials remap in LocalWordPressCredentials.kt,
+# which rewrites the site URL the app connects to and applies automatically.
+# This plugin covers the URLs WordPress emits in response bodies, which the app
+# receives as content rather than configuration.
+#
+# The mu-plugins directory is mounted into the running server, so toggling
+# takes effect without restarting. That also means this is a plain file
+# operation which works whether or not the environment is running.
+#
+# Usage:
+#   bash bin/wp-env-android.sh           # Report the current mode
+#   MODE=on  bash bin/wp-env-android.sh  # Emit 10.0.2.2 URLs
+#   MODE=off bash bin/wp-env-android.sh  # Emit localhost URLs
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SOURCE_PLUGIN="$PROJECT_ROOT/wp-env/android-url-override.php"
+ACTIVE_PLUGIN="$PROJECT_ROOT/wp-env/mu-plugins/gutenbergkit-android-urls.php"
+
+VALID_MODES="on off"
+MODE="${MODE:-}"
+
+# ---------------------------------------------------------------------------
+# Validate the requested mode before touching the filesystem
+# ---------------------------------------------------------------------------
+
+if [ -n "$MODE" ]; then
+    case " $VALID_MODES " in
+        *" $MODE "*) ;;
+        *)
+            echo "Error: invalid MODE '$MODE'." >&2
+            echo "Valid modes: $VALID_MODES" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+if [ "$MODE" = "on" ]; then
+    if [ ! -f "$SOURCE_PLUGIN" ]; then
+        echo "Error: $SOURCE_PLUGIN not found." >&2
+        exit 1
+    fi
+
+    cp "$SOURCE_PLUGIN" "$ACTIVE_PLUGIN"
+elif [ "$MODE" = "off" ]; then
+    rm -f "$ACTIVE_PLUGIN"
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+if [ -f "$ACTIVE_PLUGIN" ]; then
+    CURRENT="on"
+else
+    CURRENT="off"
+fi
+
+echo "Android emulator URLs: $CURRENT"
+
+if [ "$CURRENT" = "on" ]; then
+    echo "WordPress emits 10.0.2.2 instead of localhost for media, block assets,"
+    echo "and REST links."
+else
+    echo "WordPress emits localhost URLs, reachable from a browser and the iOS"
+    echo "Simulator."
+fi
+
+if [ -n "$MODE" ]; then
+    echo "Rebuild the Android app to pick up the change."
+else
+    if [ "$CURRENT" = "on" ]; then
+        OTHER="off"
+    else
+        OTHER="on"
+    fi
+
+    echo
+    echo "To change it: make wp-env-android-urls MODE=$OTHER"
+fi

--- a/bin/wp-env-guard.sh
+++ b/bin/wp-env-guard.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# wp-env-guard.sh — Preflight check before starting the local WordPress environment.
+#
+# Starting a second Playground server while one already holds the port fails
+# with EADDRINUSE, and wp-env deletes the PID file as it unwinds the failed
+# start — including when that file names the healthy server that was already
+# running. `wp-env stop` and `wp-env status` both trust the PID file alone, so
+# afterwards they report success and "stopped" while the server keeps serving.
+#
+# Guarding before the start avoids creating that state rather than cleaning up
+# after it.
+#
+# This script only reports. Each git worktree gets its own work directory, and
+# so its own PID file, while contending for the same port, so a process holding
+# it may be another worktree's healthy environment rather than an orphan.
+# Telling them apart needs a person, and stopping the wrong one interrupts work
+# elsewhere, so the decision and the command are left to the caller.
+#
+# Usage:
+#   bash bin/wp-env-guard.sh   # Exits non-zero if the start should not proceed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Resolve the port and work directory
+#
+# Ask wp-env rather than deriving these here. The work directory honours
+# WP_ENV_HOME and moves to ~/wp-env on snap systems, and the port comes from
+# WP_ENV_PORT or the config's own "port" key. Recomputing either by hand would
+# disagree with wp-env as soon as any of those is set, leaving the guard unable
+# to recognise our own server.
+# ---------------------------------------------------------------------------
+
+CONFIG=$(cd "$PROJECT_ROOT" && node -e "
+    const { loadConfig } = require( '@wordpress/env/lib/config' );
+    loadConfig( process.cwd() )
+        .then( ( config ) => {
+            process.stdout.write(
+                [ config.env.development.port, config.workDirectoryPath ].join( '\n' )
+            );
+        } )
+        .catch( () => process.exit( 1 ) );
+") || CONFIG=""
+
+PORT=$(printf '%s\n' "$CONFIG" | sed -n '1p')
+WORK_DIR=$(printf '%s\n' "$CONFIG" | sed -n '2p')
+
+# Degrade to a plain port check rather than skipping the guard entirely when
+# the config cannot be read.
+PORT="${PORT:-${WP_ENV_PORT:-8888}}"
+
+# ---------------------------------------------------------------------------
+# Is anything holding the port?
+# ---------------------------------------------------------------------------
+
+PORT_PIDS=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | sort -u) || PORT_PIDS=""
+
+if [ -z "$PORT_PIDS" ]; then
+    exit 0
+fi
+
+# A server may listen on both IPv4 and IPv6, and the PID file names only one
+# process. Treat the set as ours only when every listener is accounted for.
+PORT_PID_COUNT=$(printf '%s\n' "$PORT_PIDS" | grep -c .)
+PORT_PID=$(printf '%s\n' "$PORT_PIDS" | sed -n '1p')
+
+# ---------------------------------------------------------------------------
+# Does it belong to this project's environment?
+# ---------------------------------------------------------------------------
+
+TRACKED_PID=""
+
+if [ -n "$WORK_DIR" ] && [ -f "$WORK_DIR/playground.pid" ]; then
+    TRACKED_PID=$(tr -d '[:space:]' < "$WORK_DIR/playground.pid" 2>/dev/null) || TRACKED_PID=""
+fi
+
+if [ -n "$TRACKED_PID" ] && [ "$TRACKED_PID" = "$PORT_PID" ] && [ "$PORT_PID_COUNT" -eq 1 ]; then
+    echo "The local WordPress environment is already running on port $PORT."
+    echo "Skipping start; credentials will be verified next."
+    echo "To apply .wp-env.json changes, run 'make wp-env-stop' first."
+    exit 10
+fi
+
+# ---------------------------------------------------------------------------
+# Untracked process on the port
+# ---------------------------------------------------------------------------
+
+echo "Error: port $PORT is held by a process this project does not track." >&2
+echo >&2
+for pid in $PORT_PIDS; do
+    echo "  PID $pid: $(ps -o command= -p "$pid" 2>/dev/null | cut -c1-160)" >&2
+done
+echo >&2
+echo "This is usually an orphaned Playground server, but it may belong to" >&2
+echo "another worktree's environment. Check the command above, then stop it:" >&2
+echo >&2
+echo "  kill $(printf '%s' "$PORT_PIDS" | tr '\n' ' ')" >&2
+
+exit 1

--- a/bin/wp-env-setup.sh
+++ b/bin/wp-env-setup.sh
@@ -8,9 +8,14 @@
 # This script uses only REST API calls (no WP-CLI / wp-env run), so it works
 # with both the Docker and Playground runtimes.
 #
+# Existing credentials are reused only when they still authenticate. The
+# Playground runtime has no persistent database, so every restart rebuilds
+# WordPress from the Blueprint and discards the application password. The
+# credentials file is the one artifact that survives that, which makes its
+# presence on disk no evidence that it still works.
+#
 # Usage:
-#   bash bin/wp-env-setup.sh           # Create credentials (skips if file exists)
-#   RESET=1 bash bin/wp-env-setup.sh   # Recreate credentials from scratch
+#   bash bin/wp-env-setup.sh   # Reuse working credentials, otherwise recreate
 
 set -euo pipefail
 
@@ -24,20 +29,38 @@ PASSWORD="password"
 APP_NAME="GutenbergKit"
 
 # ---------------------------------------------------------------------------
-# Parse flags
+# Reuse existing credentials only if they still authenticate
+#
+# Anything other than a clean 200 falls through to provisioning: regenerating
+# unnecessarily costs a few seconds, whereas keeping credentials that no longer
+# work leaves the demo apps unable to connect.
 # ---------------------------------------------------------------------------
 
-RESET="${RESET:-}"
-
-if { [ "$RESET" = "true" ] || [ "$RESET" = "1" ]; } && [ -f "$CREDENTIALS_FILE" ]; then
-    echo "Removing existing credentials file..."
-    rm -f "$CREDENTIALS_FILE"
-fi
-
 if [ -f "$CREDENTIALS_FILE" ]; then
-    echo "Credentials file already exists at $CREDENTIALS_FILE — skipping setup."
-    echo "Use RESET=1 to regenerate credentials."
-    exit 0
+    EXISTING_AUTH=$(node -e "
+        const fs = require('fs');
+        try {
+            const c = JSON.parse(fs.readFileSync('$CREDENTIALS_FILE', 'utf8'));
+            if (!c.authHeader) process.exit(1);
+            process.stdout.write(c.authHeader);
+        } catch {
+            process.exit(1);
+        }
+    ") || EXISTING_AUTH=""
+
+    if [ -n "$EXISTING_AUTH" ]; then
+        PROBE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+            -H "Authorization: $EXISTING_AUTH" \
+            "$SITE_URL/?rest_route=/wp/v2/users/me" 2>/dev/null) || PROBE_STATUS=""
+
+        if [ "$PROBE_STATUS" = "200" ]; then
+            echo "Existing credentials are valid — skipping setup."
+            exit 0
+        fi
+    fi
+
+    echo "Existing credentials are no longer valid — regenerating..."
+    rm -f "$CREDENTIALS_FILE"
 fi
 
 # ---------------------------------------------------------------------------

--- a/bin/wp-env-setup.sh
+++ b/bin/wp-env-setup.sh
@@ -23,7 +23,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CREDENTIALS_FILE="$PROJECT_ROOT/.wp-env.credentials.json"
 
-SITE_URL="http://localhost:8888"
+# Resolve the port from wp-env so a "port" key in .wp-env.json or WP_ENV_PORT is
+# honoured here too, rather than provisioning against a site that moved.
+PORT=$(cd "$PROJECT_ROOT" && node -e "
+    const { loadConfig } = require( '@wordpress/env/lib/config' );
+    loadConfig( process.cwd() )
+        .then( ( config ) => process.stdout.write( String( config.env.development.port ) ) )
+        .catch( () => process.exit( 1 ) );
+") || PORT=""
+
+SITE_URL="http://localhost:${PORT:-${WP_ENV_PORT:-8888}}"
 USERNAME="admin"
 PASSWORD="password"
 APP_NAME="GutenbergKit"

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -30,7 +30,7 @@ Once started, the **"Local WordPress"** option in both the iOS and Android demo 
 | --------------------------------------- | ------------------------------------------------------------- |
 | `make wp-env-start`                     | Start the environment and provision credentials               |
 | `make wp-env-stop`                      | Stop the environment                                          |
-| `make wp-env-clean`                     | Destroy the environment and remove all local files            |
+| `make wp-env-clean`                     | Remove downloaded WordPress, plugin, and theme files          |
 | `make wp-env-android-urls`              | Report whether WordPress emits emulator-reachable URLs        |
 | `make wp-env-android-urls MODE=on\|off` | Emit `10.0.2.2` URLs for the Android emulator, or `localhost` |
 
@@ -147,6 +147,8 @@ If the port belongs to an unrelated service, change the wp-env port in `.wp-env.
 	"port": 9999
 }
 ```
+
+The make targets read the port from wp-env, so a `port` key here — or the `WP_ENV_PORT` environment variable — applies to the port check and credential provisioning as well as to the server itself.
 
 ### Resetting the environment
 

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -117,11 +117,21 @@ Access the WordPress admin dashboard at **http://localhost:8888/wp-admin/**:
 
 ### Port 8888 is already in use
 
+`make wp-env-start` checks the port before starting and reports the process holding it:
+
 ```
-Error: Port 8888 is already allocated
+Error: port 8888 is held by a process this project does not track.
+
+  PID 31041: node .../wp-playground.js server --port 8888 ...
 ```
 
-Another service is using port 8888. Stop the conflicting service or change the wp-env port in `.wp-env.json`:
+It reports the process rather than stopping it. Because each git worktree tracks its own environment while sharing one port, the process may be another worktree's healthy site rather than an orphan — check the command line, then stop it yourself:
+
+```bash
+kill <PID>
+```
+
+If the port belongs to an unrelated service, change the wp-env port in `.wp-env.json` instead:
 
 ```json
 {
@@ -137,6 +147,8 @@ To start fresh, destroy the environment and recreate it:
 make wp-env-clean
 make wp-env-start
 ```
+
+`make wp-env-clean` also checks the port afterwards. If a server is still holding it — one wp-env lost track of, and so could not stop — it reports the process so the next start does not fail on it.
 
 ### Credentials file not found
 

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -54,7 +54,9 @@ The `bin/wp-env-setup.sh` script runs automatically after `wp-env start`:
 3. Generates a Base64-encoded Basic Auth header.
 4. Writes credentials to `.wp-env.credentials.json`.
 
-The script is idempotent — it skips if the credentials file already exists. Use `make wp-env-start RESET=1` (or `make wp-env-clean`) to regenerate.
+The script is idempotent. It reuses existing credentials only when they still authenticate, and regenerates them otherwise — so `make wp-env-start` is safe to run repeatedly.
+
+This matters because the Playground runtime has no persistent database. Every restart rebuilds WordPress from the Blueprint, which recreates the `admin` user and discards the application password. The credentials file survives the restart even though the credentials it holds do not, so the file's presence alone is not evidence that it works.
 
 ### Demo App Integration
 

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -26,13 +26,15 @@ Once started, the **"Local WordPress"** option in both the iOS and Android demo 
 
 ## Available Commands
 
-| Command                     | Description                                             |
-| --------------------------- | ------------------------------------------------------- |
-| `make wp-env-start`         | Start the environment and provision credentials         |
-| `make wp-env-stop`          | Stop the environment (preserves data)                   |
-| `make wp-env-clean`         | Destroy the environment and remove all data             |
-| `make wp-env-android`       | Restart with site URL remapped for the Android emulator |
-| `make wp-env-android-reset` | Restart with the default localhost site URL             |
+| Command                                 | Description                                                   |
+| --------------------------------------- | ------------------------------------------------------------- |
+| `make wp-env-start`                     | Start the environment and provision credentials               |
+| `make wp-env-stop`                      | Stop the environment                                          |
+| `make wp-env-clean`                     | Destroy the environment and remove all local files            |
+| `make wp-env-android-urls`              | Report whether WordPress emits emulator-reachable URLs        |
+| `make wp-env-android-urls MODE=on\|off` | Emit `10.0.2.2` URLs for the Android emulator, or `localhost` |
+
+The site is rebuilt from scratch on every start, so stopping the environment discards any content you created. Use `make wp-env-clean` when you also want to remove the downloaded WordPress, plugin, and theme files.
 
 ## How It Works
 
@@ -78,25 +80,32 @@ The Xcode scheme includes a `WP_ENV_CREDENTIALS_PATH` environment variable point
 
 The Android emulator cannot reach `localhost` on the host machine directly. The credentials loader automatically remaps `localhost` to `10.0.2.2` (the emulator's alias for the host). Credentials are read at build time and baked into `BuildConfig` fields, since the emulator cannot access the host filesystem at runtime.
 
-#### Image URLs in the Android Emulator
+#### Server-Generated URLs in the Android Emulator
 
-WordPress generates image URLs (e.g., for uploaded media) using its configured site URL, which defaults to `http://localhost:8888`. These URLs don't resolve inside the Android emulator because `localhost` points to the emulator itself.
+The credentials remap above covers the site URL the app connects to. It does not cover the URLs WordPress writes into its responses — uploaded media, block editor assets, theme styles, and REST links — which WordPress generates from its configured site URL of `http://localhost:8888`. The app receives those as content rather than configuration, and they don't resolve inside the emulator because `localhost` points at the emulator itself.
 
-To fix this, activate a mu-plugin that remaps URLs and restart wp-env:
+To remap them, enable the URL override:
 
 ```bash
-make wp-env-android
+make wp-env-android-urls MODE=on
 ```
 
-This installs a mu-plugin (`gutenbergkit-android-urls.php`) that rewrites `localhost` and `127.0.0.1` to `10.0.2.2` in WordPress's site URL output, then restarts wp-env and regenerates credentials. After restarting, rebuild the Android app so the new credentials are baked into `BuildConfig`.
+This installs a mu-plugin (`gutenbergkit-android-urls.php`) that rewrites `localhost` and `127.0.0.1` to `10.0.2.2` in WordPress's URL output. The mu-plugins directory is mounted into the running server, so the change applies immediately — no restart, and existing credentials keep working.
+
+Rebuild the Android app afterwards. This is needed for the URL change itself, not because credentials rotated: `BuildConfig` is populated at build time.
 
 To revert (for browser access or iOS testing):
 
 ```bash
-make wp-env-android-reset
+make wp-env-android-urls MODE=off
 ```
 
-Note: While the URL override is active, the WordPress admin dashboard (`http://localhost:8888/wp-admin/`) will redirect to `10.0.2.2`, which doesn't resolve in a desktop browser.
+Run it with no `MODE` to report the current setting.
+
+Two things to be aware of while the override is active:
+
+-   The WordPress admin dashboard (`http://localhost:8888/wp-admin/`) redirects to `10.0.2.2`, which doesn't resolve in a desktop browser.
+-   The `/wp/v2/settings` endpoint still reports `url` as `localhost`, because that field reads the stored option directly rather than passing through the `site_url` and `home_url` filters. It is not a reliable way to check whether the override is on — use `make wp-env-android-urls` instead.
 
 ### Physical Devices
 


### PR DESCRIPTION
## What?

Three failure modes in the `wp-env` make targets: credentials went stale after every restart, a mistimed start could orphan the Playground server and wedge the environment, and the Android URL targets triggered that orphan by design.

## Why?

`make wp-env-start` produced an environment the demo apps couldn't authenticate against, and recovering from a wedged server meant running `lsof` and `kill` by hand.

**Stale credentials.** The Playground runtime has no persistent database. Every start replays the Blueprint into a fresh database, recreating the `admin` user and discarding its application password. The credentials file is the one artifact that survives — so skipping setup when that file exists guaranteed stale credentials after any stop/start.

**Orphaned server.** Starting a second server fails with `EADDRINUSE`, and wp-env unlinks the PID file as it unwinds — including when that file names the _healthy_ server still running. `wp-env stop` and `wp-env status` trust the PID file alone, so afterwards they report `✔ Stopped` and `status: stopped` while the server keeps serving.

**Android targets.** `wp-env-android` and `wp-env-android-reset` called `wp-env-start` with no `stop` first, which is exactly the double-start above. The restart was never needed: mu-plugins are mounted into the running server, so the toggle applies on the next request.

## How?

**Credentials** — probe `/wp/v2/users/me` with the stored auth header; reuse on a clean `200`, regenerate otherwise. This removes `RESET`, which existed only to force the regeneration the probe now handles.

**Guard** — check the port before starting (`bin/wp-env-guard.sh`). Ours running → skip the start, verify credentials. Untracked process → report the PIDs, their command lines, and the command that stops them, then exit.

It reports rather than stopping anything itself. Each worktree tracks its own environment while sharing one port, so a process holding it may be another worktree's healthy site; telling them apart needs a person, and stopping the wrong one interrupts work elsewhere.

The port and work directory come from wp-env's own config loader, so `WP_ENV_HOME`, `WP_ENV_PORT`, and a `port` key in `.wp-env.json` are all honoured. `bin/wp-env-setup.sh` resolves the port the same way, so provisioning follows the site when it moves.

**Android** — one `wp-env-android-urls` target taking `MODE=on|off`. No restart, so content and credentials survive. With no `MODE` it reports the current setting and suggests the flag to change it. Docs move off the images-only framing, since block editor assets, theme styles, and REST links all remap too.

**Clean** — `wp-env destroy` stops only the server named by its PID file, so it can report success while a server keeps holding the port. `wp-env-clean` runs the same check afterwards and reports anything still listening, so the next start does not fail on it.

## Testing Instructions

1. `make wp-env-start` — environment starts, credentials provisioned.
2. `make wp-env-start` again — reports "already running" and finishes in seconds, noting that applying `.wp-env.json` changes needs a stop first. _(Previously: `EADDRINUSE`, orphaned server.)_
3. `make wp-env-stop`, then `make wp-env-start`. Open http://localhost:8888/wp-admin/ and confirm the editor loads. In the iOS or Android demo app, open **Local WordPress** and confirm it connects. _(Previously: failed to authenticate.)_
4. `make wp-env-android-urls` — reports `off` and suggests `MODE=on`.
5. `make wp-env-android-urls MODE=on` — returns immediately, no restart. Rebuild the Android app, open **Local WordPress** in the emulator, and confirm images and block assets load.
6. `make wp-env-android-urls MODE=off` — reverts; http://localhost:8888/wp-admin/ loads in a browser again.

### Accessibility Testing Instructions

N/A — developer tooling, no UI changes.
