### PR TITLE
ci: AINFRA-2999: Use CI toolkit 6.3.0 for better artifact caching

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -6,7 +6,7 @@
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed 's/^~> *//' .xcode-version)
 CI_TOOLKIT_PLUGIN_VERSION="6.3.0"
-NVM_PLUGIN_VERSION='0.3.0'
+NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="xcode-$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed 's/^~> *//' .xcode-version)
-CI_TOOLKIT_PLUGIN_VERSION="3.5.1"
+CI_TOOLKIT_PLUGIN_VERSION="6.3.0"
 NVM_PLUGIN_VERSION='0.3.0'
 
 export IMAGE_ID="xcode-$XCODE_VERSION"


### PR DESCRIPTION
The majors crossed (4.0.0, 5.0.0, 6.0.0) carry three breaking changes between them: pr_changed_files switching to exit codes, and two Windows-only script removals. GutenbergKit calls install_gems and prepare_to_publish_to_s3_params, so we're good.

As of 6.1.0, CI toolkit uses the Synology NAS on-premises on the macOS queue, falling back to S3 only when that's not available, resulting in lower S3 hits.