### PR TITLE
chore: ignore Playwright output in ESLint and Prettier

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,7 @@
 android/
 build/
 dist/
+e2e/test-results/
 ios/
+playwright-report/
 vendor/

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ ios
 package-lock.json
 .github/**/*.md
 vendor
+e2e/test-results
+playwright-report


### PR DESCRIPTION
## What?

Add the Playwright output directories, `e2e/test-results/` and `playwright-report/`, to `.eslintignore` and `.prettierignore`.

## Why?

Git already ignores both directories, but the linters did not. After a local `make test-e2e` run, `make lint-js` failed with 227 errors, all inside the generated `playwright-report/trace/*.js` bundles, and `npm run format` would rewrite 13 generated files. None of it relates to project code, and the failure only appears on machines that have run the E2E suite locally.

## How?

Mirror the existing `.gitignore` entries in both linter ignore files.

## Testing Instructions

1. Run `make test-e2e` at least once so both directories exist.
2. Run `make lint-js`. It passes.
3. Run `npx prettier --check playwright-report e2e/test-results`. It reports nothing to fix.
4. Run `npx prettier --check playwright-report e2e/test-results --ignore-path /dev/null`. It flags the generated files, confirming the ignore entries are what suppress them.

### Accessibility Testing Instructions

N/A. No UI changes.

## Screenshots or screencast

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnQd7G77gehA2PgnzKvFei
