### PR TITLE
ci(release): use get_prs_between_tags with fail_on_error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'fastlane', '~> 2.238'
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 14.11'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 15.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-wpmreleasetoolkit (14.11.3)
+    fastlane-plugin-wpmreleasetoolkit (15.0.0)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -316,7 +316,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane (~> 2.238)
-  fastlane-plugin-wpmreleasetoolkit (~> 14.11)
+  fastlane-plugin-wpmreleasetoolkit (~> 15.0)
 
 CHECKSUMS
   CFPropertyList (3.0.8) sha256=2c99d0d980536d3d7ab252f7bd59ac8be50fbdd1ff487c98c949bb66bb114261
@@ -358,7 +358,7 @@ CHECKSUMS
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   fastimage (2.4.1) sha256=c64bebd46b6fd8943ab70c1e6e85ff728f970f2e48f92ecd249b6bc3a540ad20
   fastlane (2.238.0) sha256=78e9252df2224c7e427012638e41051edfa29b133a40fda883fd2f1c13a77b98
-  fastlane-plugin-wpmreleasetoolkit (14.11.3) sha256=cfe39597775611aa7745ff3a6d6c7ac07644a052bee9d7e4c3eaebe0f7e03cac
+  fastlane-plugin-wpmreleasetoolkit (15.0.0) sha256=6ffd06713e7e98c0d4a65df404b6cf8ffe66258b0976900899d888e57909aa67
   fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
   fiddle (1.1.8) sha256=7fa8ee3627271497f3add5503acdbc3f40b32f610fc1cf49634f083ef3f32eee
   forwardable (1.4.0) sha256=f1cd40cc9812937980e1c76f1aa053660990a7c9b6a98fc37d945468afcce838

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -317,14 +317,16 @@ end
 # previous tag. `set_github_release`'s `is_generate_release_notes` cannot express
 # one.
 #
-# Uses `GithubHelper` rather than the `get_prs_between_tags` action that wraps it
-# until https://github.com/wordpress-mobile/release-toolkit/pull/772 gets ships in the next release-toolkit
-# version (at which point we'll be able to use the action and its new `fail_on_error: true` parameter)
+# `fail_on_error` is required, not cosmetic: the tag is already pushed by this
+# point, and the action otherwise returns the API error as the changelog itself,
+# publishing a release whose notes read "❌ Error computing the list of PRs…".
 def generated_release_notes(version:, token:)
-  Fastlane::Helper::GithubHelper.new(github_token: token).generate_release_notes(
+  get_prs_between_tags(
     repository: GITHUB_REPO,
     tag_name: version,
-    previous_tag: previous_release_tag!(version: version, token: token)
+    previous_tag: previous_release_tag!(version: version, token: token),
+    fail_on_error: true,
+    github_token: token
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -316,7 +316,6 @@ end
 # Build the release body via GitHub's notes generator, pinned to an explicit
 # previous tag. `set_github_release`'s `is_generate_release_notes` cannot express
 # one.
-#
 def generated_release_notes(version:, token:)
   get_prs_between_tags(
     repository: GITHUB_REPO,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -317,14 +317,13 @@ end
 # previous tag. `set_github_release`'s `is_generate_release_notes` cannot express
 # one.
 #
-# `fail_on_error` is required, not cosmetic: the tag is already pushed by this
-# point, and the action otherwise returns the API error as the changelog itself,
-# publishing a release whose notes read "❌ Error computing the list of PRs…".
 def generated_release_notes(version:, token:)
   get_prs_between_tags(
     repository: GITHUB_REPO,
     tag_name: version,
     previous_tag: previous_release_tag!(version: version, token: token),
+    # Hard fail on errors. Otherwise, we might get release notes reading something
+    # like "Error computing the list of PRs."
     fail_on_error: true,
     github_token: token
   )


### PR DESCRIPTION
AI-generated below:

## What?

Bumps `fastlane-plugin-wpmreleasetoolkit` to 15.0.0 and switches `generated_release_notes` back to the `get_prs_between_tags` action, now passing `fail_on_error: true`.

Closes [CMM-2332](https://linear.app/a8c/issue/CMM-2332) / #591.

## Why?

#588 deliberately bypassed the action and called `GithubHelper#generate_release_notes` directly, because the action rescued every `StandardError` and returned the message as the changelog — a transient API failure would publish a release whose notes read `❌ Error computing the list of PRs…`. We push the tag before creating the Release, so that has to fail the step instead.

[release-toolkit#772](https://github.com/wordpress-mobile/release-toolkit/pull/772) added the opt-out, and it has now shipped in 15.0.0, so the workaround can go.

## How?

`fail_on_error: true` is load-bearing rather than cosmetic, which is the one thing the diff doesn't say on its own — hence the comment that replaces the old workaround note.

The major bump is manual: Dependabot only proposes this repo's toolkit updates through the `ruby-minor-and-patch` group. Neither of 15.0.0's breaking changes reaches this repo — there are no `*_build_preflight` call sites, and `EnvManager` now populating the process `ENV` by default is a no-op here, where no `.env` file ships.

## Testing Instructions

The release lane only runs on CI, so I exercised the action directly against the live API from this branch:

```sh
bundle exec fastlane run get_prs_between_tags \
  repository:wordpress-mobile/GutenbergKit tag_name:v0.19.0 \
  previous_tag:v0.18.1 fail_on_error:true
```

Returns the v0.18.1 → v0.19.0 notes. Swapping in a nonexistent `previous_tag` exits 1 with `Octokit::BadRequest: 400 - Invalid previous_tag parameter`, where the same call with `fail_on_error:false` exits 0 and hands back the `❌ Error computing the list of PRs…` string — i.e. exactly the failure this change exists to prevent.

Heads-up for whoever reads the next release page: the action rewrites GitHub's `## What's Changed` heading into `## New PRs since [<previous_tag>](<link>)`.
