### PR TITLE
fix: stop persisting the editor configuration in localStorage

### DIFF
--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -667,12 +667,8 @@ class GutenbergView : FrameLayout {
             nativeUploadToken = uploadServer?.token
         )
         val gbKitJson = gbKit.toJsonString()
-        val gbKitConfig = """
-            window.GBKit = $gbKitJson;
-            localStorage.setItem('GBKit', JSON.stringify(window.GBKit));
-        """.trimIndent()
 
-        webView.evaluateJavascript(gbKitConfig, null)
+        webView.evaluateJavascript("window.GBKit = $gbKitJson;", null)
     }
 
     private fun startUploadServer() {
@@ -726,12 +722,7 @@ class GutenbergView : FrameLayout {
     }
 
     fun clearConfig() {
-        val jsCode = """
-            delete window.GBKit;
-            localStorage.removeItem('GBKit');
-        """.trimIndent()
-
-        webView.evaluateJavascript(jsCode, null)
+        webView.evaluateJavascript("delete window.GBKit;", null)
     }
 
     fun setContent(newContent: String) {

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/HttpServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/HttpServer.kt
@@ -114,10 +114,10 @@ enum class CorsPolicy {
                 // `*` (any origin) rather than echoing a specific origin is
                 // deliberate, and safe here — not an oversight to tighten. The
                 // server is loopback-only, and every non-OPTIONS request is gated
-                // by a per-session random bearer token stored only in the editor
-                // origin's localStorage/window.GBKit, which is origin-scoped and
-                // unreadable by any other origin — so no cross-origin can obtain
-                // it. `*` only governs whether a *token-holding* origin may read
+                // by a per-session random bearer token held only in the editor
+                // origin's window.GBKit, which is origin-scoped and unreadable
+                // by any other origin — so no cross-origin can obtain it. `*`
+                // only governs whether a *token-holding* origin may read
                 // the response, and the sole token-holder is the editor itself, the
                 // legitimate client. Echoing the origin isn't viable anyway: the
                 // editor loads from file:// (Origin null), which can't be cleanly

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -467,15 +467,26 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
             nativeUploadToken: isUploadPipelineEnabled ? uploadServer?.token : nil,
             networkProxy: networkProxyGlobal
         )
-        let stringValue = try gbkitGlobal.toString()
+        return WKUserScript(
+            source: Self.configurationScript(gbkitGlobal: try gbkitGlobal.toString()),
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+    }
 
-        let jsCode = """
-        window.GBKit = \(stringValue);
-        localStorage.setItem('GBKit', JSON.stringify(window.GBKit));
+    /// The document-start script that installs `window.GBKit`.
+    ///
+    /// The configuration is session-scoped — it carries the site credential and
+    /// the local server's port and tokens — so no copy of it outlives the load
+    /// that injected it. Earlier versions mirrored it into `localStorage`, which
+    /// the default website data store keeps on disk across launches; the script
+    /// removes that key so a device upgraded from one of them is scrubbed.
+    static func configurationScript(gbkitGlobal: String) -> String {
+        """
+        window.GBKit = \(gbkitGlobal);
+        localStorage.removeItem('GBKit');
         "done";
         """
-
-        return WKUserScript(source: jsCode, injectionTime: .atDocumentStart, forMainFrameOnly: true)
     }
 
     /// Starts the local HTTP server for routing file uploads through native processing.

--- a/ios/Sources/GutenbergKitHTTP/CORSPolicy.swift
+++ b/ios/Sources/GutenbergKitHTTP/CORSPolicy.swift
@@ -22,10 +22,10 @@ public enum CORSPolicy: Sendable {
                 // `*` (any origin) rather than echoing a specific origin is
                 // deliberate, and safe here — not an oversight to tighten. The
                 // server is loopback-only, and every non-OPTIONS request is gated
-                // by a per-session random bearer token stored only in the editor
-                // origin's `localStorage`/`window.GBKit`, which is origin-scoped
-                // and unreadable by any other origin — so no cross-origin can
-                // obtain it. `*` only governs whether a *token-holding* origin may
+                // by a per-session random bearer token held only in the editor
+                // origin's `window.GBKit`, which is origin-scoped and unreadable
+                // by any other origin — so no cross-origin can obtain it. `*`
+                // only governs whether a *token-holding* origin may
                 // read the response, and the sole token-holder is the editor
                 // itself, the legitimate client. Echoing the origin isn't viable
                 // anyway: the editor loads from `file://` and WebKit sends

--- a/ios/Tests/GutenbergKitTests/EditorConfigurationScriptTests.swift
+++ b/ios/Tests/GutenbergKitTests/EditorConfigurationScriptTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+
+@testable import GutenbergKit
+
+#if canImport(UIKit)
+
+@Suite("Editor configuration script")
+struct EditorConfigurationScriptTests {
+
+    @MainActor
+    @Test("injects the configuration without persisting it")
+    func doesNotPersistTheConfiguration() {
+        // The injected configuration carries the site credential and the local
+        // server's port and tokens, all of them valid only for this session.
+        let script = EditorViewController.configurationScript(
+            gbkitGlobal: #"{"authHeader":"Bearer secret"}"#
+        )
+
+        #expect(script.contains(#"window.GBKit = {"authHeader":"Bearer secret"};"#))
+        #expect(script.contains("localStorage.removeItem('GBKit')"))
+        #expect(!script.contains("localStorage.setItem"))
+    }
+}
+
+#endif

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -261,22 +261,13 @@ export const POST_FALLBACKS = {
 };
 
 /**
- * Retrieves the native-host-provided GBKit object from localStorage or returns
- * an empty object if not found.
+ * Retrieves the native-host-provided GBKit object or returns an empty object
+ * if the host has not injected one.
  *
  * @return {GBKitConfig} The GBKit object.
  */
 export function getGBKit() {
-	if ( window.GBKit ) {
-		return window.GBKit;
-	}
-
-	try {
-		return JSON.parse( localStorage.getItem( 'GBKit' ) ) || {};
-	} catch ( err ) {
-		error( 'Failed to parse GBKit from localStorage', err );
-		return {};
-	}
+	return window.GBKit || {};
 }
 
 /**


### PR DESCRIPTION
## What?

Stop mirroring the editor configuration (`window.GBKit`) into `localStorage` on iOS and Android, and drop the JavaScript fallback that read it.

## Why?

`GBKit` carries the site credential and the local server's port and tokens, all valid only for the load that injected them. iOS mirrored it into `localStorage`, which the default website data store keeps on disk across launches, so a stale copy could outlive the session and hand a previous session's port and token to anything reading through the fallback.

Nothing needs the copy. The persisted copy arrived with the global in #14, when iOS injected the configuration with `evaluateJavaScript` after the page had loaded. #15 moved iOS to a document-start `WKUserScript`, which WebKit replays on every navigation, including the reload after a WebContent process termination. Android re-injects the global on every page start and wipes web storage before each load. Boot also waits for `window.GBKit` before anything reads the configuration and, outside `?dev_mode`, aborts when it never arrives, so the fallback was unreachable in production.

#611 reads the relay's port and token through `getGBKit` as well, so landing this first keeps a stale copy from pointing the relay at a stopped server.

## How?

- `getGBKit` returns the injected global or an empty object.
- iOS drops the `setItem` line from the document-start script and removes the key instead, so devices upgraded from an earlier version are scrubbed. A test pins the script's shape.
- Android drops the `setItem` line and the matching `removeItem` in `clearConfig`.
- The CORS rationale comments on both platforms name `window.GBKit` alone as where the token lives.

## Testing Instructions

1. Run `make test-js`, `make test-swift-package`, and `make test-android`.
2. In the iOS demo, open a post, then force a WebContent process termination (Activity Monitor: quit `com.apple.WebKit.WebContent` for the Simulator). The editor should reload with the current post.
3. In the Android demo, open a post, background the app until the activity is recreated, then return. The editor should reload with the current post.
4. On iOS, upgrade from a build before this change with a post open, then reopen a post. Safari Web Inspector's Storage tab for the editor page should show no `GBKit` key.

Note: `make test-android` fails six `HttpServerAuthenticationTests` cases locally with a 407 on a valid token. They fail identically with these changes reverted, and neither the server nor the test has changed since #561.

## Screenshots or screencast

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsMCoa3jNEuvnhxicDVRBV
