### PR TITLE
fix(ios): surface block inserter media failures to the user

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorLocalization.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorLocalization.swift
@@ -11,6 +11,11 @@ public enum EditorLocalizableString {
 
     // MARK: - Media
     case failedToInsertMedia
+    case failedToLoadSelectedMedia
+    case failedToProcessCapturedMedia
+
+    // MARK: - Common
+    case ok
 
     // MARK: - Patterns
     case patterns
@@ -96,6 +101,9 @@ public final class EditorLocalization {
         case .search: "Search"
         case .insertBlock: "Insert Block"
         case .failedToInsertMedia: "Failed to insert media"
+        case .failedToLoadSelectedMedia: "The selected media could not be loaded. It may not be fully downloaded to this device."
+        case .failedToProcessCapturedMedia: "The captured media could not be processed."
+        case .ok: "OK"
         case .patterns: "Patterns"
         case .noPatternsFound: "No Patterns Found"
         case .insertPattern: "Insert Pattern"

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
@@ -73,6 +73,13 @@ struct BlockInserterView: View {
                 }
                 .ignoresSafeArea()
             }
+            .alert(item: $viewModel.error) { error in
+                Alert(
+                    title: Text(EditorLocalization[.failedToInsertMedia]),
+                    message: Text(error.message),
+                    dismissButton: .default(Text(EditorLocalization[.ok]))
+                )
+            }
             .animation(.smooth(duration: 2), value: viewModel.isProcessingMedia)
             .animation(.snappy, value: inlineSelectedMediaItems.count)
             .onDisappear {

--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
@@ -2,6 +2,7 @@
 import SwiftUI
 import PhotosUI
 import Combine
+import OSLog
 
 @MainActor
 class BlockInserterViewModel: ObservableObject {
@@ -82,14 +83,15 @@ class BlockInserterViewModel: ObservableObject {
                 }
             } catch {
                 anyError = error
+                Logger.media.error("Failed to import picker selection: \(error)")
             }
 
             guard !Task.isCancelled else {
                 return []
             }
 
-            if results.isEmpty {
-                self.error = MediaError(message: anyError?.localizedDescription ?? EditorLocalization[.failedToInsertMedia])
+            if results.isEmpty, anyError != nil {
+                self.error = MediaError(message: EditorLocalization[.failedToLoadSelectedMedia])
             }
 
             return results
@@ -109,7 +111,7 @@ class BlockInserterViewModel: ObservableObject {
                 switch media {
                 case .photo(let image):
                     guard let imageData = image.jpegData(compressionQuality: 0.8) else {
-                        throw MediaError(message: "Failed to convert image to JPEG")
+                        throw MediaError(message: EditorLocalization[.failedToProcessCapturedMedia])
                     }
 
                     let fileURL = try await fileManager.writeData(imageData, withExtension: "jpg")
@@ -128,7 +130,8 @@ class BlockInserterViewModel: ObservableObject {
 
                 return [mediaInfo]
             } catch {
-                self.error = MediaError(message: error.localizedDescription)
+                Logger.media.error("Failed to process captured media: \(error)")
+                self.error = MediaError(message: EditorLocalization[.failedToProcessCapturedMedia])
                 return []
             }
         }


### PR DESCRIPTION
## What?

Media import failures in the native block inserter showed the user nothing at all. `BlockInserterViewModel.error` was assigned but never read by any view, so a failed photo import or camera capture left the inserter sheet open with no feedback.

## Why?

The lack of user feedback during causes confusion. 

## How?

Bind `error` to an `.alert(item:)` in `BlockInserterView` — `MediaError` is already `Identifiable`.

Replace the system-derived messages with a small set of localized strings. Previously the picker path surfaced `error.localizedDescription`, which for the common `URLError.unknown` case is generic text that tells a user nothing actionable, and the camera path threw an unlocalized `"Failed to convert image to JPEG"` literal. Three new `EditorLocalization` cases: one shared alert title, one message per failure family, plus `ok`. Hosts that do not translate them fall back to the editor's own strings and get a one-time log, per the existing design.

## Testing Instructions

Neither failure is easy to trigger organically — the picker path realistically needs an offloaded iCloud photo with no network, and the camera path needs a device. Apply the patch below to force both.

<details>
<summary>Reproduction patch — forces both failures</summary>

Both failures fire from independent entry points, so this triggers each one without toggling anything: the photo button demonstrates one message, the camera button the other.

```diff
diff --git a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterView.swift
@@ -179,7 +179,10 @@ struct BlockInserterView: View {
             }
 
             Button {
-                isShowingCamera = true
+                // TEMPORARY: route straight to `processCameraMedia` so the
+                // captured-media alert is reachable in the Simulator, which
+                // has no camera.
+                insertCameraMedia(.photo(UIImage()))
             } label: {
                 Image(systemName: "camera")
             }
diff --git a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
--- a/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
+++ b/ios/Sources/GutenbergKit/Sources/Views/BlockInserter/BlockInserterViewModel.swift
@@ -77,6 +77,7 @@ class BlockInserterViewModel: ObservableObject {
             var anyError: Error?
 
             do {
+                throw URLError(.unknown) // TEMPORARY: force picker failure.
                 for item in items {
                     let item = try await self.fileManager.import(item)
                     results.append(item)
@@ -108,6 +109,9 @@ class BlockInserterViewModel: ObservableObject {
             do {
                 let mediaInfo: MediaInfo
 
+                // TEMPORARY: force camera failure.
+                throw MediaError(message: EditorLocalization[.failedToProcessCapturedMedia])
+
                 switch media {
                 case .photo(let image):
                     guard let imageData = image.jpegData(compressionQuality: 0.8) else {

```

This produces two `code after 'throw' will never be executed` warnings. Expected — wrapping each throw in `if true { }` silences them if you prefer a clean build.

</details>

With the patch applied, in the Demo app:

1. Open a post and tap **+** to open the block inserter.
2. Tap the photo toolbar button and select any image. **Expected:** an alert titled _"Failed to insert media"_ with _"The selected media could not be loaded. It may not be fully downloaded to this device."_
3. Dismiss, then select an image via the inline picker under "Most used" and tap the **+N** confirm button. **Expected:** the same alert.
4. Tap the camera toolbar button. **Expected:** an alert titled _"Failed to insert media"_ with _"The captured media could not be processed."_
5. Confirm the alert renders correctly over the still-presented inserter sheet, and that dismissing it leaves the inserter usable.

Then revert the patch and confirm the regression path:

6. Insert a photo normally. **Expected:** it inserts as before, with no alert.

### Accessibility Testing Instructions

With VoiceOver enabled, follow the steps above. On failure, VoiceOver should announce the alert title and message, and focus should move into the alert. Confirm the OK button is reachable and dismisses it, returning focus to the inserter.

## Screenshots or screencast

Media strip | Camera
-- | --
<img width="760" height="1511" alt="media-strip" src="https://github.com/user-attachments/assets/76913db5-a61e-43e2-93e4-39bb3a5ba7a4" /> | <img width="760" height="1510" alt="camera" src="https://github.com/user-attachments/assets/a6c42556-a06e-45d3-a6c8-863ec2786d1b" />
