### PR TITLE
Add initial iOS Find in Post support

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -245,6 +245,7 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         config.applicationNameForUserAgent = "GutenbergKit/\(GutenbergKitVersion.version)"
 
         self.webView = GBWebView(frame: .zero, configuration: config)
+        self.webView.isFindInteractionEnabled = true
         self.webView.scrollView.keyboardDismissMode = .interactive
 
         self.isWarmupMode = isWarmupMode
@@ -556,6 +557,11 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         guard isReady else { return }
         evaluate("editor.redo();")
     }
+
+    public func presentFindNavigator() {
+        webView.findInteraction?.presentFindNavigator(showingReplace: false)
+    }
+
 
     /// Dismisses the topmost modal dialog or menu in the editor
     public func dismissTopModal() {


### PR DESCRIPTION
## What?

Adds the initial iOS native Find in Post spike to GutenbergKit by enabling `WKWebView`'s native Find interaction and exposing a `presentFindNavigator()` method from `EditorViewController`.

## Why?

This is part of the work for WordPress-Android #23222 ("Find in post").

The editor is shared through GutenbergKit, so the Find behavior should be implemented at the GutenbergKit level rather than separately in the host applications.

This spike is intended to verify whether the native `WKWebView` Find interaction is suitable for Gutenberg's `contenteditable` editor before proceeding with the Android implementation.

## How?

- Enables `WKWebView.isFindInteractionEnabled`.
- Adds `presentFindNavigator()` to `EditorViewController`, which presents the native iOS Find navigator.
- Keeps the implementation limited to the native iOS Find API for this initial feasibility spike.

## Testing Instructions

Runtime testing is still pending.

I am developing on Windows and currently do not have access to a macOS/iOS environment to run the GutenbergKit iOS application.

Once an iOS environment is available, verify:

1. Open a post containing repeated instances of the same text.
2. Open the native Find navigator.
3. Search for the repeated text.
4. Verify that matching text is highlighted.
5. Navigate between matches using next/previous.
6. Verify that the editor scrolls to the selected match.
7. Dismiss the Find navigator.
8. Verify that searching does not modify the post or create an undo/redo entry.
9. Verify that Gutenberg's caret/block selection is not unexpectedly changed.

## Accessibility Testing Instructions

Runtime accessibility testing is pending because an iOS/macOS environment is not currently available.

Once available, verify that the native Find navigator can be opened and operated using VoiceOver, including entering a search query, navigating between matches, and dismissing the navigator.

## Screenshots or screencast

Not available yet because runtime iOS testing is pending.