### PR TITLE
fix(ios): refuse a passthrough upload whose body measures zero

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -480,10 +480,22 @@ class DefaultMediaUploader: @unchecked Sendable {
     /// Used when the delegate's `processFile` returned the file unchanged —
     /// the incoming multipart body is already valid for WordPress.
     func passthroughUpload(body: RequestBody, contentType: String, query: String) async throws -> MediaUploadResponse {
+        // `count` is a file-size lookup for a disk-backed body, and reports zero
+        // when it fails. Sending that as the `Content-Length` would upload an
+        // empty body, which WordPress accepts as a no-op and answers with a 2xx
+        // — reported to the editor as a successful upload of nothing. Fail
+        // instead. (`makeInputStream()` already throws for the missing file that
+        // is the likeliest cause, so this covers the rest.)
+        let length = body.count
+        guard length > 0 else {
+            Logger.uploadServer.error("Refusing to upload a body whose length could not be read")
+            throw UploadError.streamReadFailed
+        }
+
         var request = URLRequest(url: mediaEndpointURL(query: query))
         request.httpMethod = "POST"
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-        request.setValue("\(body.count)", forHTTPHeaderField: "Content-Length")
+        request.setValue("\(length)", forHTTPHeaderField: "Content-Length")
         request.httpBodyStream = try body.makeInputStream()
 
         return try await performUpload(request)

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -626,6 +626,32 @@ struct DefaultMediaUploaderRelayTests {
     let url = try #require(client.lastURL)
     #expect(url.absoluteString == "https://example.com/wp-json/wp/v2/sites/123/media?_embed=wp:featuredmedia")
   }
+
+  @Test("refuses a passthrough body that measures zero rather than uploading nothing")
+  func refusesUnmeasurableBody() async throws {
+    // A zero `Content-Length` sends no body at all, and WordPress answers that
+    // no-op with a 2xx — reported to the editor as a successful upload. The body
+    // opens fine here; only its length is unusable, which is the case
+    // `makeInputStream()` does not already catch.
+    let client = URLCapturingHTTPClient()
+    let uploader = DefaultMediaUploader(
+      httpClient: client,
+      siteApiRoot: URL(string: "https://example.com/wp-json/")!
+    )
+
+    let emptyFile = FileManager.default.temporaryDirectory.appendingPathComponent("empty-\(UUID().uuidString).bin")
+    try Data().write(to: emptyFile)
+    defer { try? FileManager.default.removeItem(at: emptyFile) }
+
+    await #expect(throws: UploadError.self) {
+      try await uploader.passthroughUpload(
+        body: RequestBody(fileURL: emptyFile),
+        contentType: "multipart/form-data; boundary=x",
+        query: ""
+      )
+    }
+    #expect(client.lastURL == nil, "nothing should reach WordPress")
+  }
 }
 
 /// An HTTP client whose `performRaw` relays a canned response without validating


### PR DESCRIPTION
## What?

The native upload passthrough could send WordPress an empty body and report the result to the editor as a successful upload.

Found while reviewing #611, but pre-existing and independent of it, so this lands on its own. The two touch `MediaUploadServer.swift` in different functions and merge cleanly in either order.

## Why?

`RequestBody.count` is a file-size lookup for a disk-backed body, and reports zero when the lookup fails. `passthroughUpload` sent that as the `Content-Length`, so nothing was uploaded — and WordPress accepts an empty media POST as a no-op and answers 2xx, which the editor reports as success for a file that never arrived.

The likeliest cause of a zero — a temp file that has gone missing — already throws in `makeInputStream()`, which both callers turn into a 500. So this closes the window that remains rather than a live failure: a body that opens cleanly but whose length is unusable.

## How?

Read the length once, refuse a zero before the request is built, and log it. The caller already converts the throw into a 500, so the editor surfaces a real failure instead of a false success.

## Testing Instructions

```sh
make test-swift-package
```

The new test drives a body that opens cleanly and measures zero, then asserts nothing reached WordPress. Reverting the guard and re-running shows what it catches:

```
Expectation failed: an error was expected but none was thrown and
"MediaUploadResponse(statusCode: 201, body: 2 bytes)" was returned
(client.lastURL → https://example.com/wp-json/wp/v2/media) == nil
```

That 201 is the failure mode: an upload of nothing, reported as success.
