### PR TITLE
fix(android): load the editor same-origin on sites with a non-standard port

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -587,12 +587,11 @@ class GutenbergView : FrameLayout {
         // document shares the site's origin, making REST API and AJAX requests
         // same-origin and eliminating CORS restrictions.
         //
-        // This must be the authority (host *and* port), not the host: an origin
-        // is scheme + host + port, so dropping the port from a site served on a
-        // non-default one (e.g. `http://10.0.2.2:8888`) would make the editor
-        // cross-origin with the site. `WebViewAssetLoader` matches on authority,
-        // so a port-bearing value still resolves assets correctly.
-        assetAuthority = Uri.parse(configuration.siteURL).authority ?: DEFAULT_ASSET_DOMAIN
+        // This must carry the port, not just the host: an origin is scheme + host
+        // + port, so dropping the port from a site served on a non-default one
+        // (e.g. `http://10.0.2.2:8888`) would make the editor cross-origin with
+        // the site. See [originAuthority] for why a default port is left off.
+        assetAuthority = originAuthority(configuration.siteURL) ?: DEFAULT_ASSET_DOMAIN
 
         // Set up asset caching
         requestInterceptor = CachedAssetRequestInterceptor(
@@ -1233,6 +1232,35 @@ class GutenbergView : FrameLayout {
 
         /** Hosts that are safe to serve assets over HTTP (local development only). */
         private val LOCAL_HOSTS = setOf("localhost", "127.0.0.1", "10.0.2.2")
+
+        /**
+         * Returns [url]'s origin authority: its host, plus its port when that port
+         * is not the scheme's default.
+         *
+         * This deliberately does not use [Uri.authority], which returns whatever the
+         * URL was written with. Chromium canonicalizes a URL before it reaches
+         * [WebResourceRequest.url], dropping a default port and any userinfo, so
+         * `https://example.com:443` arrives as `example.com`. Comparing that against
+         * a raw authority of `example.com:443` would never match — and since
+         * `WebViewAssetLoader.PathMatcher` compares authorities exactly, the bundled
+         * editor document would not be served at all.
+         *
+         * Returns null when [url] has no host, leaving the caller to decide a default.
+         */
+        internal fun originAuthority(url: String): String? {
+            val uri = Uri.parse(url)
+            val authority = uri.authority ?: return null
+
+            // `Uri` does not parse a bracketed IPv6 literal into `host`/`port`, so
+            // fall back to the authority as written. A default port is not stripped
+            // in that case, but an IPv6 site URL is not a configuration this
+            // supports reaching, and the authority is at least well-formed.
+            if (authority.startsWith("[")) return authority
+
+            val host = uri.host ?: return null
+            val defaultPort = if (uri.scheme == "http") 80 else 443
+            return if (uri.port != -1 && uri.port != defaultPort) "$host:${uri.port}" else host
+        }
 
         private const val ASSET_LOADING_TIMEOUT_MS = 5000L
 

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -472,7 +472,7 @@ class GutenbergView : FrameLayout {
                 }
 
                 // Allow WordPress REST API
-                if (url.host == configuration.siteApiRoot.removePrefix("https://").removePrefix("http://")) {
+                if (url.authority == originAuthority(configuration.siteApiRoot)) {
                     if (url.path?.contains("/wp-json/") == true || url.query?.contains("rest_route=") == true) {
                         return false
                     }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -98,7 +98,7 @@ class GutenbergView : FrameLayout {
     private var isEditorLoaded = false
     private var didFireEditorLoaded = false
     private lateinit var assetLoader: WebViewAssetLoader
-    private lateinit var assetDomain: String
+    private lateinit var assetAuthority: String
     private val configuration: EditorConfiguration
     private lateinit var dependencies: EditorDependencies
 
@@ -429,7 +429,7 @@ class GutenbergView : FrameLayout {
                     if (response != null) return response
                 }
 
-                if (request.url.host == assetDomain) {
+                if (request.url.authority == assetAuthority) {
                     return assetLoader.shouldInterceptRequest(request.url)
                 }
 
@@ -461,8 +461,8 @@ class GutenbergView : FrameLayout {
 
                 // Allow asset URLs (restrict to the asset path prefix so that
                 // arbitrary site pages don't load inside the WebView when the
-                // asset domain matches the site domain)
-                if (url.host == assetDomain && url.path?.startsWith("/assets/") == true) {
+                // asset authority matches the site authority)
+                if (url.authority == assetAuthority && url.path?.startsWith("/assets/") == true) {
                     return false
                 }
 
@@ -583,10 +583,16 @@ class GutenbergView : FrameLayout {
     private fun loadEditor(dependencies: EditorDependencies) {
         this.dependencies = dependencies
 
-        // Derive the asset loader domain from the site URL so that the editor
+        // Derive the asset loader authority from the site URL so that the editor
         // document shares the site's origin, making REST API and AJAX requests
         // same-origin and eliminating CORS restrictions.
-        assetDomain = Uri.parse(configuration.siteURL).host ?: DEFAULT_ASSET_DOMAIN
+        //
+        // This must be the authority (host *and* port), not the host: an origin
+        // is scheme + host + port, so dropping the port from a site served on a
+        // non-default one (e.g. `http://10.0.2.2:8888`) would make the editor
+        // cross-origin with the site. `WebViewAssetLoader` matches on authority,
+        // so a port-bearing value still resolves assets correctly.
+        assetAuthority = Uri.parse(configuration.siteURL).authority ?: DEFAULT_ASSET_DOMAIN
 
         // Set up asset caching
         requestInterceptor = CachedAssetRequestInterceptor(
@@ -601,7 +607,7 @@ class GutenbergView : FrameLayout {
         val siteUri = Uri.parse(configuration.siteURL)
         val isLocalHttpSite = siteUri.scheme == "http" && siteUri.host in LOCAL_HOSTS
         assetLoader = WebViewAssetLoader.Builder()
-            .setDomain(assetDomain)
+            .setDomain(assetAuthority)
             .setHttpAllowed(isLocalHttpSite)
             .addPathHandler("/assets/", AssetsPathHandler(this.context))
             .build()
@@ -612,7 +618,7 @@ class GutenbergView : FrameLayout {
         initializeWebView()
 
         val scheme = if (isLocalHttpSite) "http" else "https"
-        val assetUrl = "$scheme://$assetDomain$ASSET_PATH_INDEX"
+        val assetUrl = "$scheme://$assetAuthority$ASSET_PATH_INDEX"
         val editorUrl = BuildConfig.GUTENBERG_EDITOR_URL.ifEmpty {
             assetUrl
         }

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
@@ -240,4 +240,74 @@ class GutenbergViewTest {
             result
         )
     }
+
+    // ===== originAuthority =====
+
+    @Test
+    fun `originAuthority keeps a non-default port`() {
+        assertEquals("10.0.2.2:8888", GutenbergView.originAuthority("http://10.0.2.2:8888"))
+        assertEquals("example.com:8443", GutenbergView.originAuthority("https://example.com:8443"))
+    }
+
+    @Test
+    fun `originAuthority drops an explicit default port`() {
+        // Chromium canonicalizes these away before the URL reaches the WebViewClient,
+        // so keeping them would leave the asset loader unable to match its own document.
+        assertEquals("example.com", GutenbergView.originAuthority("https://example.com:443"))
+        assertEquals("example.com", GutenbergView.originAuthority("http://example.com:80"))
+    }
+
+    @Test
+    fun `originAuthority omits a port that is absent`() {
+        assertEquals("example.com", GutenbergView.originAuthority("https://example.com"))
+    }
+
+    @Test
+    fun `originAuthority strips userinfo`() {
+        // Credentials are also removed during canonicalization.
+        assertEquals("example.com", GutenbergView.originAuthority("https://user:pass@example.com"))
+        assertEquals(
+            "example.com:8443",
+            GutenbergView.originAuthority("https://user:pass@example.com:8443")
+        )
+    }
+
+    @Test
+    fun `originAuthority preserves an IPv6 authority verbatim`() {
+        // `Uri` does not split a bracketed IPv6 literal into host/port, so the
+        // authority is used as written rather than being rebuilt.
+        assertEquals("[::1]:8888", GutenbergView.originAuthority("http://[::1]:8888"))
+        assertEquals("[::1]", GutenbergView.originAuthority("http://[::1]"))
+        assertEquals(
+            "[2001:db8::1]:8443",
+            GutenbergView.originAuthority("https://[2001:db8::1]:8443")
+        )
+    }
+
+    @Test
+    fun `originAuthority returns null when the URL has no host`() {
+        assertEquals(null, GutenbergView.originAuthority(""))
+        assertEquals(null, GutenbergView.originAuthority("not a url"))
+    }
+
+    @Test
+    fun `shouldOverrideUrlLoading allows asset URLs when the site URL has an explicit default port`() {
+        val siteView = GutenbergView(
+            EditorConfiguration.builder("https://example.com:443", "https://example.com:443/wp-json/")
+                .build(),
+            EditorDependencies.empty,
+            testScope,
+            RuntimeEnvironment.getApplication()
+        )
+
+        val request = mock(WebResourceRequest::class.java)
+        // Chromium canonicalizes `:443` away, so this is the URL the client actually sees.
+        `when`(request.url).thenReturn(Uri.parse("https://example.com/assets/index.html"))
+
+        val result = siteView.editorWebView.webViewClient.shouldOverrideUrlLoading(siteView.editorWebView, request)
+        assertFalse(
+            "An explicit default port in the site URL must still match the canonicalized request",
+            result
+        )
+    }
 }

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
@@ -200,4 +200,44 @@ class GutenbergViewTest {
         val result = siteView.editorWebView.webViewClient.shouldOverrideUrlLoading(siteView.editorWebView, request)
         assertTrue("Non-asset URLs on the site domain should open externally", result)
     }
+
+    @Test
+    fun `shouldOverrideUrlLoading allows asset path URLs when the site URL has a port`() {
+        val siteView = GutenbergView(
+            EditorConfiguration.builder("http://10.0.2.2:8888", "http://10.0.2.2:8888/wp-json/")
+                .build(),
+            EditorDependencies.empty,
+            testScope,
+            RuntimeEnvironment.getApplication()
+        )
+
+        val request = mock(WebResourceRequest::class.java)
+        `when`(request.url).thenReturn(Uri.parse("http://10.0.2.2:8888/assets/index.html"))
+
+        val result = siteView.editorWebView.webViewClient.shouldOverrideUrlLoading(siteView.editorWebView, request)
+        assertFalse(
+            "Asset URLs on the site's authority should load in the WebView so the editor stays same-origin",
+            result
+        )
+    }
+
+    @Test
+    fun `shouldOverrideUrlLoading blocks asset path URLs that drop the site's port`() {
+        val siteView = GutenbergView(
+            EditorConfiguration.builder("http://10.0.2.2:8888", "http://10.0.2.2:8888/wp-json/")
+                .build(),
+            EditorDependencies.empty,
+            testScope,
+            RuntimeEnvironment.getApplication()
+        )
+
+        val request = mock(WebResourceRequest::class.java)
+        `when`(request.url).thenReturn(Uri.parse("http://10.0.2.2/assets/index.html"))
+
+        val result = siteView.editorWebView.webViewClient.shouldOverrideUrlLoading(siteView.editorWebView, request)
+        assertTrue(
+            "A portless URL is a different origin than the site and must not be treated as an asset URL",
+            result
+        )
+    }
 }

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
@@ -290,6 +290,82 @@ class GutenbergViewTest {
         assertEquals(null, GutenbergView.originAuthority("not a url"))
     }
 
+    // ===== REST API navigation =====
+
+    @Test
+    fun `shouldOverrideUrlLoading allows REST API URLs on the site's API root`() {
+        // Callers pass a full API root with a path, e.g. WordPress-Android's
+        // `site.wpApiRestUrl ?: "${site.url}/wp-json/"`.
+        val siteView = GutenbergView(
+            EditorConfiguration.builder("https://example.com", "https://example.com/wp-json/")
+                .build(),
+            EditorDependencies.empty,
+            testScope,
+            RuntimeEnvironment.getApplication()
+        )
+
+        val request = mock(WebResourceRequest::class.java)
+        `when`(request.url).thenReturn(Uri.parse("https://example.com/wp-json/wp/v2/posts"))
+
+        val result = siteView.editorWebView.webViewClient.shouldOverrideUrlLoading(siteView.editorWebView, request)
+        assertFalse("REST API URLs on the site's API root should load in the WebView", result)
+    }
+
+    @Test
+    fun `shouldOverrideUrlLoading allows REST API URLs for a rest_route API root`() {
+        val siteView = GutenbergView(
+            EditorConfiguration.builder(
+                "https://example.com",
+                "https://example.com/index.php?rest_route=/"
+            ).build(),
+            EditorDependencies.empty,
+            testScope,
+            RuntimeEnvironment.getApplication()
+        )
+
+        val request = mock(WebResourceRequest::class.java)
+        `when`(request.url).thenReturn(
+            Uri.parse("https://example.com/index.php?rest_route=/wp/v2/posts")
+        )
+
+        val result = siteView.editorWebView.webViewClient.shouldOverrideUrlLoading(siteView.editorWebView, request)
+        assertFalse("rest_route REST API URLs should load in the WebView", result)
+    }
+
+    @Test
+    fun `shouldOverrideUrlLoading blocks REST API URLs on a different host`() {
+        val siteView = GutenbergView(
+            EditorConfiguration.builder("https://example.com", "https://example.com/wp-json/")
+                .build(),
+            EditorDependencies.empty,
+            testScope,
+            RuntimeEnvironment.getApplication()
+        )
+
+        val request = mock(WebResourceRequest::class.java)
+        `when`(request.url).thenReturn(Uri.parse("https://other.example.net/wp-json/wp/v2/posts"))
+
+        val result = siteView.editorWebView.webViewClient.shouldOverrideUrlLoading(siteView.editorWebView, request)
+        assertTrue("REST API URLs on another host should open externally", result)
+    }
+
+    @Test
+    fun `shouldOverrideUrlLoading allows REST API URLs when the API root has a port`() {
+        val siteView = GutenbergView(
+            EditorConfiguration.builder("http://10.0.2.2:8888", "http://10.0.2.2:8888/wp-json/")
+                .build(),
+            EditorDependencies.empty,
+            testScope,
+            RuntimeEnvironment.getApplication()
+        )
+
+        val request = mock(WebResourceRequest::class.java)
+        `when`(request.url).thenReturn(Uri.parse("http://10.0.2.2:8888/wp-json/wp/v2/posts"))
+
+        val result = siteView.editorWebView.webViewClient.shouldOverrideUrlLoading(siteView.editorWebView, request)
+        assertFalse("REST API URLs on a port-bearing API root should load in the WebView", result)
+    }
+
     @Test
     fun `shouldOverrideUrlLoading allows asset URLs when the site URL has an explicit default port`() {
         val siteView = GutenbergView(


### PR DESCRIPTION
## What?

The editor document was served from the site's host without its port, so on a site with a non-standard port it ran on a different origin than the site and every REST request became cross-origin — the opposite of what the surrounding code intends.

## Why?

An origin is scheme + host + port, so a site at `http://10.0.2.2:8888` produced an editor at `http://10.0.2.2` (implicit port 80).

Users on a self-hosted site with a non-standard port — behind a reverse proxy, on alternate-port hosting, or an internal deployment — get an editor that cannot read site data. Blocks that fetch from the REST API to render, such as Latest Posts, Categories List, and Terms List, fail. Requests only succeed at all if the site adds server-side CORS configuration that a same-origin editor never needs. Even then, response headers outside the CORS safelist stay unreadable, because core's `rest_send_cors_headers()` only exposes `X-WP-Total`, `X-WP-TotalPages`, and `Link`.

Sites on default ports (`:80`/`:443`) are unaffected, since their URLs carry no port. That covers WordPress.com and most self-hosted sites, which is why this went unnoticed.

It is also invisible in day-to-day development: setting `GUTENBERG_EDITOR_URL` makes the WebView load the dev server instead of the bundled assets, so the affected value is computed and discarded. The bug only surfaces in bundled builds — the configuration that ships.

Against wp-env, this blocked the entire editor bootstrap: settings, taxonomies, global styles, block patterns, blocks, media, pages, and the theme's webfont.

## How?

Derive the asset origin from the site URL's authority (host **and** port) rather than its host. `WebViewAssetLoader` matches on authority, so a port-bearing value still resolves assets correctly.

The comparisons in `shouldInterceptRequest` and `shouldOverrideUrlLoading` move to `authority` in the same change — a port-bearing value would otherwise stop matching and break asset interception entirely.

Deliberately left alone:

- `cachedAssetHosts` is a caller-supplied host allowlist, not an origin comparison. WordPress-Android passes bare hosts (`s0.wp.com`, the site host), so converting it would silently break those callers.
- `LOCAL_HOSTS` is likewise a host allowlist.
- `DEFAULT_ASSET_DOMAIN` keeps its name as a public top-level `const`, and is already a valid authority.

Not a breaking change for consumers: the renamed field is `private`, and the public `EditorConfiguration` API is untouched.

## Testing Instructions

The bug is only reachable in a **bundled** build, so `GUTENBERG_EDITOR_URL` must be unset.

1. `make wp-env-android` — installs the URL-remap mu-plugin and starts wp-env with the site URL remapped to `http://10.0.2.2:8888` for the emulator.
2. Comment out `GUTENBERG_EDITOR_URL` in `android/local.properties` so the app uses the bundled build.
3. Build and install the Android demo app on an emulator.
4. Open **Local WordPress (wp-env)**, enable **Enable Network Logging**, and tap **Start**.
5. Insert blocks that depend on REST API requests to render:
   - **Latest Posts**
   - **Categories List**
   - **Terms List**

Expected: each block renders its content. Before this fix they fail, because the requests backing them are blocked cross-origin.

Also confirm the editor bootstrap itself is clean — `adb logcat` should show no `blocked by CORS policy` errors, and the console `source` should be `http://10.0.2.2:8888/assets/index.html` (with the port), matching the site origin.

To see the failure for comparison, check out `trunk` and repeat from step 3: the same blocks fail and logcat fills with CORS errors against `origin 'http://10.0.2.2'`.

Regression check on the unaffected path: open a WordPress.com or default-port self-hosted site and confirm the editor still loads normally. Host and authority are identical there, so behavior should be unchanged.

### Accessibility Testing Instructions

N/A — no user interface changes.
