### PR TITLE
fix: expose @wordpress/theme as window.wp.theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
 				"@wordpress/server-side-render": "^6.14.0",
 				"@wordpress/shortcode": "^4.38.0",
 				"@wordpress/style-engine": "^2.43.0",
+				"@wordpress/theme": "^0.8.0",
 				"@wordpress/token-list": "^3.38.0",
 				"@wordpress/url": "^4.42.0",
 				"@wordpress/viewport": "^6.38.0",
@@ -222,7 +223,6 @@
 			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.7",
 				"@babel/generator": "^7.29.7",
@@ -3339,7 +3339,6 @@
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"@wordpress/server-side-render": "^6.14.0",
 		"@wordpress/shortcode": "^4.38.0",
 		"@wordpress/style-engine": "^2.43.0",
+		"@wordpress/theme": "^0.8.0",
 		"@wordpress/token-list": "^3.38.0",
 		"@wordpress/url": "^4.42.0",
 		"@wordpress/viewport": "^6.38.0",

--- a/src/utils/wordpress-globals.js
+++ b/src/utils/wordpress-globals.js
@@ -53,6 +53,7 @@ import * as router from '@wordpress/router';
 import * as serverSideRender from '@wordpress/server-side-render';
 import * as shortcode from '@wordpress/shortcode';
 import * as styleEngine from '@wordpress/style-engine';
+import * as theme from '@wordpress/theme';
 import * as tokenList from '@wordpress/token-list';
 import * as url from '@wordpress/url';
 import * as viewport from '@wordpress/viewport';
@@ -123,6 +124,7 @@ export async function initializeWordPressGlobals() {
 	window.wp.serverSideRender = serverSideRender;
 	window.wp.shortcode = shortcode;
 	window.wp.styleEngine = styleEngine;
+	window.wp.theme = theme;
 	window.wp.tokenList = tokenList.default || tokenList;
 	window.wp.url = url;
 	window.wp.viewport = viewport;


### PR DESCRIPTION
## What?

Expose `@wordpress/theme` as `window.wp.theme` alongside the other WordPress globals, and add it as a direct dependency.

## Why?

Jetpack blocks fail to register in the editor against Jetpack's upcoming 16.2 release, which currently ships on the wordpress.org trunk build that `.wp-env.json` installs. The web E2E `third-party-blocks` spec fails as a result.

Jetpack's editor bundle now includes `@wordpress/ui` 0.21, whose `ThemeProvider` shim reads `window.wp.theme` at module-evaluation time and throws when it is missing:

```
@wordpress/ui: @wordpress/theme must expose `ThemeProvider` or `privateApis.ThemeProvider`.
```

In wp-admin, WordPress registers the `wp-theme` script. GutenbergKit populates `window.wp` itself and did not define `theme`, and the Jetpack editor-assets endpoint treats `wp-` handles as core-provided, so nothing else fills the gap.

## How?

Import `@wordpress/theme` in `wordpress-globals.js` and assign it to `window.wp.theme`. The installed 0.8.0 exposes `privateApis`, which the `@wordpress/ui` shim unlocks as a fallback for `ThemeProvider`. The package was previously only a transitive dependency via `@wordpress/dataviews`, so it is now declared directly.

## Testing Instructions

1. Run `make wp-env-start`.
2. Run `npx playwright test e2e/third-party-blocks.spec.js`.
3. Both tests pass. On `trunk` they fail with the error above.

### Accessibility Testing Instructions

N/A. No UI changes.

## Screenshots or screencast

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnQd7G77gehA2PgnzKvFei
