### PR TITLE
fix: resolve the REST index locally on namespaced sites

### DIFF
--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -34,6 +34,7 @@ export function configureApiFetch() {
 	apiFetch.use( nativeMediaUploadMiddleware );
 	apiFetch.use( mediaUploadMiddleware );
 	apiFetch.use( transformOEmbedApiResponse );
+	apiFetch.use( siteIndexMiddleware );
 	apiFetch.use(
 		apiFetch.createPreloadingMiddleware( preloadData ?? defaultPreloadData )
 	);
@@ -458,6 +459,52 @@ function transformOEmbedApiResponse( options, next ) {
 	}
 
 	return next( options, next );
+}
+
+/**
+ * Middleware resolving the REST API index locally on namespaced sites.
+ *
+ * Gutenberg's `root`/`__unstableBase` entity fetches the REST API index (`/`)
+ * during editor initialization. On a namespaced site that path has no segments
+ * for `apiPathModifierMiddleware` to insert the namespace into, so the request
+ * targets the API host's root, which serves no index. Rather than let the
+ * request fail, resolve the entity with the fields the host already provides.
+ *
+ * Consumers tolerate the remaining fields being absent: the site blocks read
+ * the `site` entity when the user can edit settings, and client-side media
+ * processing treats missing image sizes as none.
+ *
+ * Runs after the preloading middleware so a host-supplied index entry takes
+ * precedence. `apiFetch.use()` prepends, so this is registered immediately
+ * before it.
+ *
+ * @type {APIFetchMiddleware}
+ */
+function siteIndexMiddleware( options, next ) {
+	const { siteApiNamespace = [], siteURL } = getGBKit();
+	const isNamespacedSite = siteApiNamespace.length > 0;
+	const isGet = ! options.method || options.method.toUpperCase() === 'GET';
+
+	if ( ! isNamespacedSite || ! isGet || ! isRestIndexPath( options.path ) ) {
+		return next( options );
+	}
+
+	const home = siteURL?.replace( /\/+$/, '' );
+	return Promise.resolve( home ? { home, url: home } : {} );
+}
+
+/**
+ * Whether a request path targets the REST API index.
+ *
+ * @param {string} [path] The request path, e.g. `/?_fields=name`.
+ * @return {boolean} True for `/` with or without a query string.
+ */
+function isRestIndexPath( path ) {
+	if ( typeof path !== 'string' ) {
+		return false;
+	}
+	const pathname = path.split( '?' )[ 0 ];
+	return pathname === '' || pathname === '/';
 }
 
 const defaultPreloadData = {

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -468,7 +468,9 @@ function transformOEmbedApiResponse( options, next ) {
  * during editor initialization. On a namespaced site that path has no segments
  * for `apiPathModifierMiddleware` to insert the namespace into, so the request
  * targets the API host's root, which serves no index. Rather than let the
- * request fail, resolve the entity with the fields the host already provides.
+ * request fail, resolve the entity with `home` from the host's site URL. The
+ * host supplies a single URL, so `url`, the WordPress address, has no accurate
+ * source and is left unset.
  *
  * Consumers tolerate the remaining fields being absent: the site blocks read
  * the `site` entity when the user can edit settings, and client-side media
@@ -490,7 +492,7 @@ function siteIndexMiddleware( options, next ) {
 	}
 
 	const home = siteURL?.replace( /\/+$/, '' );
-	return Promise.resolve( home ? { home, url: home } : {} );
+	return Promise.resolve( home ? { home } : {} );
 }
 
 /**

--- a/src/utils/api-fetch.test.js
+++ b/src/utils/api-fetch.test.js
@@ -194,6 +194,74 @@ describe( 'api-fetch credentials handling', () => {
 		} );
 	} );
 
+	describe( 'siteIndexMiddleware', () => {
+		const indexPath = '/?_fields=name,home,url,image_sizes';
+
+		it( 'resolves the REST index locally on namespaced sites', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://public-api.example.com/',
+				siteApiNamespace: [ 'sites/123/' ],
+				namespaceExcludedPaths: [],
+				siteURL: 'https://example.com/',
+			} );
+
+			const result = await apiFetch( { path: indexPath } );
+
+			expect( global.fetch ).not.toHaveBeenCalled();
+			expect( result ).toEqual( {
+				home: 'https://example.com',
+				url: 'https://example.com',
+			} );
+		} );
+
+		it( 'resolves an empty record when the site URL is unknown', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://public-api.example.com/',
+				siteApiNamespace: [ 'sites/123/' ],
+				namespaceExcludedPaths: [],
+			} );
+
+			const result = await apiFetch( { path: '/' } );
+
+			expect( global.fetch ).not.toHaveBeenCalled();
+			expect( result ).toEqual( {} );
+		} );
+
+		it( 'requests the REST index from sites without a namespace', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [],
+				namespaceExcludedPaths: [],
+				siteURL: 'https://example.com/',
+			} );
+
+			await apiFetch( { path: indexPath } );
+
+			expect( global.fetch ).toHaveBeenCalled();
+			const [ url ] = global.fetch.mock.calls[ 0 ];
+			expect( url ).toMatch(
+				/^https:\/\/example\.com\/wp-json\/\?_fields=/
+			);
+		} );
+
+		it( 'lets non-index requests through on namespaced sites', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://public-api.example.com/',
+				siteApiNamespace: [ 'sites/123/' ],
+				namespaceExcludedPaths: [],
+				siteURL: 'https://example.com/',
+			} );
+
+			try {
+				await apiFetch( { path: '/wp/v2/posts' } );
+			} catch ( error ) {
+				// Ignore errors from the actual fetch
+			}
+
+			expect( global.fetch ).toHaveBeenCalled();
+		} );
+	} );
+
 	it( 'should preserve other headers when adding Authorization', async () => {
 		bridge.getGBKit.mockReturnValue( {
 			siteApiRoot: 'https://example.com/wp-json/',

--- a/src/utils/api-fetch.test.js
+++ b/src/utils/api-fetch.test.js
@@ -208,10 +208,7 @@ describe( 'api-fetch credentials handling', () => {
 			const result = await apiFetch( { path: indexPath } );
 
 			expect( global.fetch ).not.toHaveBeenCalled();
-			expect( result ).toEqual( {
-				home: 'https://example.com',
-				url: 'https://example.com',
-			} );
+			expect( result ).toEqual( { home: 'https://example.com' } );
 		} );
 
 		it( 'resolves an empty record when the site URL is unknown', async () => {

--- a/src/utils/bridge.js
+++ b/src/utils/bridge.js
@@ -225,6 +225,7 @@ export function onNetworkRequest( requestData ) {
  * @typedef GBKitConfig
  *
  * @property {boolean}  [themeStyles]            Controls if theme styles are applied to the editor.
+ * @property {string}   [siteURL]                The site's home URL.
  * @property {string}   [siteApiRoot]            The root URL of the site's API.
  * @property {string[]} [siteApiNamespace]       The namespace of the site's API; if multiple namespaces are provided, the first one is used as the default.
  * @property {string[]} [namespaceExcludedPaths] The paths that should not be namespaced.


### PR DESCRIPTION
## What?

Resolve Gutenberg's REST API index request locally on namespaced sites instead of sending it to the API host's root.

## Why?

This was primarily implemented to address an observed request failure in the console. There was no user-facing issue observed. 

The editor fails a request on every launch for a namespaced site. Gutenberg's `root`/`__unstableBase` entity fetches the REST API index (`/?_fields=...`) during initialization. That path has no segments for `apiPathModifierMiddleware` to insert the namespace into, so the request targets the bare API host root, which serves no index. Over HTTP origins (the Vite dev server, Android) it fails CORS preflight; from `file://` on iOS it follows a redirect to a docs page and fails JSON parsing.

The only unconditional consumer, `useBlockEditorSettings`, reads image sizes for client-side media processing, which GutenbergKit does not enable. The Site Title, Tagline, and Logo blocks read the `site` entity when the user can edit settings and only fall back to this record otherwise. No namespaced route serves the index, so there is nothing to redirect to.

## How?

Add `siteIndexMiddleware` to `configureApiFetch`. For GET requests to `/` on a site with a configured API namespace, it resolves with `home` and `url` from the host's `siteURL` rather than calling `next`. Every other request passes through unchanged. It runs after the preloading middleware so a host-supplied index entry still takes precedence.

## Testing Instructions

> [!tip]
> Use the bundled build rather than the Vite dev server for step 4. Some hosts answer the index request from a dev-server origin with a 429 that carries no CORS headers, which the browser reports as a CORS failure unrelated to this change.

1. Run `make build` and launch the demo app against a namespaced site (e.g., WordPress.com Simple).
2. Open Web Inspector's Network tab, filtered to XHR/Fetch.
3. Confirm no request to the API host root (`/?_fields=...`) appears and the editor loads normally.
4. Repeat against a self-hosted site and confirm the index request still goes to `<siteApiRoot>/?_fields=...` and succeeds.
5. `npm run test:unit -- src/utils/api-fetch.test.js`

Example root `/?_fields=...` request:

<img width="666" height="268" alt="image" src="https://github.com/user-attachments/assets/81408651-573d-4e54-96b7-af522697a996" />


### Accessibility Testing Instructions

No UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jPW5y3FrRywuHHn3gAHgu
