### PR TITLE
Split the media delegate into `MediaProcessor` and `MediaUploader`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,7 @@ playwright-report/
 wp-env/mu-plugins/*
 !wp-env/mu-plugins/gutenbergkit-cors.php
 !wp-env/mu-plugins/gutenbergkit-jetpack-blocks.php
+!wp-env/mu-plugins/gutenbergkit-media-failure.php
 
 # Claude
 .claude/settings.local.json

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ wp-env-android-reset: ## Remove the Android emulator URL remap and restart
 	@RESET=1 $(MAKE) wp-env-start
 
 .PHONY: wp-env-media-failure
-wp-env-media-failure: ## Report the media upload failure simulation mode (MODE=off|recover|always to set it)
+wp-env-media-failure: ## Report the media upload failure simulation mode (set via MODE=off|recover|always)
 	@MODE=$(MODE) bash bin/wp-env-media-failure.sh
 
 ################################################################################

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,10 @@ wp-env-android-reset: ## Remove the Android emulator URL remap and restart
 	@rm -f wp-env/mu-plugins/gutenbergkit-android-urls.php
 	@RESET=1 $(MAKE) wp-env-start
 
+.PHONY: wp-env-media-failure
+wp-env-media-failure: ## Report the media upload failure simulation mode (MODE=off|recover|always to set it)
+	@MODE=$(MODE) bash bin/wp-env-media-failure.sh
+
 ################################################################################
 # Code Quality Targets
 ################################################################################

--- a/android/Gutenberg/detekt-baseline.xml
+++ b/android/Gutenberg/detekt-baseline.xml
@@ -11,6 +11,7 @@
     <ID>ExplicitItLambdaParameter:EditorAssetsLibrary.kt$EditorAssetsLibrary${ str, it -&gt; str + "%02x".format(it) }</ID>
     <ID>FunctionNaming:EditorURLCache.kt$EditorURLCache$private fun __store( response: EditorURLResponse, url: String, httpMethod: EditorHttpMethod, currentDate: Date )</ID>
     <ID>LargeClass:GutenbergView.kt$GutenbergView : FrameLayout</ID>
+    <ID>LargeClass:MediaUploadServerTest.kt$MediaUploadServerTest</ID>
     <ID>LongMethod:FixtureTests.kt$FixtureTests$@Test fun `request parsing - all basic cases pass`()</ID>
     <ID>LongMethod:FixtureTests.kt$FixtureTests$@Test fun `request parsing - all incremental cases pass`()</ID>
     <ID>LongMethod:HTTPRequestParser.kt$HTTPRequestParser$fun append(data: ByteArray): Unit</ID>

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -121,6 +121,10 @@ class GutenbergView : FrameLayout {
      * construction (e.g. in the `AndroidView` factory). It is captured once, when
      * the page begins loading; setting it afterward has no effect, so the setter
      * throws to surface the mistake.
+     *
+     * This view owns the processor for its lifetime, so you don't need to keep a
+     * reference after assigning it — and avoid strongly retaining this [GutenbergView]
+     * from your processor in return, so the two don't form a reference cycle.
      */
     var mediaProcessor: MediaProcessor? = null
         set(value) {
@@ -133,7 +137,13 @@ class GutenbergView : FrameLayout {
      * queue, resumable transport). Setting it makes the host own every upload and
      * its whole lifecycle; GutenbergKit stays out of the network entirely for media.
      *
-     * Same lifecycle rules as [mediaProcessor]: set it before the editor loads.
+     * Same lifecycle rules as [mediaProcessor]: set it before the editor loads, and
+     * this view owns it for its lifetime — so you needn't retain it yourself, just
+     * don't strongly retain this [GutenbergView] from your uploader.
+     *
+     * Requires site credentials in the editor configuration: media deletes always
+     * relay to the configured site, so an uploader set without a site root and auth
+     * header is a configuration error and throws at load.
      */
     var mediaUploader: MediaUploader? = null
         set(value) {
@@ -689,16 +699,26 @@ class GutenbergView : FrameLayout {
         // processor or an uploader. (Matches iOS.)
         if (mediaProcessor == null && mediaUploader == null) return
 
-        // A DefaultMediaUploader delivers GutenbergKit-owned uploads (when no uploader
+        // An InternalMediaClient delivers GutenbergKit-owned uploads (when no uploader
         // is set) and relays the editor's media DELETEs to the configured site — every
         // attachment lives there, even one a host uploader delivered. It needs a site
-        // root and an auth header (every host provides one — the editor injects it
-        // because the WebView has no auth cookies). If GutenbergKit would have to
-        // deliver uploads itself but lacks those, there's nothing to upload through, so
-        // leave the server down and let uploads fall to the default WebView path.
-        if (mediaUploader == null &&
-            (configuration.siteApiRoot.isEmpty() || configuration.authHeader.isEmpty())
-        ) {
+        // root and an auth header (the editor injects it because the WebView has no
+        // auth cookies). Without them the behavior forks by intent:
+        //
+        // - A mediaProcessor only enhances GutenbergKit-owned uploads; with no
+        //   credentials there's nothing to deliver through, so nothing to process —
+        //   leave the server down and let uploads fall to the default WebView path.
+        //
+        // - A mediaUploader means the host is taking over uploads. Falling back would
+        //   silently drop it, and its media deletes still need the internal media client to
+        //   reach the configured site. A host that sets an uploader must provide
+        //   credentials too; omitting them is a configuration error, so fail fast.
+        if (configuration.siteApiRoot.isEmpty() || configuration.authHeader.isEmpty()) {
+            check(mediaUploader == null) {
+                "A mediaUploader needs site credentials so GutenbergKit can relay the " +
+                    "editor's media deletes to the configured site. Set siteApiRoot and " +
+                    "the auth header in the editor configuration."
+            }
             return
         }
 
@@ -720,25 +740,19 @@ class GutenbergView : FrameLayout {
         }
 
         try {
-            // Build a DefaultMediaUploader whenever there are credentials to reach the
-            // site: it delivers GutenbergKit-owned uploads and relays the editor's
-            // DELETEs there. null only when a host owns uploads and no creds exist.
-            val defaultUploader = if (
-                configuration.siteApiRoot.isNotEmpty() && configuration.authHeader.isNotEmpty()
-            ) {
-                DefaultMediaUploader(
-                    httpClient = uploadHttpClient,
-                    siteApiRoot = configuration.siteApiRoot,
-                    authHeader = configuration.authHeader,
-                    siteApiNamespace = configuration.siteApiNamespace.toList()
-                )
-            } else {
-                null
-            }
+            // Credentials are present (checked above), so always build a default
+            // uploader: it delivers GutenbergKit-owned uploads and relays the editor's
+            // media DELETEs to the configured site.
+            val internalClient = InternalMediaClient(
+                httpClient = uploadHttpClient,
+                siteApiRoot = configuration.siteApiRoot,
+                authHeader = configuration.authHeader,
+                siteApiNamespace = configuration.siteApiNamespace.toList()
+            )
             uploadServer = MediaUploadServer(
                 processor = mediaProcessor,
                 uploader = mediaUploader,
-                defaultUploader = defaultUploader,
+                internalClient = internalClient,
                 cacheDir = context.cacheDir,
                 scope = coroutineScope
             )

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -113,30 +113,44 @@ class GutenbergView : FrameLayout {
     var requestInterceptor: GutenbergRequestInterceptor = DefaultGutenbergRequestInterceptor()
 
     /**
-     * Optional delegate for customizing media upload behavior (resize, transcode,
-     * custom upload).
+     * Transforms media (resize, transcode, …) before GutenbergKit delivers it to
+     * the configured site. The safe, common extension point — a processor never
+     * performs the upload itself, so it cannot deliver media to the wrong place.
      *
      * Provide this **before the editor loads** — typically right after
      * construction (e.g. in the `AndroidView` factory). It is captured once, when
-     * the page begins loading, and advertised to the page then; setting it
-     * afterward has no effect, so the setter throws to surface the mistake.
+     * the page begins loading; setting it afterward has no effect, so the setter
+     * throws to surface the mistake.
      */
-    var mediaUploadDelegate: MediaUploadDelegate? = null
+    var mediaProcessor: MediaProcessor? = null
         set(value) {
-            check(!hasStartedLoading) {
-                "mediaUploadDelegate must be set before the editor loads (e.g. right " +
-                    "after construction). It is captured when the page begins loading; " +
-                    "setting it afterward has no effect."
-            }
+            check(!hasStartedLoading) { lateMediaAssignmentMessage("mediaProcessor") }
             field = value
         }
+
+    /**
+     * Takes over media upload on the host's own stack (background service, offline
+     * queue, resumable transport). Setting it makes the host own every upload and
+     * its whole lifecycle; GutenbergKit stays out of the network entirely for media.
+     *
+     * Same lifecycle rules as [mediaProcessor]: set it before the editor loads.
+     */
+    var mediaUploader: MediaUploader? = null
+        set(value) {
+            check(!hasStartedLoading) { lateMediaAssignmentMessage("mediaUploader") }
+            field = value
+        }
+
+    private fun lateMediaAssignmentMessage(name: String) =
+        "$name must be set before the editor loads (e.g. right after construction). " +
+            "It is captured when the page begins loading; setting it afterward has no effect."
 
     @Volatile private var uploadServer: MediaUploadServer? = null
 
     /**
      * True once the editor page has begun loading and the upload server's
-     * configuration has been captured. After this the [mediaUploadDelegate] can no
-     * longer take effect, so its setter throws.
+     * configuration has been captured. After this the [mediaProcessor]/[mediaUploader]
+     * can no longer take effect, so their setters throw.
      */
     @Volatile private var hasStartedLoading = false
 
@@ -638,13 +652,13 @@ class GutenbergView : FrameLayout {
 
     /**
      * Invoked when the editor page begins loading. Starts the upload server once —
-     * capturing the [mediaUploadDelegate] provided before load — then advertises
-     * the editor globals (including the server's port and token) to the page.
+     * capturing the [mediaProcessor]/[mediaUploader] provided before load — then
+     * advertises the editor globals (including the server's port and token) to the page.
      *
      * Starting the server here, on the UI thread, rather than from the
-     * [mediaUploadDelegate] setter keeps its whole lifecycle — start here, stop in
-     * [onDetachedFromWindow] — on the UI thread, so it can't race a
-     * background-thread delegate assignment.
+     * [mediaProcessor]/[mediaUploader] setters keeps its whole lifecycle — start
+     * here, stop in [onDetachedFromWindow] — on the UI thread, so it can't race a
+     * background-thread assignment.
      */
     private fun onEditorPageStarted() {
         if (!hasStartedLoading) {
@@ -671,17 +685,22 @@ class GutenbergView : FrameLayout {
     }
 
     private fun startUploadServer() {
-        // No delegate means nothing wants to customize uploads, so there's no reason
-        // to route them through the native server — leave it down and let uploads
-        // fall to the default WebView path. (Matches iOS.)
-        if (mediaUploadDelegate == null) return
+        // Nothing to route through the native server unless the host provided a
+        // processor or an uploader. (Matches iOS.)
+        if (mediaProcessor == null && mediaUploader == null) return
 
-        // The native upload server relays through DefaultMediaUploader, which needs a
-        // site root and an auth header (every host provides one — the editor injects
-        // it because the WebView has no auth cookies). Without both there is nothing
-        // to upload through, so leave the server down and let uploads fall to the
-        // default WebView path rather than start a server that could only fail.
-        if (configuration.siteApiRoot.isEmpty() || configuration.authHeader.isEmpty()) return
+        // A DefaultMediaUploader delivers GutenbergKit-owned uploads (when no uploader
+        // is set) and relays the editor's media DELETEs to the configured site — every
+        // attachment lives there, even one a host uploader delivered. It needs a site
+        // root and an auth header (every host provides one — the editor injects it
+        // because the WebView has no auth cookies). If GutenbergKit would have to
+        // deliver uploads itself but lacks those, there's nothing to upload through, so
+        // leave the server down and let uploads fall to the default WebView path.
+        if (mediaUploader == null &&
+            (configuration.siteApiRoot.isEmpty() || configuration.authHeader.isEmpty())
+        ) {
+            return
+        }
 
         // The editor reaches the loopback server over cleartext http://localhost. If
         // the host app's network-security config doesn't permit cleartext to
@@ -701,14 +720,24 @@ class GutenbergView : FrameLayout {
         }
 
         try {
-            val defaultUploader = DefaultMediaUploader(
-                httpClient = uploadHttpClient,
-                siteApiRoot = configuration.siteApiRoot,
-                authHeader = configuration.authHeader,
-                siteApiNamespace = configuration.siteApiNamespace.toList()
-            )
+            // Build a DefaultMediaUploader whenever there are credentials to reach the
+            // site: it delivers GutenbergKit-owned uploads and relays the editor's
+            // DELETEs there. null only when a host owns uploads and no creds exist.
+            val defaultUploader = if (
+                configuration.siteApiRoot.isNotEmpty() && configuration.authHeader.isNotEmpty()
+            ) {
+                DefaultMediaUploader(
+                    httpClient = uploadHttpClient,
+                    siteApiRoot = configuration.siteApiRoot,
+                    authHeader = configuration.authHeader,
+                    siteApiNamespace = configuration.siteApiNamespace.toList()
+                )
+            } else {
+                null
+            }
             uploadServer = MediaUploadServer(
-                uploadDelegate = mediaUploadDelegate,
+                processor = mediaProcessor,
+                uploader = mediaUploader,
                 defaultUploader = defaultUploader,
                 cacheDir = context.cacheDir,
                 scope = coroutineScope

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/HttpServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/HttpServer.kt
@@ -125,6 +125,12 @@ enum class CorsPolicy {
                 "Access-Control-Allow-Origin" to "*",
                 "Access-Control-Allow-Methods" to "GET, POST, PUT, DELETE, OPTIONS",
                 "Access-Control-Allow-Headers" to "Authorization, Relay-Authorization, Content-Type",
+                // Only CORS-safelisted response headers are readable
+                // cross-origin by default. The editor needs to read
+                // `x-wp-upload-attachment-id` off a relayed media upload
+                // response to retry `post-process` and clean up an orphaned
+                // attachment, so it has to be exposed explicitly.
+                "Access-Control-Expose-Headers" to "x-wp-upload-attachment-id",
                 "Access-Control-Max-Age" to "86400"
             )
         }
@@ -179,6 +185,7 @@ private fun HttpResponse.addingHeadersIfAbsent(newHeaders: Map<String, String>):
  *     Access-Control-Allow-Origin: <origin>
  *     Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
  *     Access-Control-Allow-Headers: Authorization, Relay-Authorization, Content-Type
+ *     Access-Control-Expose-Headers: x-wp-upload-attachment-id
  *     Access-Control-Max-Age: 86400
  *
  * Without these headers, browsers will reject the preflight and block

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -554,6 +554,16 @@ internal class MediaUploadServer(
                 // Hand the host the editor's non-file fields (e.g. `post`) and query
                 // too, so its own POST can reproduce a native upload — otherwise the
                 // attachment is created unattached and `?_embed` is lost.
+                //
+                // The UTF-8 decode is lossless because of an invariant nothing enforces:
+                // the only client is the editor's browser FormData. The server binds to
+                // loopback behind a per-session token; a FormData string value is a
+                // USVString, already well-formed at append time; and its only way to carry
+                // arbitrary bytes is a Blob, which always gets a filename and so is
+                // filtered out of extraParts above. Valid UTF-8 — emoji, any script —
+                // round-trips exactly. If that stops holding this silently substitutes
+                // U+FFFD, and differently from iOS (Java reports one replacement char for
+                // ED A0 80 where Swift's maximal-subpart rule reports three).
                 val fields = extraParts.map { part ->
                     MediaUploadField(part.name, String(part.body.readBytes(), Charsets.UTF_8))
                 }
@@ -663,8 +673,11 @@ internal open class InternalMediaClient(
         val mediaType = mimeType.toMediaType()
         val builder = okhttp3.MultipartBody.Builder().setType(okhttp3.MultipartBody.FORM)
         // Preserve the non-file parts (post, additionalData) through the re-encode.
-        // Append each field's raw bytes (not via String) so a non-UTF-8 value is
-        // forwarded verbatim rather than coerced. filename=null makes it a plain
+        // Each field's raw bytes are appended rather than round-tripped through String
+        // — not because malformed values are expected (they can't reach here; see the
+        // invariant where `fields` is built), but so this re-encode stays byte-identical
+        // to the passthrough it stands in for: a user's upload shouldn't change shape
+        // just because a processor resized the image. filename=null makes it a plain
         // field, matching okhttp's String overload byte-for-byte.
         for (part in extraParts) {
             builder.addFormDataPart(part.name, null, part.body.readBytes().toRequestBody())

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -222,15 +222,55 @@ internal class MediaUploadServer(
     }
 
     private suspend fun handleRequest(request: HttpRequest): HttpResponse {
-        // Route: only POST /upload is handled. (OPTIONS preflight is answered by
-        // the HTTP library under its permissive CORS policy.) Match on the path
-        // alone — the target carries a query string (e.g. `?_embed`) that the
-        // upload handler relays on to WordPress.
-        if (request.method.uppercase() != "POST" || request.path != "/upload") {
-            return errorResponse(404, "Not found")
+        // Routes: POST /upload, and DELETE /media/<id> for the editor's orphan
+        // cleanup. (OPTIONS preflight is answered by the HTTP library under its
+        // permissive CORS policy.) Match on the path alone — the target carries
+        // a query string (e.g. `?_embed`, `?force=true`) relayed to WordPress.
+        val method = request.method.uppercase()
+
+        if (method == "POST" && request.path == "/upload") {
+            return handleUpload(request)
         }
 
-        return handleUpload(request)
+        if (method == "DELETE") {
+            attachmentIdFromPath(request.path)?.let { attachmentId ->
+                return handleDelete(attachmentId, request.query)
+            }
+        }
+
+        return errorResponse(404, "Not found")
+    }
+
+    /**
+     * The attachment ID in a `/media/<id>` path, or `null` if the path is not one.
+     *
+     * Deliberately narrow: this server relays media operations, not arbitrary
+     * REST requests, so only a numeric attachment ID under `/media/` matches.
+     */
+    private fun attachmentIdFromPath(path: String): String? {
+        val components = path.split("/").filter { it.isNotEmpty() }
+        if (components.size != 2 || components[0] != "media") return null
+        val id = components[1]
+        return if (id.isNotEmpty() && id.all { it.isDigit() }) id else null
+    }
+
+    /**
+     * Relays the editor's orphan cleanup to WordPress.
+     *
+     * Core's media upload middleware deletes the attachment when every
+     * `post-process` retry fails. A cross-origin editor cannot issue that
+     * request directly — api-fetch tunnels `DELETE` as a `POST` carrying
+     * `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
+     * browser blocks it at preflight. Relaying it here lets the cleanup run.
+     */
+    private suspend fun handleDelete(attachmentId: String, query: String): HttpResponse {
+        val uploader = defaultUploader ?: return errorResponse(500, "No uploader configured")
+        return try {
+            relayResponse(uploader.deleteMedia(attachmentId, query))
+        } catch (e: IOException) {
+            Log.e(TAG, "Media deletion failed", e)
+            errorResponse(500, e.message ?: "Deletion failed")
+        }
     }
 
     private suspend fun handleUpload(request: HttpRequest): HttpResponse {
@@ -494,8 +534,26 @@ internal open class DefaultMediaUploader(
      * namespacing (so it matches every other REST URL) and carrying the original
      * request query (e.g. `?_embed`) through to WordPress.
      */
-    private fun mediaEndpointUrl(query: String): String =
-        RestUrlBuilder.namespaced(siteApiRoot, siteApiNamespace.firstOrNull(), "/wp/v2/media") + query
+    private fun mediaEndpointUrl(query: String, attachmentId: String? = null): String {
+        val path = if (attachmentId != null) "/wp/v2/media/$attachmentId" else "/wp/v2/media"
+        return RestUrlBuilder.namespaced(siteApiRoot, siteApiNamespace.firstOrNull(), path) + query
+    }
+
+    /**
+     * Deletes an attachment, relaying WordPress's response verbatim.
+     *
+     * Carries the editor's query through unchanged — core's cleanup sends
+     * `?force=true`, without which WordPress trashes rather than deletes.
+     */
+    open suspend fun deleteMedia(attachmentId: String, query: String): MediaUploadResponse {
+        val request = okhttp3.Request.Builder()
+            .url(mediaEndpointUrl(query, attachmentId))
+            .addHeader("Authorization", authHeader)
+            .delete()
+            .build()
+
+        return performUpload(request)
+    }
 
     open suspend fun upload(
         file: File, mimeType: String, filename: String,

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -352,11 +352,18 @@ internal class MediaUploadServer(
      * the editor retry `post-process` for an upload whose metadata generation
      * fataled server-side, rather than surfacing a permanent failure and leaving
      * an orphaned attachment behind.
+     *
+     * The response's own `Content-Type` wins over the JSON default, matched
+     * case-insensitively — HTTP header names are case-insensitive, and
+     * [HttpResponse] serializes every entry it is given, so a plain map merge
+     * would emit the name twice for a delegate that spells it `content-type`.
      */
     private fun relayResponse(response: MediaUploadResponse): HttpResponse {
+        val hasContentType = response.headers.keys.any { it.lowercase() == "content-type" }
+        val defaults = if (hasContentType) emptyMap() else mapOf("Content-Type" to "application/json")
         return HttpResponse(
             status = response.statusCode,
-            headers = mapOf("Content-Type" to "application/json") + response.headers,
+            headers = defaults + response.headers,
             body = response.body
         )
     }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -111,6 +111,20 @@ interface MediaUploadDelegate {
      * the editor sees a complete attachment object.
      */
     suspend fun uploadFile(file: File, mimeType: String, filename: String): MediaUploadResponse? = null
+
+    /**
+     * Delete a previously uploaded attachment.
+     *
+     * The editor deletes the attachment when an upload's server-side
+     * post-processing fails past recovery, so it does not leave an orphan
+     * behind. A delegate that uploaded the attachment itself via [uploadFile]
+     * owns an ID only it can resolve, so it must delete the attachment itself
+     * too — the default uploader would address the wrong site.
+     *
+     * Return the raw response (status code + body), which GutenbergKit relays
+     * to the editor unchanged, or null to use the default uploader.
+     */
+    suspend fun deleteFile(attachmentId: String): MediaUploadResponse? = null
 }
 
 /**
@@ -234,7 +248,7 @@ internal class MediaUploadServer(
 
         if (method == "DELETE") {
             attachmentIdFromPath(request.path)?.let { attachmentId ->
-                return handleDelete(attachmentId, request.query)
+                return handleMediaDelete(attachmentId, request.query)
             }
         }
 
@@ -255,17 +269,22 @@ internal class MediaUploadServer(
     }
 
     /**
-     * Relays the editor's orphan cleanup to WordPress.
+     * Relays the editor's orphan cleanup.
      *
      * Core's media upload middleware deletes the attachment when every
      * `post-process` retry fails. A cross-origin editor cannot issue that
      * request directly — api-fetch tunnels `DELETE` as a `POST` carrying
      * `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
      * browser blocks it at preflight. Relaying it here lets the cleanup run.
+     *
+     * Offers the deletion to the delegate first, as [handleUpload] does, so a
+     * host that uploaded the attachment itself deletes it from the same place.
      */
-    private suspend fun handleDelete(attachmentId: String, query: String): HttpResponse {
-        val uploader = defaultUploader ?: return errorResponse(500, "No uploader configured")
+    private suspend fun handleMediaDelete(attachmentId: String, query: String): HttpResponse {
         return try {
+            uploadDelegate?.deleteFile(attachmentId)?.let { return relayResponse(it) }
+
+            val uploader = defaultUploader ?: return errorResponse(500, "No uploader configured")
             relayResponse(uploader.deleteMedia(attachmentId, query))
         } catch (e: IOException) {
             Log.e(TAG, "Media deletion failed", e)

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -123,6 +123,15 @@ interface MediaUploadDelegate {
      *
      * Return the raw response (status code + body), which GutenbergKit relays
      * to the editor unchanged, or null to use the default uploader.
+     *
+     * Return null for any ID the delegate does not recognize. Unlike the upload
+     * path, there is no [handlesFile] gate here — an attachment ID carries no
+     * MIME type or filename — so this method is called for *every* deletion,
+     * including attachments the delegate declined at upload time and WordPress
+     * therefore created itself. Returning a response for one of those (an error
+     * from the host's own media service, say) leaves the real WordPress
+     * attachment undeleted — precisely the orphan this cleanup exists to remove.
+     * null hands it to the default uploader, which addresses the right site.
      */
     suspend fun deleteFile(attachmentId: String): MediaUploadResponse? = null
 }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -99,6 +99,27 @@ interface MediaProcessor {
 }
 
 /**
+ * Everything a [MediaUploader] needs to reproduce a native upload: the file to send,
+ * its metadata, the editor's non-file form fields, and the request's query.
+ *
+ * @property file The file to upload — already processed, if a [MediaProcessor] ran.
+ * @property mimeType The file's MIME type.
+ * @property filename The file's name.
+ * @property fields The editor's non-file form fields, decoded as UTF-8 — most
+ *   importantly `post`, the parent post's ID, without which the attachment is created
+ *   unattached. Send each as a form part on your `POST /wp/v2/media`.
+ * @property query The request's query string (leading `?`, e.g. `?_embed=...`), or
+ *   empty. Carry it on your request so the editor gets the response it expects.
+ */
+data class MediaUpload(
+    val file: File,
+    val mimeType: String,
+    val filename: String,
+    val fields: Map<String, String>,
+    val query: String
+)
+
+/**
  * Takes over performing a media upload — on the host's own stack: its own
  * networking (say, to log every request), a background service, an offline queue,
  * a resumable transport, its own retry policy.
@@ -119,6 +140,10 @@ interface MediaUploader {
      * throw on terminal failure: a returned value is taken as a completed attachment,
      * and there is no GutenbergKit recovery behind you.
      *
+     * The [MediaUpload] carries the file plus the editor's form fields (e.g. `post`)
+     * and query — send them all so the created attachment matches a native upload
+     * rather than landing as an unattached orphan.
+     *
      * That recovery is yours to run. When `POST /wp/v2/media` fatals in server-side
      * post-processing it returns a 5xx carrying the attachment's ID in
      * `x-wp-upload-attachment-id` — the attachment exists but is unfinished. Don't
@@ -131,7 +156,7 @@ interface MediaUploader {
      * before you throw, or it stays on the site — neither GutenbergKit nor core
      * cleans up behind you.
      */
-    suspend fun upload(file: File, mimeType: String, filename: String): ByteArray
+    suspend fun upload(upload: MediaUpload): ByteArray
 }
 
 /**
@@ -149,8 +174,8 @@ interface MediaUploader {
 internal class MediaUploadServer(
     private val processor: MediaProcessor?,
     private val uploader: MediaUploader?,
-    private val defaultUploader: DefaultMediaUploader?,
-    cacheDir: File? = null,
+    private val internalClient: InternalMediaClient,
+    cacheDir: File,
     scope: CoroutineScope? = null,
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : HttpServerDelegate {
@@ -163,11 +188,10 @@ internal class MediaUploadServer(
     private val server: HttpServer
 
     /**
-     * Directory for staging uploaded files, under the injected cache dir (with a
-     * system-temp fallback) so orphans share the app's managed cache lifecycle.
+     * Directory for staging uploaded files, under the injected cache dir so orphans
+     * share the app's managed cache lifecycle.
      */
-    private val uploadsTempDir: File =
-        File(cacheDir ?: File(System.getProperty("java.io.tmpdir")), "gutenbergkit-uploads")
+    private val uploadsTempDir: File = File(cacheDir, "gutenbergkit-uploads")
 
     /**
      * The scope MediaUploadServer created itself because the caller supplied none.
@@ -286,13 +310,13 @@ internal class MediaUploadServer(
      * browser blocks it at preflight; relaying it here lets the deletion run.
      *
      * Every attachment lives on the configured site — even one a host uploader
-     * delivered — so its deletion is relayed to the default uploader there. See
+     * delivered — so its deletion is relayed to the internal media client there. See
      * the accepted-risk note in the body.
      */
     @Suppress("TooGenericExceptionCaught")
     private suspend fun handleMediaDelete(attachmentId: String, query: String): HttpResponse {
         return try {
-            // Relay to the default uploader (the configured site) — every attachment
+            // Relay to the internal media client (the configured site) — every attachment
             // lives there, even one a host uploader delivered. Core issues this only
             // as orphan cleanup after failed recovery, but the relay can't tell that
             // from any other DELETE the WebView sends: a compromised editor script
@@ -301,8 +325,7 @@ internal class MediaUploadServer(
             // access, and a server-side compromise (a malicious plugin) deletes media
             // directly without the editor, so scoping this with a per-session ledger
             // buys little for the cost.
-            val defaultUploader = defaultUploader ?: return errorResponse(500, "No uploader configured")
-            relayResponse(defaultUploader.deleteMedia(attachmentId, query))
+            relayResponse(internalClient.deleteMedia(attachmentId, query))
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
             throw e // Never swallow coroutine cancellation.
         } catch (e: Exception) {
@@ -337,7 +360,7 @@ internal class MediaUploadServer(
         val tempFile = writePartToTempFile(filePart)
             ?: return errorResponse(500, "Failed to save file")
 
-        return processAndRespond(request, tempFile, filePart, extraParts, query)
+        return processAndRespond(request, tempFile, filePart, extraParts, query, processorWantsFile)
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -362,17 +385,15 @@ internal class MediaUploadServer(
      * fataled server-side, rather than surfacing a permanent failure and leaving
      * an orphaned attachment behind.
      *
-     * The response's own `Content-Type` wins over the JSON default, matched
-     * case-insensitively — HTTP header names are case-insensitive, and
-     * [HttpResponse] serializes every entry it is given, so a plain map merge
-     * would emit the name twice for a delegate that spells it `content-type`.
+     * The relayed body is always WordPress REST JSON — an attachment, or a
+     * `{code, message, data}` error — so the response is always `application/json`.
+     * The relayed headers are a content-type-free allowlist (`RELAYABLE_HEADER_NAMES`),
+     * so prepending the JSON default never collides with them.
      */
     private fun relayResponse(response: MediaUploadResponse): HttpResponse {
-        val hasContentType = response.headers.keys.any { it.lowercase() == "content-type" }
-        val defaults = if (hasContentType) emptyMap() else mapOf("Content-Type" to "application/json")
         return HttpResponse(
             status = response.statusCode,
-            headers = defaults + response.headers,
+            headers = mapOf("Content-Type" to "application/json") + response.headers,
             body = response.body
         )
     }
@@ -421,11 +442,12 @@ internal class MediaUploadServer(
     @Suppress("TooGenericExceptionCaught")
     private suspend fun processAndRespond(
         request: HttpRequest, tempFile: File, filePart: MultipartPart,
-        extraParts: List<MultipartPart>, query: String
+        extraParts: List<MultipartPart>, query: String, processorWantsFile: Boolean
     ): HttpResponse {
         try {
             val uploadResult = processAndUpload(
-                tempFile, filePart.contentType, filePart.filename ?: "upload", extraParts, query
+                tempFile, filePart.contentType, filePart.filename ?: "upload",
+                extraParts, query, processorWantsFile
             )
             val response = when (uploadResult) {
                 is UploadResult.Uploaded -> {
@@ -469,19 +491,20 @@ internal class MediaUploadServer(
     private suspend fun performPassthroughUpload(request: HttpRequest, query: String): MediaUploadResponse {
         val body = request.body
         val contentType = request.header("Content-Type")
-        val uploader = defaultUploader
-        if (body == null || contentType == null || uploader == null) {
-            throw MediaUploadException("Passthrough upload requires a request body, Content-Type, and default uploader")
+        if (body == null || contentType == null) {
+            throw MediaUploadException("Passthrough upload requires a request body and Content-Type")
         }
-        return uploader.passthroughUpload(body, contentType, query)
+        return internalClient.passthroughUpload(body, contentType, query)
     }
 
     private suspend fun processAndUpload(
         file: File, mimeType: String, filename: String,
-        extraParts: List<MultipartPart>, query: String
+        extraParts: List<MultipartPart>, query: String, processorWantsFile: Boolean
     ): UploadResult {
-        // Transform (resize, transcode, …) if a processor claims the file.
-        val processed = if (processor?.handlesFile(mimeType, filename) == true) {
+        // Transform (resize, transcode, …) if a processor claims the file. Reuse the
+        // gate's handlesFile decision from handleUpload rather than asking again — one
+        // metadata call per upload, and the admit and transform steps can't disagree.
+        val processed = if (processorWantsFile && processor != null) {
             processor.processFile(file, mimeType, filename)
         } else {
             ProcessedProxyFile.Original
@@ -509,8 +532,15 @@ internal class MediaUploadServer(
             // An uploader owns delivery on the host's own stack and returns the
             // finished attachment JSON (or throws); GutenbergKit relays that as a
             // success and never runs its own recovery behind it.
-            uploader?.let {
-                return UploadResult.Uploaded(MediaUploadResponse(201, it.upload(targetFile, targetMimeType, targetFilename)))
+            uploader?.let { up ->
+                // Hand the host the editor's non-file fields (e.g. `post`) and query
+                // too, so its own POST can reproduce a native upload — otherwise the
+                // attachment is created unattached and `?_embed` is lost.
+                val fields = extraParts.associate { part ->
+                    part.name to String(part.body.readBytes(), Charsets.UTF_8)
+                }
+                val upload = MediaUpload(targetFile, targetMimeType, targetFilename, fields, query)
+                return UploadResult.Uploaded(MediaUploadResponse(201, up.upload(upload)))
             }
 
             // Unmodified — forward the original request body directly, skipping
@@ -519,8 +549,7 @@ internal class MediaUploadServer(
                 return UploadResult.Passthrough
             }
 
-            val result = defaultUploader?.upload(targetFile, targetMimeType, targetFilename, extraParts, query)
-                ?: error("No uploader or default uploader configured")
+            val result = internalClient.upload(targetFile, targetMimeType, targetFilename, extraParts, query)
             return UploadResult.Uploaded(result)
         } finally {
             // The processed file (if the delegate produced a new one) is ours to
@@ -577,7 +606,7 @@ internal class MediaUploadException(message: String, cause: Throwable? = null) :
 /**
  * Uploads files to the WordPress REST API using OkHttp.
  */
-internal open class DefaultMediaUploader(
+internal open class InternalMediaClient(
     private val httpClient: okhttp3.OkHttpClient,
     private val siteApiRoot: String,
     private val authHeader: String,

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -280,13 +280,16 @@ internal class MediaUploadServer(
      * Offers the deletion to the delegate first, as [handleUpload] does, so a
      * host that uploaded the attachment itself deletes it from the same place.
      */
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun handleMediaDelete(attachmentId: String, query: String): HttpResponse {
         return try {
             uploadDelegate?.deleteFile(attachmentId)?.let { return relayResponse(it) }
 
             val uploader = defaultUploader ?: return errorResponse(500, "No uploader configured")
             relayResponse(uploader.deleteMedia(attachmentId, query))
-        } catch (e: IOException) {
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e // Never swallow coroutine cancellation.
+        } catch (e: Exception) {
             Log.e(TAG, "Media deletion failed", e)
             errorResponse(500, e.message ?: "Deletion failed")
         }

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -99,6 +99,22 @@ interface MediaProcessor {
 }
 
 /**
+ * One of the editor's non-file form fields, as sent with a media upload.
+ *
+ * A named type rather than a `Pair`, so the two platforms describe this the same way
+ * and reading a field says `name`/`value` rather than `first`/`second`. (On iOS the
+ * equivalent change is load-bearing: a tuple there would block Equatable/Hashable/
+ * Codable synthesis on [MediaUpload] permanently.)
+ *
+ * @property name The field name, e.g. `post`. Not unique — a `field[]` array repeats it.
+ * @property value The field's value, decoded as UTF-8.
+ */
+data class MediaUploadField(
+    val name: String,
+    val value: String
+)
+
+/**
  * Everything a [MediaUploader] needs to reproduce a native upload: the file to send,
  * its metadata, the editor's non-file form fields, and the request's query.
  *
@@ -107,9 +123,9 @@ interface MediaProcessor {
  * @property filename The file's name.
  * @property fields The editor's non-file form fields, in order, each decoded as UTF-8 —
  *   most importantly `post`, the parent post's ID, without which the attachment is
- *   created unattached. A list of `(name, value)` pairs, not a map, so repeated field
- *   names (e.g. a `field[]` array) survive verbatim. Send each as a form part on your
- *   `POST /wp/v2/media`, in the given order.
+ *   created unattached. A list, not a map, so repeated field names (e.g. a `field[]`
+ *   array) survive verbatim. Send each as a form part on your `POST /wp/v2/media`,
+ *   in the given order.
  * @property query The request's query string (leading `?`, e.g. `?_embed=...`), or
  *   empty. Carry it on your request so the editor gets the response it expects.
  */
@@ -117,7 +133,7 @@ data class MediaUpload(
     val file: File,
     val mimeType: String,
     val filename: String,
-    val fields: List<Pair<String, String>>,
+    val fields: List<MediaUploadField>,
     val query: String
 )
 
@@ -539,7 +555,7 @@ internal class MediaUploadServer(
                 // too, so its own POST can reproduce a native upload — otherwise the
                 // attachment is created unattached and `?_embed` is lost.
                 val fields = extraParts.map { part ->
-                    part.name to String(part.body.readBytes(), Charsets.UTF_8)
+                    MediaUploadField(part.name, String(part.body.readBytes(), Charsets.UTF_8))
                 }
                 val upload = MediaUpload(targetFile, targetMimeType, targetFilename, fields, query)
                 return UploadResult.Uploaded(MediaUploadResponse(201, up.upload(upload)))

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -105,9 +105,11 @@ interface MediaProcessor {
  * @property file The file to upload — already processed, if a [MediaProcessor] ran.
  * @property mimeType The file's MIME type.
  * @property filename The file's name.
- * @property fields The editor's non-file form fields, decoded as UTF-8 — most
- *   importantly `post`, the parent post's ID, without which the attachment is created
- *   unattached. Send each as a form part on your `POST /wp/v2/media`.
+ * @property fields The editor's non-file form fields, in order, each decoded as UTF-8 —
+ *   most importantly `post`, the parent post's ID, without which the attachment is
+ *   created unattached. A list of `(name, value)` pairs, not a map, so repeated field
+ *   names (e.g. a `field[]` array) survive verbatim. Send each as a form part on your
+ *   `POST /wp/v2/media`, in the given order.
  * @property query The request's query string (leading `?`, e.g. `?_embed=...`), or
  *   empty. Carry it on your request so the editor gets the response it expects.
  */
@@ -115,7 +117,7 @@ data class MediaUpload(
     val file: File,
     val mimeType: String,
     val filename: String,
-    val fields: Map<String, String>,
+    val fields: List<Pair<String, String>>,
     val query: String
 )
 
@@ -536,7 +538,7 @@ internal class MediaUploadServer(
                 // Hand the host the editor's non-file fields (e.g. `post`) and query
                 // too, so its own POST can reproduce a native upload — otherwise the
                 // attachment is created unattached and `?_embed` is lost.
-                val fields = extraParts.associate { part ->
+                val fields = extraParts.map { part ->
                     part.name to String(part.body.readBytes(), Charsets.UTF_8)
                 }
                 val upload = MediaUpload(targetFile, targetMimeType, targetFilename, fields, query)

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -31,8 +31,8 @@ import okio.source
  * so every consumer — image sub-sizes, attachment links, error notices —
  * behaves identically to a non-native upload.
  */
-class MediaUploadResponse(
-    /** The HTTP status code WordPress (or the host's upload service) returned. */
+internal class MediaUploadResponse(
+    /** The HTTP status code WordPress returned. */
     val statusCode: Int,
     /**
      * The raw response body — a WordPress REST attachment on success, or a
@@ -52,7 +52,7 @@ class MediaUploadResponse(
 )
 
 /**
- * The result of a delegate's [MediaUploadDelegate.processFile].
+ * The result of a [MediaProcessor.processFile].
  */
 sealed class ProcessedProxyFile {
     /** The delegate did not modify the file; the original upload is forwarded unchanged. */
@@ -68,72 +68,70 @@ sealed class ProcessedProxyFile {
 }
 
 /**
- * Interface for customizing media upload behavior.
+ * Transforms media before GutenbergKit delivers it.
  *
- * The native host app can provide an implementation to resize images,
- * transcode video, or use its own upload service.
+ * A processor only changes *bytes* — GutenbergKit still uploads the result to the
+ * configured site and owns the whole lifecycle (retries, cleanup). Because it
+ * never performs the upload itself, a processor cannot deliver media to the wrong
+ * place. Set [GutenbergView.mediaProcessor] to resize images, transcode video,
+ * strip EXIF, etc. This is the safe, common extension point: most hosts want only
+ * this.
  */
-interface MediaUploadDelegate {
+interface MediaProcessor {
     /**
-     * Whether this delegate might handle a file with the given metadata — either
-     * processing it ([processFile]) or uploading it itself ([uploadFile]).
-     *
-     * A cheap, metadata-only gate the server consults *before* materializing the
-     * upload to a temp file. Return false to decline a file by type — e.g. an
-     * image-only delegate returning false for a video — so the server forwards
-     * the original upload to WordPress without first copying a file the delegate
-     * won't touch. Because it gates the temp-file copy needed by *both*
-     * [processFile] and [uploadFile], return true for any file the delegate will
-     * either process or upload itself.
-     *
-     * Defaults to true: every file is materialized and the full pipeline runs. A
-     * true here is not a commitment — [processFile] may still return
-     * [ProcessedProxyFile.Original] after inspecting the file's contents.
+     * Whether this processor might transform a file with the given metadata. A
+     * cheap, metadata-only gate consulted *before* the upload is materialized to a
+     * temp file; return false to pass a file straight through untouched — e.g. an
+     * image-only processor returning false for a video. Defaults to true; not a
+     * commitment, since [processFile] may still return [ProcessedProxyFile.Original]
+     * after inspecting the file's contents.
      */
     fun handlesFile(mimeType: String, filename: String): Boolean = true
 
     /**
-     * Process a file before upload (e.g., resize image, transcode video).
-     *
-     * Return [ProcessedProxyFile.Original] to upload the file unchanged, or
-     * [ProcessedProxyFile.Processed] with the processed file and its metadata.
-     * When the format changes, report the new mimeType and filename so WordPress
-     * stores it with the correct extension and type.
+     * Transform a file before upload (e.g., resize image, transcode video). Return
+     * [ProcessedProxyFile.Original] to upload it unchanged, or
+     * [ProcessedProxyFile.Processed] with the new file and its metadata (report the
+     * new mimeType and filename when the format changes, so WordPress stores it
+     * with the correct extension and type).
      */
     suspend fun processFile(file: File, mimeType: String, filename: String): ProcessedProxyFile = ProcessedProxyFile.Original
+}
 
+/**
+ * Takes over performing a media upload — on the host's own stack: its own
+ * networking (say, to log every request), a background service, an offline queue,
+ * a resumable transport, its own retry policy.
+ *
+ * This is a choice of who executes the requests, not where they go: an uploader
+ * and GutenbergKit's built-in default both target the same configured site.
+ * Setting [GutenbergView.mediaUploader] makes the host own that upload end-to-end —
+ * the request, its own retries, and its recovery and cleanup — with GutenbergKit
+ * out of the network entirely. Because the host does the retries itself, there's no
+ * raw response left for core to retry behind it. The attachment you return lives on
+ * that same configured site, where the editor reads and updates it by ID.
+ */
+interface MediaUploader {
     /**
-     * Upload a processed file to the remote WordPress site.
+     * Upload a (possibly processed) file and return the finished WordPress
+     * attachment JSON the editor inserts — the same object a direct
+     * `POST /wp/v2/media` returns. Return only once the upload is genuinely done, or
+     * throw on terminal failure: a returned value is taken as a completed attachment,
+     * and there is no GutenbergKit recovery behind you.
      *
-     * Return the raw WordPress response (status code + body), which GutenbergKit
-     * relays to the editor unchanged, or null to use the default uploader. A host
-     * that uploads to WordPress should return the exact response it received so
-     * the editor sees a complete attachment object.
+     * That recovery is yours to run. When `POST /wp/v2/media` fatals in server-side
+     * post-processing it returns a 5xx carrying the attachment's ID in
+     * `x-wp-upload-attachment-id` — the attachment exists but is unfinished. Don't
+     * re-upload; drive `POST /wp/v2/media/<id>/post-process` to completion, the way
+     * core recovers its own uploads (up to 5 attempts), then return the finished
+     * attachment.
+     *
+     * Owning the upload means owning cleanup on the server too: if post-process
+     * can't be recovered, force-delete the orphan (`DELETE /wp/v2/media/<id>?force=true`)
+     * before you throw, or it stays on the site — neither GutenbergKit nor core
+     * cleans up behind you.
      */
-    suspend fun uploadFile(file: File, mimeType: String, filename: String): MediaUploadResponse? = null
-
-    /**
-     * Delete a previously uploaded attachment.
-     *
-     * The editor deletes the attachment when an upload's server-side
-     * post-processing fails past recovery, so it does not leave an orphan
-     * behind. A delegate that uploaded the attachment itself via [uploadFile]
-     * owns an ID only it can resolve, so it must delete the attachment itself
-     * too — the default uploader would address the wrong site.
-     *
-     * Return the raw response (status code + body), which GutenbergKit relays
-     * to the editor unchanged, or null to use the default uploader.
-     *
-     * Return null for any ID the delegate does not recognize. Unlike the upload
-     * path, there is no [handlesFile] gate here — an attachment ID carries no
-     * MIME type or filename — so this method is called for *every* deletion,
-     * including attachments the delegate declined at upload time and WordPress
-     * therefore created itself. Returning a response for one of those (an error
-     * from the host's own media service, say) leaves the real WordPress
-     * attachment undeleted — precisely the orphan this cleanup exists to remove.
-     * null hands it to the default uploader, which addresses the right site.
-     */
-    suspend fun deleteFile(attachmentId: String): MediaUploadResponse? = null
+    suspend fun upload(file: File, mimeType: String, filename: String): ByteArray
 }
 
 /**
@@ -149,7 +147,8 @@ interface MediaUploadDelegate {
  * stop on detach.
  */
 internal class MediaUploadServer(
-    private val uploadDelegate: MediaUploadDelegate?,
+    private val processor: MediaProcessor?,
+    private val uploader: MediaUploader?,
     private val defaultUploader: DefaultMediaUploader?,
     cacheDir: File? = null,
     scope: CoroutineScope? = null,
@@ -278,24 +277,32 @@ internal class MediaUploadServer(
     }
 
     /**
-     * Relays the editor's orphan cleanup.
+     * Relays a media deletion.
      *
-     * Core's media upload middleware deletes the attachment when every
-     * `post-process` retry fails. A cross-origin editor cannot issue that
-     * request directly — api-fetch tunnels `DELETE` as a `POST` carrying
-     * `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
-     * browser blocks it at preflight. Relaying it here lets the cleanup run.
+     * The editor deletes an attachment when the user removes it, and core deletes
+     * an upload's orphan when every `post-process` retry fails. A cross-origin
+     * editor cannot issue `DELETE` directly — api-fetch tunnels it as a `POST`
+     * carrying `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
+     * browser blocks it at preflight; relaying it here lets the deletion run.
      *
-     * Offers the deletion to the delegate first, as [handleUpload] does, so a
-     * host that uploaded the attachment itself deletes it from the same place.
+     * Every attachment lives on the configured site — even one a host uploader
+     * delivered — so its deletion is relayed to the default uploader there. See
+     * the accepted-risk note in the body.
      */
     @Suppress("TooGenericExceptionCaught")
     private suspend fun handleMediaDelete(attachmentId: String, query: String): HttpResponse {
         return try {
-            uploadDelegate?.deleteFile(attachmentId)?.let { return relayResponse(it) }
-
-            val uploader = defaultUploader ?: return errorResponse(500, "No uploader configured")
-            relayResponse(uploader.deleteMedia(attachmentId, query))
+            // Relay to the default uploader (the configured site) — every attachment
+            // lives there, even one a host uploader delivered. Core issues this only
+            // as orphan cleanup after failed recovery, but the relay can't tell that
+            // from any other DELETE the WebView sends: a compromised editor script
+            // holding the loopback token could force-delete arbitrary media on the
+            // configured site. Accepted risk — such a script already has broad write
+            // access, and a server-side compromise (a malicious plugin) deletes media
+            // directly without the editor, so scoping this with a per-session ledger
+            // buys little for the cost.
+            val defaultUploader = defaultUploader ?: return errorResponse(500, "No uploader configured")
+            relayResponse(defaultUploader.deleteMedia(attachmentId, query))
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
             throw e // Never swallow coroutine cancellation.
         } catch (e: Exception) {
@@ -317,11 +324,13 @@ internal class MediaUploadServer(
         val mimeType = filePart.contentType
         val filename = filePart.filename ?: "upload"
 
-        // Ask the delegate — from metadata alone — whether it will touch a file
-        // like this. If not, forward the original upload to WordPress directly,
-        // skipping a full temp-file copy of a file the delegate won't process or
-        // upload (e.g. a video handed to an image-only delegate).
-        if (uploadDelegate?.handlesFile(mimeType, filename) != true) {
+        // Materialize a temp file only if someone will touch it: a processor that
+        // claims this file, or an uploader (which always delivers the file itself).
+        // If GutenbergKit will deliver (no uploader) and no processor wants the
+        // file, forward the original request body directly, skipping a temp copy of
+        // a file nobody will process (e.g. a video handed to an image-only processor).
+        val processorWantsFile = processor?.handlesFile(mimeType, filename) == true
+        if (uploader == null && !processorWantsFile) {
             return passthroughResponse(request, query)
         }
 
@@ -424,8 +433,8 @@ internal class MediaUploadServer(
                     uploadResult.response
                 }
                 is UploadResult.Passthrough -> {
-                    // Delegate didn't modify the file — forward the original
-                    // request body to WordPress without re-encoding.
+                    // No uploader is set and the processor left the file unmodified —
+                    // forward the original request body without re-encoding.
                     Log.d(TAG, "Passthrough: forwarding original request body to WordPress")
                     performPassthroughUpload(request, query)
                 }
@@ -450,7 +459,7 @@ internal class MediaUploadServer(
         }
     }
 
-    // MARK: - Delegate Pipeline
+    // MARK: - Process + Deliver Pipeline
 
     private sealed class UploadResult {
         data class Uploaded(val response: MediaUploadResponse) : UploadResult()
@@ -471,10 +480,15 @@ internal class MediaUploadServer(
         file: File, mimeType: String, filename: String,
         extraParts: List<MultipartPart>, query: String
     ): UploadResult {
-        val processed = uploadDelegate?.processFile(file, mimeType, filename) ?: ProcessedProxyFile.Original
+        // Transform (resize, transcode, …) if a processor claims the file.
+        val processed = if (processor?.handlesFile(mimeType, filename) == true) {
+            processor.processFile(file, mimeType, filename)
+        } else {
+            ProcessedProxyFile.Original
+        }
 
         // Resolve the file to upload and its metadata. Processed uses the
-        // delegate's values verbatim, so a format change is reported to WordPress.
+        // processor's values verbatim, so a format change is reported to WordPress.
         val targetFile: File
         val targetMimeType: String
         val targetFilename: String
@@ -492,9 +506,11 @@ internal class MediaUploadServer(
         }
 
         try {
-            // If the delegate provided its own upload, use that.
-            uploadDelegate?.uploadFile(targetFile, targetMimeType, targetFilename)?.let {
-                return UploadResult.Uploaded(it)
+            // An uploader owns delivery on the host's own stack and returns the
+            // finished attachment JSON (or throws); GutenbergKit relays that as a
+            // success and never runs its own recovery behind it.
+            uploader?.let {
+                return UploadResult.Uploaded(MediaUploadResponse(201, it.upload(targetFile, targetMimeType, targetFilename)))
             }
 
             // Unmodified — forward the original request body directly, skipping
@@ -504,7 +520,7 @@ internal class MediaUploadServer(
             }
 
             val result = defaultUploader?.upload(targetFile, targetMimeType, targetFilename, extraParts, query)
-                ?: error("No upload delegate or default uploader configured")
+                ?: error("No uploader or default uploader configured")
             return UploadResult.Uploaded(result)
         } finally {
             // The processed file (if the delegate produced a new one) is ours to

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/MediaUploadServer.kt
@@ -38,7 +38,17 @@ class MediaUploadResponse(
      * The raw response body — a WordPress REST attachment on success, or a
      * WordPress REST error object (`{ "code", "message", "data" }`) on failure.
      */
-    val body: ByteArray
+    val body: ByteArray,
+    /**
+     * The response headers to relay to the editor.
+     *
+     * `x-wp-upload-attachment-id` is the one that carries behavior: WordPress
+     * sets it on a failed upload whose attachment row was created before
+     * metadata generation fataled, and the editor's api-fetch middleware reads
+     * it to retry `post-process` and clean up the orphan. Dropping it turns a
+     * recoverable upload into a permanent failure.
+     */
+    val headers: Map<String, String> = emptyMap()
 )
 
 /**
@@ -264,13 +274,18 @@ internal class MediaUploadServer(
     }
 
     /**
-     * Relays WordPress's exact status and body to the editor so it sees the same
-     * attachment object (or error) as a direct upload.
+     * Relays WordPress's exact status, body, and relayable headers to the editor
+     * so it sees the same attachment object (or error) as a direct upload.
+     *
+     * The headers matter for recovery: `x-wp-upload-attachment-id` is what lets
+     * the editor retry `post-process` for an upload whose metadata generation
+     * fataled server-side, rather than surfacing a permanent failure and leaving
+     * an orphaned attachment behind.
      */
     private fun relayResponse(response: MediaUploadResponse): HttpResponse {
         return HttpResponse(
             status = response.statusCode,
-            headers = mapOf("Content-Type" to "application/json"),
+            headers = mapOf("Content-Type" to "application/json") + response.headers,
             body = response.body
         )
     }
@@ -559,7 +574,11 @@ internal open class DefaultMediaUploader(
                     // holding a connection permit.
                     val result = try {
                         response.use {
-                            MediaUploadResponse(it.code, it.body?.bytes() ?: ByteArray(0))
+                            MediaUploadResponse(
+                                it.code,
+                                it.body?.bytes() ?: ByteArray(0),
+                                relayableHeaders(it)
+                            )
                         }
                     } catch (e: IOException) {
                         if (!continuation.isCancelled) continuation.resumeWithException(e)
@@ -576,5 +595,23 @@ internal open class DefaultMediaUploader(
                 }
             })
         }
+    }
+
+    /** Picks the headers to relay out of an upstream response. */
+    private fun relayableHeaders(response: okhttp3.Response): Map<String, String> =
+        RELAYABLE_HEADER_NAMES.mapNotNull { name ->
+            response.header(name)?.let { name to it }
+        }.toMap()
+
+    companion object {
+        /**
+         * The upstream headers worth relaying to the editor.
+         *
+         * Deliberately an allowlist rather than a filtered passthrough: the body
+         * is re-sent with a recomputed length, so relaying upstream entity or
+         * transport headers wholesale would risk contradicting what the server
+         * actually sends.
+         */
+        private val RELAYABLE_HEADER_NAMES = listOf("x-wp-upload-attachment-id")
     }
 }

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewUploadServerTest.kt
@@ -148,6 +148,40 @@ class GutenbergViewUploadServerTest {
     }
 
     @Test
+    fun `an uploader without a site api root is a configuration error`() {
+        // The other arm of the same gate: an auth header is no use without a site to
+        // send it to. Both fields have to be present and usable for the internal media
+        // client to reach the configured site, so either one missing traps — iOS gates
+        // on the same pair.
+        val config = EditorConfiguration
+            .builder("https://example.com", "")
+            .setAuthHeader("Bearer token")
+            .build() // deliberately no site API root
+        val view = GutenbergView(
+            config,
+            EditorDependencies.empty,
+            testScope,
+            RuntimeEnvironment.getApplication()
+        )
+        try {
+            view.mediaUploader = mock(MediaUploader::class.java)
+            val error = assertThrows(InvocationTargetException::class.java) {
+                startLoading(view)
+            }
+            assertTrue(
+                "an uploader without a site api root should fail with IllegalStateException",
+                error.cause is IllegalStateException
+            )
+            assertNull(
+                "no server should be left running after the configuration error",
+                uploadServerOf(view)
+            )
+        } finally {
+            detach(view)
+        }
+    }
+
+    @Test
     fun `detaching the view stops and clears the upload server`() {
         val view = makeView()
         view.mediaProcessor = mock(MediaProcessor::class.java)

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewUploadServerTest.kt
@@ -62,15 +62,15 @@ class GutenbergViewUploadServerTest {
     private fun idle() = shadowOf(Looper.getMainLooper()).idle()
 
     @Test
-    fun `the upload server starts when the page begins loading, capturing the delegate`() {
+    fun `the upload server starts when the page begins loading, capturing the processor`() {
         val view = makeView()
         try {
-            // A delegate provided before load is captured when the page starts.
-            view.mediaUploadDelegate = mock(MediaUploadDelegate::class.java)
+            // A processor provided before load is captured when the page starts.
+            view.mediaProcessor = mock(MediaProcessor::class.java)
             startLoading(view)
             idle()
             assertNotNull(
-                "a delegate provided before load should bring up the upload server",
+                "a processor provided before load should bring up the upload server",
                 uploadServerOf(view)
             )
         } finally {
@@ -79,14 +79,14 @@ class GutenbergViewUploadServerTest {
     }
 
     @Test
-    fun `no delegate means no upload server`() {
+    fun `no processor or uploader means no upload server`() {
         val view = makeView()
         try {
-            // No delegate provided — uploads should use the default WebView path.
+            // Nothing provided — uploads should use the default WebView path.
             startLoading(view)
             idle()
             assertNull(
-                "with no delegate, no upload server should be started",
+                "with no processor or uploader, no upload server should be started",
                 uploadServerOf(view)
             )
         } finally {
@@ -95,15 +95,15 @@ class GutenbergViewUploadServerTest {
     }
 
     @Test
-    fun `setting the delegate after the page has started loading throws`() {
+    fun `setting a media handler after the page has started loading throws`() {
         val view = makeView()
         try {
             startLoading(view)
             idle()
-            // The delegate is captured at load; a later assignment is a programmer
+            // The processor is captured at load; a later assignment is a programmer
             // error and must surface loudly rather than silently do nothing.
             assertThrows(IllegalStateException::class.java) {
-                view.mediaUploadDelegate = mock(MediaUploadDelegate::class.java)
+                view.mediaProcessor = mock(MediaProcessor::class.java)
             }
         } finally {
             detach(view)
@@ -113,7 +113,7 @@ class GutenbergViewUploadServerTest {
     @Test
     fun `detaching the view stops and clears the upload server`() {
         val view = makeView()
-        view.mediaUploadDelegate = mock(MediaUploadDelegate::class.java)
+        view.mediaProcessor = mock(MediaProcessor::class.java)
         startLoading(view)
         idle()
         assertNotNull(uploadServerOf(view))

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewUploadServerTest.kt
@@ -2,10 +2,12 @@ package org.wordpress.gutenberg
 
 import android.os.Looper
 import android.view.View
+import java.lang.reflect.InvocationTargetException
 import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -105,6 +107,41 @@ class GutenbergViewUploadServerTest {
             assertThrows(IllegalStateException::class.java) {
                 view.mediaProcessor = mock(MediaProcessor::class.java)
             }
+        } finally {
+            detach(view)
+        }
+    }
+
+    @Test
+    fun `an uploader without site credentials is a configuration error`() {
+        // A mediaUploader owns uploads, but media deletes still relay to the configured
+        // site — which needs credentials to reach. Setting an uploader without them is
+        // a programmer error, surfaced loudly rather than starting a server whose every
+        // delete would fail. (A processor without credentials is fine — it just falls
+        // back to the default WebView path, covered above.)
+        val config = EditorConfiguration
+            .builder("https://example.com", "https://example.com/wp-json/")
+            .build() // deliberately no auth header
+        val view = GutenbergView(
+            config,
+            EditorDependencies.empty,
+            testScope,
+            RuntimeEnvironment.getApplication()
+        )
+        try {
+            view.mediaUploader = mock(MediaUploader::class.java)
+            // startUploadServer runs inside onEditorPageStarted, so reflection wraps its throw.
+            val error = assertThrows(InvocationTargetException::class.java) {
+                startLoading(view)
+            }
+            assertTrue(
+                "an uploader without credentials should fail with IllegalStateException",
+                error.cause is IllegalStateException
+            )
+            assertNull(
+                "no server should be left running after the configuration error",
+                uploadServerOf(view)
+            )
         } finally {
             detach(view)
         }

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -256,7 +256,7 @@ class MediaUploadServerTest {
         val boundary = "test-boundary-123"
         val body = buildMultipartBody(
             boundary, "photo.jpg", "image/jpeg", "fake image data".toByteArray(),
-            fields = listOf("post" to "123")
+            fields = listOf(MediaUploadField("post", "123"))
         )
 
         val response = sendRawRequest(
@@ -275,7 +275,7 @@ class MediaUploadServerTest {
         assertEquals("photo.jpg", uploader.lastFilename)
         // The editor's post association and query must reach the host uploader, so it
         // can reproduce a native upload (attach to the post, honor ?_embed).
-        assertEquals("123", uploader.lastFields.first { it.first == "post" }.second)
+        assertEquals("123", uploader.lastFields.first { it.name == "post" }.value)
         assertEquals("?_embed=wp:featuredmedia", uploader.lastQuery)
         // …and the actual file bytes the editor sent — the host uploads them itself.
         assertEquals("fake image data", uploader.lastFileBytes?.decodeToString())
@@ -308,7 +308,11 @@ class MediaUploadServerTest {
         val boundary = "test-boundary-123"
         val body = buildMultipartBody(
             boundary, "photo.jpg", "image/jpeg", "fake image data".toByteArray(),
-            fields = listOf("post" to "123", "media_folder[]" to "12", "media_folder[]" to "45")
+            fields = listOf(
+                MediaUploadField("post", "123"),
+                MediaUploadField("media_folder[]", "12"),
+                MediaUploadField("media_folder[]", "45")
+            )
         )
 
         val response = sendRawRequest(
@@ -326,9 +330,9 @@ class MediaUploadServerTest {
         // Both repeated values survive, in order — not collapsed to the last.
         assertEquals(
             listOf("12", "45"),
-            uploader.lastFields.filter { it.first == "media_folder[]" }.map { it.second }
+            uploader.lastFields.filter { it.name == "media_folder[]" }.map { it.value }
         )
-        assertEquals("123", uploader.lastFields.first { it.first == "post" }.second)
+        assertEquals("123", uploader.lastFields.first { it.name == "post" }.value)
     }
 
     @Test
@@ -904,7 +908,7 @@ class MediaUploadServerTest {
         filename: String,
         mimeType: String,
         data: ByteArray,
-        fields: List<Pair<String, String>> = emptyList()
+        fields: List<MediaUploadField> = emptyList()
     ): ByteArray {
         val out = java.io.ByteArrayOutputStream()
         for ((name, value) in fields) {
@@ -935,7 +939,7 @@ class MediaUploadServerTest {
         @Volatile var uploadCalled = false
         @Volatile var lastMimeType: String? = null
         @Volatile var lastFilename: String? = null
-        @Volatile var lastFields: List<Pair<String, String>> = emptyList()
+        @Volatile var lastFields: List<MediaUploadField> = emptyList()
         @Volatile var lastQuery: String? = null
         @Volatile var lastFileBytes: ByteArray? = null
 

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -336,6 +336,69 @@ class MediaUploadServerTest {
     }
 
     @Test
+    fun `keeps a filename-bearing part out of the fields handed to an uploader`() {
+        // Pins the invariant that makes the UTF-8 decode of `fields` lossless. A browser
+        // FormData can only carry arbitrary bytes as a Blob, and a Blob always gets a
+        // filename, so the partition on `filename == null` is what keeps binary out of
+        // `fields`. Change it and the decode silently substitutes U+FFFD — and does so
+        // differently from iOS.
+        //
+        // Deliberately not asserted: what becomes of the second filename-bearing part.
+        // It is currently dropped rather than relayed, which is a separate open question.
+        val uploader = MockUploader()
+        val internalClient = MockInternalMediaClient()
+        server.stop()
+        server = MediaUploadServer(
+            processor = null,
+            uploader = uploader,
+            internalClient = internalClient,
+            cacheDir = tempFolder.root
+        )
+
+        val boundary = "test-boundary-123"
+        val out = java.io.ByteArrayOutputStream()
+        // A plain field — no filename, so it belongs in `fields`.
+        out.write("--$boundary\r\n".toByteArray())
+        out.write("Content-Disposition: form-data; name=\"post\"\r\n\r\n".toByteArray())
+        out.write("123".toByteArray())
+        out.write("\r\n".toByteArray())
+        // The file.
+        out.write("--$boundary\r\n".toByteArray())
+        out.write("Content-Disposition: form-data; name=\"file\"; filename=\"photo.jpg\"\r\n".toByteArray())
+        out.write("Content-Type: image/jpeg\r\n\r\n".toByteArray())
+        out.write("fake image data".toByteArray())
+        out.write("\r\n".toByteArray())
+        // A Blob-shaped sidecar: filename present, bytes not valid UTF-8. If the
+        // partition admitted this to `fields`, the lone 0xFF would become U+FFFD.
+        out.write("--$boundary\r\n".toByteArray())
+        out.write("Content-Disposition: form-data; name=\"sidecar\"; filename=\"blob\"\r\n".toByteArray())
+        out.write("Content-Type: application/octet-stream\r\n\r\n".toByteArray())
+        out.write(byteArrayOf(0x61, 0xFF.toByte(), 0x62))
+        out.write("\r\n--$boundary--\r\n".toByteArray())
+
+        sendRawRequest(
+            method = "POST",
+            path = "/upload",
+            headers = mapOf(
+                "Relay-Authorization" to "Bearer ${server.token}",
+                "Content-Type" to "multipart/form-data; boundary=$boundary"
+            ),
+            body = out.toByteArray()
+        )
+
+        assertTrue(uploader.uploadCalled)
+        assertEquals(
+            "only filename-less parts belong in fields",
+            listOf("post"),
+            uploader.lastFields.map { it.name }
+        )
+        assertTrue(
+            "no field value should have been lossily decoded",
+            uploader.lastFields.none { it.value.contains('�') }
+        )
+    }
+
+    @Test
     fun `hands the processed file and its new metadata to the uploader`() {
         // A processor transcodes the file; the host uploader must receive the processed
         // bytes and the new metadata, not the original clip.mov.

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -33,7 +33,12 @@ class MediaUploadServerTest {
 
     @Before
     fun setUp() {
-        server = MediaUploadServer(processor = null, uploader = null, defaultUploader = null, cacheDir = tempFolder.root)
+        server = MediaUploadServer(
+            processor = null,
+            uploader = null,
+            internalClient = MockInternalMediaClient(),
+            cacheDir = tempFolder.root
+        )
     }
 
     @After
@@ -53,7 +58,12 @@ class MediaUploadServerTest {
     fun `stop cancels an internally-created scope but leaves a caller-supplied one alone`() {
         // No scope supplied → the server owns one, which stop() must cancel.
         val owningServer =
-            MediaUploadServer(processor = null, uploader = null, defaultUploader = null, cacheDir = tempFolder.root)
+            MediaUploadServer(
+                processor = null,
+                uploader = null,
+                internalClient = MockInternalMediaClient(),
+                cacheDir = tempFolder.root
+            )
         val ownedScope = ownedScopeOf(owningServer)
         assertNotNull("server should own a scope when none is supplied", ownedScope)
         assertTrue(ownedScope!!.isActive)
@@ -65,7 +75,7 @@ class MediaUploadServerTest {
         val borrowingServer = MediaUploadServer(
             processor = null,
             uploader = null,
-            defaultUploader = null,
+            internalClient = MockInternalMediaClient(),
             cacheDir = tempFolder.root,
             scope = callerScope
         )
@@ -142,17 +152,17 @@ class MediaUploadServerTest {
     }
 
     @Test
-    fun `relays a deletion to the default uploader even when an uploader owns uploads`() {
+    fun `relays a deletion to the internal media client even when an uploader owns uploads`() {
         // An attachment lives on the configured site even when a host uploader
-        // delivered it, so its deletion goes to the default uploader — the host
+        // delivered it, so its deletion goes to the internal media client — the host
         // uploader owns uploads, not deletes.
         val uploader = MockUploader()
-        val defaultUploader = MockDefaultUploader()
+        val internalClient = MockInternalMediaClient()
         server.stop()
         server = MediaUploadServer(
             processor = null,
             uploader = uploader,
-            defaultUploader = defaultUploader,
+            internalClient = internalClient,
             cacheDir = tempFolder.root
         )
 
@@ -164,22 +174,22 @@ class MediaUploadServerTest {
         )
 
         assertTrue("Expected 200 but got: ${response.statusLine}", response.statusLine.contains("200"))
-        assertTrue(defaultUploader.deleteMediaCalled)
-        assertEquals("42", defaultUploader.deletedAttachmentId)
+        assertTrue(internalClient.deleteMediaCalled)
+        assertEquals("42", internalClient.deletedAttachmentId)
     }
 
     // MARK: - Media deletion
 
     @Test
-    fun `relays a deletion to the default uploader (configured site)`() {
+    fun `relays a deletion to the internal media client (configured site)`() {
         // With no uploader set, GutenbergKit owns deletes: core's orphan cleanup
-        // DELETE is relayed to the default uploader (the configured site).
-        val mockUploader = MockDefaultUploader()
+        // DELETE is relayed to the internal media client (the configured site).
+        val mockUploader = MockInternalMediaClient()
         server.stop()
         server = MediaUploadServer(
             processor = null,
             uploader = null,
-            defaultUploader = mockUploader,
+            internalClient = mockUploader,
             cacheDir = tempFolder.root
         )
 
@@ -198,9 +208,9 @@ class MediaUploadServerTest {
     @Test
     fun `routes upload with a query string and relays the query`() {
         val processor = PassthroughProcessor()
-        val mockUploader = MockDefaultUploader()
+        val mockUploader = MockInternalMediaClient()
         server.stop()
-        server = MediaUploadServer(processor = processor, uploader = null, defaultUploader = mockUploader, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = processor, uploader = null, internalClient = mockUploader, cacheDir = tempFolder.root)
 
         // `@wordpress/media-utils` uploads to `/wp/v2/media?_embed=wp:featuredmedia`,
         // so the middleware forwards that query on to the native server. Routing must
@@ -232,19 +242,70 @@ class MediaUploadServerTest {
     @Test
     fun `routes an upload to the uploader and relays its attachment`() {
         // With an uploader set, GutenbergKit hands it the file and relays the finished
-        // attachment it returns — the default uploader (configured site) is never used.
+        // attachment it returns — the internal media client (configured site) is never used.
         val uploader = MockUploader()
-        val defaultUploader = MockDefaultUploader()
+        val internalClient = MockInternalMediaClient()
         server.stop()
         server = MediaUploadServer(
             processor = null,
             uploader = uploader,
-            defaultUploader = defaultUploader,
+            internalClient = internalClient,
             cacheDir = tempFolder.root
         )
 
         val boundary = "test-boundary-123"
-        val body = buildMultipartBody(boundary, "photo.jpg", "image/jpeg", "fake image data".toByteArray())
+        val body = buildMultipartBody(
+            boundary, "photo.jpg", "image/jpeg", "fake image data".toByteArray(),
+            fields = mapOf("post" to "123")
+        )
+
+        val response = sendRawRequest(
+            method = "POST",
+            path = "/upload?_embed=wp:featuredmedia",
+            headers = mapOf(
+                "Relay-Authorization" to "Bearer ${server.token}",
+                "Content-Type" to "multipart/form-data; boundary=$boundary"
+            ),
+            body = body
+        )
+
+        assertTrue("Expected 201 but got: ${response.statusLine}", response.statusLine.contains("201"))
+        assertTrue(uploader.uploadCalled)
+        assertEquals("image/jpeg", uploader.lastMimeType)
+        assertEquals("photo.jpg", uploader.lastFilename)
+        // The editor's post association and query must reach the host uploader, so it
+        // can reproduce a native upload (attach to the post, honor ?_embed).
+        assertEquals("123", uploader.lastFields["post"])
+        assertEquals("?_embed=wp:featuredmedia", uploader.lastQuery)
+        // …and the actual file bytes the editor sent — the host uploads them itself.
+        assertEquals("fake image data", uploader.lastFileBytes?.decodeToString())
+        // The host owns delivery — GutenbergKit must not upload to the configured site.
+        assertFalse(internalClient.uploadCalled)
+        assertFalse(internalClient.passthroughUploadCalled)
+
+        // The server relays the exact attachment JSON the uploader returned.
+        val json = JsonParser.parseString(response.body).asJsonObject
+        assertEquals(42, json.get("id").asInt)
+        assertEquals("https://example.com/photo.jpg", json.get("source_url").asString)
+        assertEquals("image", json.get("media_type").asString)
+    }
+
+    @Test
+    fun `hands the processed file and its new metadata to the uploader`() {
+        // A processor transcodes the file; the host uploader must receive the processed
+        // bytes and the new metadata, not the original clip.mov.
+        val processor = TranscodingProcessor()
+        val uploader = MockUploader()
+        server.stop()
+        server = MediaUploadServer(
+            processor = processor,
+            uploader = uploader,
+            internalClient = MockInternalMediaClient(),
+            cacheDir = tempFolder.root
+        )
+
+        val boundary = "test-boundary-proc"
+        val body = buildMultipartBody(boundary, "clip.mov", "video/quicktime", "movie".toByteArray())
 
         val response = sendRawRequest(
             method = "POST",
@@ -258,25 +319,45 @@ class MediaUploadServerTest {
 
         assertTrue("Expected 201 but got: ${response.statusLine}", response.statusLine.contains("201"))
         assertTrue(uploader.uploadCalled)
-        assertEquals("image/jpeg", uploader.lastMimeType)
-        assertEquals("photo.jpg", uploader.lastFilename)
-        // The host owns delivery — GutenbergKit must not upload to the configured site.
-        assertFalse(defaultUploader.uploadCalled)
-        assertFalse(defaultUploader.passthroughUploadCalled)
+        assertEquals("processed", uploader.lastFileBytes?.decodeToString())
+        assertEquals("video/mp4", uploader.lastMimeType)
+        assertEquals("clip.mp4", uploader.lastFilename)
+    }
 
-        // The server relays the exact attachment JSON the uploader returned.
-        val json = JsonParser.parseString(response.body).asJsonObject
-        assertEquals(42, json.get("id").asInt)
-        assertEquals("https://example.com/photo.jpg", json.get("source_url").asString)
-        assertEquals("image", json.get("media_type").asString)
+    @Test
+    fun `relays a 500 when the host uploader throws`() {
+        val uploader = MockUploader(error = RuntimeException("upload failed"))
+        server.stop()
+        server = MediaUploadServer(
+            processor = null,
+            uploader = uploader,
+            internalClient = MockInternalMediaClient(),
+            cacheDir = tempFolder.root
+        )
+
+        val boundary = "test-boundary-err"
+        val body = buildMultipartBody(boundary, "photo.jpg", "image/jpeg", "fake image data".toByteArray())
+
+        val response = sendRawRequest(
+            method = "POST",
+            path = "/upload",
+            headers = mapOf(
+                "Relay-Authorization" to "Bearer ${server.token}",
+                "Content-Type" to "multipart/form-data; boundary=$boundary"
+            ),
+            body = body
+        )
+
+        assertTrue("Expected 500 but got: ${response.statusLine}", response.statusLine.contains("500"))
+        assertTrue(uploader.uploadCalled)
     }
 
     @Test
     fun `forwards the processor's processed metadata to the uploader`() {
         val processor = TranscodingProcessor()
-        val mockUploader = MockDefaultUploader()
+        val mockUploader = MockInternalMediaClient()
         server.stop()
-        server = MediaUploadServer(processor = processor, uploader = null, defaultUploader = mockUploader, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = processor, uploader = null, internalClient = mockUploader, cacheDir = tempFolder.root)
 
         val boundary = "test-boundary-meta"
         val body = buildMultipartBody(boundary, "clip.mov", "video/quicktime", "movie".toByteArray())
@@ -301,9 +382,9 @@ class MediaUploadServerTest {
     @Test
     fun `deletes the processor's processed file after upload`() {
         val processor = TranscodingProcessor()
-        val mockUploader = MockDefaultUploader()
+        val mockUploader = MockInternalMediaClient()
         server.stop()
-        server = MediaUploadServer(processor = processor, uploader = null, defaultUploader = mockUploader, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = processor, uploader = null, internalClient = mockUploader, cacheDir = tempFolder.root)
 
         val boundary = "test-boundary-cleanup"
         val body = buildMultipartBody(boundary, "clip.mov", "video/quicktime", "movie".toByteArray())
@@ -343,7 +424,7 @@ class MediaUploadServerTest {
         server = MediaUploadServer(
             processor = null,
             uploader = null,
-            defaultUploader = null,
+            internalClient = MockInternalMediaClient(),
             cacheDir = tempFolder.root,
             ioDispatcher = Dispatchers.Unconfined
         )
@@ -352,15 +433,15 @@ class MediaUploadServerTest {
         assertTrue("Fresh temp should be preserved", fresh.exists())
     }
 
-    // MARK: - Fallback to default uploader
+    // MARK: - Fallback to internal media client
 
     @Test
     fun `uses passthrough when the processor does not modify the file`() {
         val processor = PassthroughProcessor()
-        val mockUploader = MockDefaultUploader()
+        val mockUploader = MockInternalMediaClient()
 
         server.stop()
-        server = MediaUploadServer(processor = processor, uploader = null, defaultUploader = mockUploader, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = processor, uploader = null, internalClient = mockUploader, cacheDir = tempFolder.root)
 
         val boundary = "test-boundary-456"
         val body = buildMultipartBody(boundary, "doc.pdf", "application/pdf", "fake pdf data".toByteArray())
@@ -388,10 +469,10 @@ class MediaUploadServerTest {
     @Test
     fun `skips processing and the temp copy when the processor declines by metadata`() {
         val processor = DecliningProcessor()
-        val mockUploader = MockDefaultUploader()
+        val mockUploader = MockInternalMediaClient()
 
         server.stop()
-        server = MediaUploadServer(processor = processor, uploader = null, defaultUploader = mockUploader, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = processor, uploader = null, internalClient = mockUploader, cacheDir = tempFolder.root)
 
         val boundary = "test-boundary-decline"
         val body = buildMultipartBody(boundary, "clip.mov", "video/quicktime", "fake movie".toByteArray())
@@ -414,10 +495,10 @@ class MediaUploadServerTest {
         assertFalse(mockUploader.uploadCalled)
     }
 
-    // MARK: - DefaultMediaUploader
+    // MARK: - InternalMediaClient
 
     @Test
-    fun `DefaultMediaUploader relays the WordPress response`() {
+    fun `InternalMediaClient relays the WordPress response`() {
         val mockWpServer = MockWebServer()
         val wpBody =
             """{"id":1,"source_url":"https://example.com/u.jpg","media_type":"image"}"""
@@ -430,7 +511,7 @@ class MediaUploadServerTest {
         mockWpServer.start()
 
         val wpBaseUrl = mockWpServer.url("/wp-json/").toString()
-        val uploader = DefaultMediaUploader(
+        val uploader = InternalMediaClient(
             httpClient = okhttp3.OkHttpClient(),
             siteApiRoot = wpBaseUrl,
             authHeader = "Bearer test-token"
@@ -455,13 +536,13 @@ class MediaUploadServerTest {
     }
 
     @Test
-    fun `DefaultMediaUploader relays a WordPress error response instead of throwing`() {
+    fun `InternalMediaClient relays a WordPress error response instead of throwing`() {
         val mockWpServer = MockWebServer()
         mockWpServer.enqueue(MockResponse().setResponseCode(500).setBody("Internal error"))
         mockWpServer.start()
 
         val wpBaseUrl = mockWpServer.url("/wp-json/").toString()
-        val uploader = DefaultMediaUploader(
+        val uploader = InternalMediaClient(
             httpClient = okhttp3.OkHttpClient(),
             siteApiRoot = wpBaseUrl,
             authHeader = "Bearer test-token"
@@ -480,7 +561,7 @@ class MediaUploadServerTest {
     }
 
     @Test
-    fun `DefaultMediaUploader relays the upload attachment ID header`() {
+    fun `InternalMediaClient relays the upload attachment ID header`() {
         // WordPress sets this header on an upload whose attachment row was
         // created before metadata generation fataled. The editor reads it to
         // retry post-process and clean up the orphan, so it must survive the
@@ -495,7 +576,7 @@ class MediaUploadServerTest {
         )
         mockWpServer.start()
 
-        val uploader = DefaultMediaUploader(
+        val uploader = InternalMediaClient(
             httpClient = okhttp3.OkHttpClient(),
             siteApiRoot = mockWpServer.url("/wp-json/").toString(),
             authHeader = "Bearer test-token"
@@ -513,12 +594,12 @@ class MediaUploadServerTest {
     }
 
     @Test
-    fun `DefaultMediaUploader deletes an attachment carrying namespace and force query`() {
+    fun `InternalMediaClient deletes an attachment carrying namespace and force query`() {
         val mockWpServer = MockWebServer()
         mockWpServer.enqueue(MockResponse().setResponseCode(200).setBody("""{"deleted":true}"""))
         mockWpServer.start()
 
-        val uploader = DefaultMediaUploader(
+        val uploader = InternalMediaClient(
             httpClient = okhttp3.OkHttpClient(),
             siteApiRoot = mockWpServer.url("/wp-json/").toString(),
             authHeader = "Bearer test-token",
@@ -536,12 +617,12 @@ class MediaUploadServerTest {
     }
 
     @Test
-    fun `DefaultMediaUploader normalizes an unslashed root and namespace`() {
+    fun `InternalMediaClient normalizes an unslashed root and namespace`() {
         val mockWpServer = MockWebServer()
         mockWpServer.enqueue(MockResponse().setResponseCode(201).setBody("{}"))
         mockWpServer.start()
 
-        val uploader = DefaultMediaUploader(
+        val uploader = InternalMediaClient(
             httpClient = okhttp3.OkHttpClient(),
             siteApiRoot = mockWpServer.url("/wp-json").toString(), // no trailing slash
             authHeader = "Bearer test-token",
@@ -573,7 +654,7 @@ class MediaUploadServerTest {
         )
         mockWpServer.start()
 
-        val uploader = DefaultMediaUploader(
+        val uploader = InternalMediaClient(
             httpClient = okhttp3.OkHttpClient(),
             siteApiRoot = mockWpServer.url("/wp-json/").toString(),
             authHeader = "Bearer test-token"
@@ -601,12 +682,12 @@ class MediaUploadServerTest {
     }
 
     @Test
-    fun `DefaultMediaUploader re-encode preserves extra parts and query`() {
+    fun `InternalMediaClient re-encode preserves extra parts and query`() {
         val mockWpServer = MockWebServer()
         mockWpServer.enqueue(MockResponse().setResponseCode(201).setBody("{}"))
         mockWpServer.start()
 
-        val uploader = DefaultMediaUploader(
+        val uploader = InternalMediaClient(
             httpClient = okhttp3.OkHttpClient(),
             siteApiRoot = mockWpServer.url("/wp-json/").toString(),
             authHeader = "Bearer test-token"
@@ -641,7 +722,7 @@ class MediaUploadServerTest {
         mockWpServer.enqueue(MockResponse().setResponseCode(201).setBody("{}"))
         mockWpServer.start()
 
-        val uploader = DefaultMediaUploader(
+        val uploader = InternalMediaClient(
             httpClient = okhttp3.OkHttpClient(),
             siteApiRoot = mockWpServer.url("/wp-json/").toString(),
             authHeader = "Bearer test-token"
@@ -781,9 +862,16 @@ class MediaUploadServerTest {
         boundary: String,
         filename: String,
         mimeType: String,
-        data: ByteArray
+        data: ByteArray,
+        fields: Map<String, String> = emptyMap()
     ): ByteArray {
         val out = java.io.ByteArrayOutputStream()
+        for ((name, value) in fields) {
+            out.write("--$boundary\r\n".toByteArray())
+            out.write("Content-Disposition: form-data; name=\"$name\"\r\n\r\n".toByteArray())
+            out.write(value.toByteArray())
+            out.write("\r\n".toByteArray())
+        }
         out.write("--$boundary\r\n".toByteArray())
         out.write("Content-Disposition: form-data; name=\"file\"; filename=\"$filename\"\r\n".toByteArray())
         out.write("Content-Type: $mimeType\r\n\r\n".toByteArray())
@@ -800,16 +888,24 @@ class MediaUploadServerTest {
      */
     private class MockUploader(
         private val uploadBody: ByteArray =
-            """{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}""".toByteArray()
+            """{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}""".toByteArray(),
+        private val error: Exception? = null
     ) : MediaUploader {
         @Volatile var uploadCalled = false
         @Volatile var lastMimeType: String? = null
         @Volatile var lastFilename: String? = null
+        @Volatile var lastFields: Map<String, String> = emptyMap()
+        @Volatile var lastQuery: String? = null
+        @Volatile var lastFileBytes: ByteArray? = null
 
-        override suspend fun upload(file: File, mimeType: String, filename: String): ByteArray {
+        override suspend fun upload(upload: MediaUpload): ByteArray {
             uploadCalled = true
-            lastMimeType = mimeType
-            lastFilename = filename
+            lastMimeType = upload.mimeType
+            lastFilename = upload.filename
+            lastFields = upload.fields
+            lastQuery = upload.query
+            lastFileBytes = upload.file.readBytes()
+            error?.let { throw it }
             return uploadBody
         }
     }
@@ -851,13 +947,13 @@ class MediaUploadServerTest {
         }
     }
 
-    private class MockDefaultUploader(
+    private class MockInternalMediaClient(
         /** The response `upload`/`passthroughUpload` return. Defaults to a 201 success. */
         private val uploadResponse: MediaUploadResponse = MediaUploadResponse(
             201,
             """{"id":99,"source_url":"https://example.com/doc.pdf","media_type":"file"}""".toByteArray()
         )
-    ) : DefaultMediaUploader(
+    ) : InternalMediaClient(
         httpClient = okhttp3.OkHttpClient(),
         siteApiRoot = "https://example.com/wp-json/",
         authHeader = "Bearer mock"

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -256,7 +256,7 @@ class MediaUploadServerTest {
         val boundary = "test-boundary-123"
         val body = buildMultipartBody(
             boundary, "photo.jpg", "image/jpeg", "fake image data".toByteArray(),
-            fields = mapOf("post" to "123")
+            fields = listOf("post" to "123")
         )
 
         val response = sendRawRequest(
@@ -275,7 +275,7 @@ class MediaUploadServerTest {
         assertEquals("photo.jpg", uploader.lastFilename)
         // The editor's post association and query must reach the host uploader, so it
         // can reproduce a native upload (attach to the post, honor ?_embed).
-        assertEquals("123", uploader.lastFields["post"])
+        assertEquals("123", uploader.lastFields.first { it.first == "post" }.second)
         assertEquals("?_embed=wp:featuredmedia", uploader.lastQuery)
         // …and the actual file bytes the editor sent — the host uploads them itself.
         assertEquals("fake image data", uploader.lastFileBytes?.decodeToString())
@@ -288,6 +288,47 @@ class MediaUploadServerTest {
         assertEquals(42, json.get("id").asInt)
         assertEquals("https://example.com/photo.jpg", json.get("source_url").asString)
         assertEquals("image", json.get("media_type").asString)
+    }
+
+    @Test
+    fun `hands a host uploader repeated form field names in order, not collapsed`() {
+        // A `field[]`-style repeated name (e.g. a custom attachment taxonomy): WordPress
+        // builds an array from these, so both values must reach the host uploader in
+        // order. A map would drop the first — the ordered-list contract must not.
+        val uploader = MockUploader()
+        val internalClient = MockInternalMediaClient()
+        server.stop()
+        server = MediaUploadServer(
+            processor = null,
+            uploader = uploader,
+            internalClient = internalClient,
+            cacheDir = tempFolder.root
+        )
+
+        val boundary = "test-boundary-123"
+        val body = buildMultipartBody(
+            boundary, "photo.jpg", "image/jpeg", "fake image data".toByteArray(),
+            fields = listOf("post" to "123", "media_folder[]" to "12", "media_folder[]" to "45")
+        )
+
+        val response = sendRawRequest(
+            method = "POST",
+            path = "/upload",
+            headers = mapOf(
+                "Relay-Authorization" to "Bearer ${server.token}",
+                "Content-Type" to "multipart/form-data; boundary=$boundary"
+            ),
+            body = body
+        )
+
+        assertTrue("Expected 201 but got: ${response.statusLine}", response.statusLine.contains("201"))
+        assertTrue(uploader.uploadCalled)
+        // Both repeated values survive, in order — not collapsed to the last.
+        assertEquals(
+            listOf("12", "45"),
+            uploader.lastFields.filter { it.first == "media_folder[]" }.map { it.second }
+        )
+        assertEquals("123", uploader.lastFields.first { it.first == "post" }.second)
     }
 
     @Test
@@ -863,7 +904,7 @@ class MediaUploadServerTest {
         filename: String,
         mimeType: String,
         data: ByteArray,
-        fields: Map<String, String> = emptyMap()
+        fields: List<Pair<String, String>> = emptyList()
     ): ByteArray {
         val out = java.io.ByteArrayOutputStream()
         for ((name, value) in fields) {
@@ -894,7 +935,7 @@ class MediaUploadServerTest {
         @Volatile var uploadCalled = false
         @Volatile var lastMimeType: String? = null
         @Volatile var lastFilename: String? = null
-        @Volatile var lastFields: Map<String, String> = emptyMap()
+        @Volatile var lastFields: List<Pair<String, String>> = emptyList()
         @Volatile var lastQuery: String? = null
         @Volatile var lastFileBytes: ByteArray? = null
 

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -447,6 +447,29 @@ class MediaUploadServerTest {
     }
 
     @Test
+    fun `DefaultMediaUploader deletes an attachment carrying namespace and force query`() {
+        val mockWpServer = MockWebServer()
+        mockWpServer.enqueue(MockResponse().setResponseCode(200).setBody("""{"deleted":true}"""))
+        mockWpServer.start()
+
+        val uploader = DefaultMediaUploader(
+            httpClient = okhttp3.OkHttpClient(),
+            siteApiRoot = mockWpServer.url("/wp-json/").toString(),
+            authHeader = "Bearer test-token",
+            siteApiNamespace = listOf("sites/123")
+        )
+
+        val response = runBlocking { uploader.deleteMedia("42", "?force=true") }
+
+        assertEquals(200, response.statusCode)
+        val recorded = mockWpServer.takeRequest()
+        assertEquals("DELETE", recorded.method)
+        assertEquals("/wp-json/wp/v2/sites/123/media/42?force=true", recorded.path)
+
+        mockWpServer.shutdown()
+    }
+
+    @Test
     fun `DefaultMediaUploader normalizes an unslashed root and namespace`() {
         val mockWpServer = MockWebServer()
         mockWpServer.enqueue(MockResponse().setResponseCode(201).setBody("{}"))

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -414,6 +414,39 @@ class MediaUploadServerTest {
     }
 
     @Test
+    fun `DefaultMediaUploader relays the upload attachment ID header`() {
+        // WordPress sets this header on an upload whose attachment row was
+        // created before metadata generation fataled. The editor reads it to
+        // retry post-process and clean up the orphan, so it must survive the
+        // relay. Unrelated upstream headers are not relayed.
+        val mockWpServer = MockWebServer()
+        mockWpServer.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .setBody("""{"code":"rest_upload_error"}""")
+                .setHeader("x-wp-upload-attachment-id", "4242")
+                .setHeader("X-Powered-By", "PHP/8.2")
+        )
+        mockWpServer.start()
+
+        val uploader = DefaultMediaUploader(
+            httpClient = okhttp3.OkHttpClient(),
+            siteApiRoot = mockWpServer.url("/wp-json/").toString(),
+            authHeader = "Bearer test-token"
+        )
+
+        val file = tempFolder.newFile("orphan.jpg")
+        file.writeBytes("data".toByteArray())
+
+        val response = runBlocking { uploader.upload(file, "image/jpeg", "orphan.jpg", emptyList(), "") }
+
+        assertEquals(500, response.statusCode)
+        assertEquals(mapOf("x-wp-upload-attachment-id" to "4242"), response.headers)
+
+        mockWpServer.shutdown()
+    }
+
+    @Test
     fun `DefaultMediaUploader normalizes an unslashed root and namespace`() {
         val mockWpServer = MockWebServer()
         mockWpServer.enqueue(MockResponse().setResponseCode(201).setBody("{}"))

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -141,6 +141,27 @@ class MediaUploadServerTest {
     }
 
     @Test
+    fun `routes a deletion to the delegate when it handles one`() {
+        // A host that uploaded the attachment itself owns an ID only it can
+        // resolve, so the default uploader must not be asked to delete it. No
+        // default uploader is configured, so a 200 here can only come from the
+        // delegate — the fallback path would fail with "no uploader".
+        val delegate = DeletingDelegate()
+        server.stop()
+        server = MediaUploadServer(uploadDelegate = delegate, defaultUploader = null, cacheDir = tempFolder.root)
+
+        val response = sendRawRequest(
+            method = "DELETE",
+            path = "/media/42?force=true",
+            headers = mapOf("Relay-Authorization" to "Bearer ${server.token}"),
+            body = ByteArray(0)
+        )
+
+        assertTrue("Expected 200 but got: ${response.statusLine}", response.statusLine.contains("200"))
+        assertEquals("42", delegate.deletedAttachmentId)
+    }
+
+    @Test
     fun `routes upload with a query string and relays the query`() {
         val delegate = ProcessOnlyDelegate()
         val mockUploader = MockDefaultUploader()
@@ -731,6 +752,19 @@ class MediaUploadServerTest {
             lastFilename = filename
             val json = """{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}"""
             return MediaUploadResponse(201, json.toByteArray())
+        }
+    }
+
+    /**
+     * A delegate that handles deletions itself, as a host uploading to its own
+     * media service would.
+     */
+    private class DeletingDelegate : MediaUploadDelegate {
+        @Volatile var deletedAttachmentId: String? = null
+
+        override suspend fun deleteFile(attachmentId: String): MediaUploadResponse? {
+            deletedAttachmentId = attachmentId
+            return MediaUploadResponse(200, """{"deleted":true}""".toByteArray())
         }
     }
 

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -162,6 +162,30 @@ class MediaUploadServerTest {
     }
 
     @Test
+    fun `relays a delegate's own Content-Type instead of emitting it twice`() {
+        // HTTP header names are case-insensitive, so a delegate spelling it
+        // `content-type` must still override the JSON default rather than merge
+        // alongside it — HttpResponse serializes every entry it is given, which
+        // would put the name on the wire twice (mirrors the iOS behavior).
+        val delegate = ContentTypeDeletingDelegate()
+        server.stop()
+        server = MediaUploadServer(uploadDelegate = delegate, defaultUploader = null, cacheDir = tempFolder.root)
+
+        val response = sendRawRequest(
+            method = "DELETE",
+            path = "/media/42?force=true",
+            headers = mapOf("Relay-Authorization" to "Bearer ${server.token}"),
+            body = ByteArray(0)
+        )
+
+        assertTrue("Expected 200 but got: ${response.statusLine}", response.statusLine.contains("200"))
+        // Assert on the raw header lines, not the parsed map: the parser
+        // lowercases keys into a map, so a duplicated header would silently
+        // collapse and this test would pass against the very bug it covers.
+        assertEquals(listOf("text/plain"), response.rawHeaderValues("content-type"))
+    }
+
+    @Test
     fun `routes upload with a query string and relays the query`() {
         val delegate = ProcessOnlyDelegate()
         val mockUploader = MockDefaultUploader()
@@ -659,8 +683,22 @@ class MediaUploadServerTest {
     private data class RawHttpResponse(
         val statusLine: String,
         val headers: Map<String, String>,
-        val body: String
-    )
+        val body: String,
+        /** The header lines exactly as received, before collapsing into [headers]. */
+        val rawHeaderLines: List<String> = emptyList()
+    ) {
+        /**
+         * Every value sent for [name], in order. Unlike [headers], this preserves
+         * repeats — the only way to catch a header emitted twice.
+         */
+        fun rawHeaderValues(name: String): List<String> =
+            rawHeaderLines.mapNotNull { line ->
+                val colonIndex = line.indexOf(':')
+                if (colonIndex <= 0) return@mapNotNull null
+                if (!line.substring(0, colonIndex).trim().equals(name, ignoreCase = true)) return@mapNotNull null
+                line.substring(colonIndex + 1).trim()
+            }
+    }
 
     private fun sendRawRequest(
         method: String,
@@ -715,7 +753,7 @@ class MediaUploadServerTest {
             }
         }
 
-        return RawHttpResponse(statusLine, responseHeaders, responseBody)
+        return RawHttpResponse(statusLine, responseHeaders, responseBody, lines.drop(1))
     }
 
     private fun buildMultipartBody(
@@ -765,6 +803,20 @@ class MediaUploadServerTest {
         override suspend fun deleteFile(attachmentId: String): MediaUploadResponse? {
             deletedAttachmentId = attachmentId
             return MediaUploadResponse(200, """{"deleted":true}""".toByteArray())
+        }
+    }
+
+    /**
+     * A delegate that sets its own `Content-Type`, lowercased, so the relay must
+     * override the JSON default rather than emit the header twice.
+     */
+    private class ContentTypeDeletingDelegate : MediaUploadDelegate {
+        override suspend fun deleteFile(attachmentId: String): MediaUploadResponse? {
+            return MediaUploadResponse(
+                200,
+                "deleted".toByteArray(),
+                mapOf("content-type" to "text/plain")
+            )
         }
     }
 

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/MediaUploadServerTest.kt
@@ -33,7 +33,7 @@ class MediaUploadServerTest {
 
     @Before
     fun setUp() {
-        server = MediaUploadServer(uploadDelegate = null, defaultUploader = null, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = null, uploader = null, defaultUploader = null, cacheDir = tempFolder.root)
     }
 
     @After
@@ -53,7 +53,7 @@ class MediaUploadServerTest {
     fun `stop cancels an internally-created scope but leaves a caller-supplied one alone`() {
         // No scope supplied → the server owns one, which stop() must cancel.
         val owningServer =
-            MediaUploadServer(uploadDelegate = null, defaultUploader = null, cacheDir = tempFolder.root)
+            MediaUploadServer(processor = null, uploader = null, defaultUploader = null, cacheDir = tempFolder.root)
         val ownedScope = ownedScopeOf(owningServer)
         assertNotNull("server should own a scope when none is supplied", ownedScope)
         assertTrue(ownedScope!!.isActive)
@@ -63,7 +63,8 @@ class MediaUploadServerTest {
         // A caller-supplied scope belongs to the caller — stop() must not cancel it.
         val callerScope = CoroutineScope(Dispatchers.IO)
         val borrowingServer = MediaUploadServer(
-            uploadDelegate = null,
+            processor = null,
+            uploader = null,
             defaultUploader = null,
             cacheDir = tempFolder.root,
             scope = callerScope
@@ -141,14 +142,19 @@ class MediaUploadServerTest {
     }
 
     @Test
-    fun `routes a deletion to the delegate when it handles one`() {
-        // A host that uploaded the attachment itself owns an ID only it can
-        // resolve, so the default uploader must not be asked to delete it. No
-        // default uploader is configured, so a 200 here can only come from the
-        // delegate — the fallback path would fail with "no uploader".
-        val delegate = DeletingDelegate()
+    fun `relays a deletion to the default uploader even when an uploader owns uploads`() {
+        // An attachment lives on the configured site even when a host uploader
+        // delivered it, so its deletion goes to the default uploader — the host
+        // uploader owns uploads, not deletes.
+        val uploader = MockUploader()
+        val defaultUploader = MockDefaultUploader()
         server.stop()
-        server = MediaUploadServer(uploadDelegate = delegate, defaultUploader = null, cacheDir = tempFolder.root)
+        server = MediaUploadServer(
+            processor = null,
+            uploader = uploader,
+            defaultUploader = defaultUploader,
+            cacheDir = tempFolder.root
+        )
 
         val response = sendRawRequest(
             method = "DELETE",
@@ -158,39 +164,43 @@ class MediaUploadServerTest {
         )
 
         assertTrue("Expected 200 but got: ${response.statusLine}", response.statusLine.contains("200"))
-        assertEquals("42", delegate.deletedAttachmentId)
+        assertTrue(defaultUploader.deleteMediaCalled)
+        assertEquals("42", defaultUploader.deletedAttachmentId)
     }
 
+    // MARK: - Media deletion
+
     @Test
-    fun `relays a delegate's own Content-Type instead of emitting it twice`() {
-        // HTTP header names are case-insensitive, so a delegate spelling it
-        // `content-type` must still override the JSON default rather than merge
-        // alongside it — HttpResponse serializes every entry it is given, which
-        // would put the name on the wire twice (mirrors the iOS behavior).
-        val delegate = ContentTypeDeletingDelegate()
+    fun `relays a deletion to the default uploader (configured site)`() {
+        // With no uploader set, GutenbergKit owns deletes: core's orphan cleanup
+        // DELETE is relayed to the default uploader (the configured site).
+        val mockUploader = MockDefaultUploader()
         server.stop()
-        server = MediaUploadServer(uploadDelegate = delegate, defaultUploader = null, cacheDir = tempFolder.root)
+        server = MediaUploadServer(
+            processor = null,
+            uploader = null,
+            defaultUploader = mockUploader,
+            cacheDir = tempFolder.root
+        )
 
         val response = sendRawRequest(
             method = "DELETE",
-            path = "/media/42?force=true",
+            path = "/media/512?force=true",
             headers = mapOf("Relay-Authorization" to "Bearer ${server.token}"),
             body = ByteArray(0)
         )
 
         assertTrue("Expected 200 but got: ${response.statusLine}", response.statusLine.contains("200"))
-        // Assert on the raw header lines, not the parsed map: the parser
-        // lowercases keys into a map, so a duplicated header would silently
-        // collapse and this test would pass against the very bug it covers.
-        assertEquals(listOf("text/plain"), response.rawHeaderValues("content-type"))
+        assertTrue(mockUploader.deleteMediaCalled)
+        assertEquals("512", mockUploader.deletedAttachmentId)
     }
 
     @Test
     fun `routes upload with a query string and relays the query`() {
-        val delegate = ProcessOnlyDelegate()
+        val processor = PassthroughProcessor()
         val mockUploader = MockDefaultUploader()
         server.stop()
-        server = MediaUploadServer(uploadDelegate = delegate, defaultUploader = mockUploader, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = processor, uploader = null, defaultUploader = mockUploader, cacheDir = tempFolder.root)
 
         // `@wordpress/media-utils` uploads to `/wp/v2/media?_embed=wp:featuredmedia`,
         // so the middleware forwards that query on to the native server. Routing must
@@ -209,7 +219,7 @@ class MediaUploadServerTest {
         )
 
         assertTrue("Expected 201 but got: ${response.statusLine}", response.statusLine.contains("201"))
-        // The delegate returns Original, so this is the passthrough branch.
+        // The processor returns Original, so this is the passthrough branch.
         // Pin which branch ran — `lastQuery` is recorded by both, so without this
         // the query assertion would pass even if routing collapsed onto one path.
         assertTrue(mockUploader.passthroughUploadCalled)
@@ -217,13 +227,21 @@ class MediaUploadServerTest {
         assertEquals("?_embed=wp:featuredmedia", mockUploader.lastQuery)
     }
 
-    // MARK: - Upload with delegate
+    // MARK: - Upload with a processor or uploader
 
     @Test
-    fun `calls delegate processFile and uploadFile`() {
-        val delegate = MockUploadDelegate()
+    fun `routes an upload to the uploader and relays its attachment`() {
+        // With an uploader set, GutenbergKit hands it the file and relays the finished
+        // attachment it returns — the default uploader (configured site) is never used.
+        val uploader = MockUploader()
+        val defaultUploader = MockDefaultUploader()
         server.stop()
-        server = MediaUploadServer(uploadDelegate = delegate, defaultUploader = null, cacheDir = tempFolder.root)
+        server = MediaUploadServer(
+            processor = null,
+            uploader = uploader,
+            defaultUploader = defaultUploader,
+            cacheDir = tempFolder.root
+        )
 
         val boundary = "test-boundary-123"
         val body = buildMultipartBody(boundary, "photo.jpg", "image/jpeg", "fake image data".toByteArray())
@@ -239,12 +257,14 @@ class MediaUploadServerTest {
         )
 
         assertTrue("Expected 201 but got: ${response.statusLine}", response.statusLine.contains("201"))
-        assertTrue(delegate.processFileCalled)
-        assertTrue(delegate.uploadFileCalled)
-        assertEquals("image/jpeg", delegate.lastMimeType)
-        assertEquals("photo.jpg", delegate.lastFilename)
+        assertTrue(uploader.uploadCalled)
+        assertEquals("image/jpeg", uploader.lastMimeType)
+        assertEquals("photo.jpg", uploader.lastFilename)
+        // The host owns delivery — GutenbergKit must not upload to the configured site.
+        assertFalse(defaultUploader.uploadCalled)
+        assertFalse(defaultUploader.passthroughUploadCalled)
 
-        // The server relays WordPress's raw response body verbatim.
+        // The server relays the exact attachment JSON the uploader returned.
         val json = JsonParser.parseString(response.body).asJsonObject
         assertEquals(42, json.get("id").asInt)
         assertEquals("https://example.com/photo.jpg", json.get("source_url").asString)
@@ -252,11 +272,11 @@ class MediaUploadServerTest {
     }
 
     @Test
-    fun `forwards the delegate's processed metadata to the uploader`() {
-        val delegate = TranscodingDelegate()
+    fun `forwards the processor's processed metadata to the uploader`() {
+        val processor = TranscodingProcessor()
         val mockUploader = MockDefaultUploader()
         server.stop()
-        server = MediaUploadServer(uploadDelegate = delegate, defaultUploader = mockUploader, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = processor, uploader = null, defaultUploader = mockUploader, cacheDir = tempFolder.root)
 
         val boundary = "test-boundary-meta"
         val body = buildMultipartBody(boundary, "clip.mov", "video/quicktime", "movie".toByteArray())
@@ -271,7 +291,7 @@ class MediaUploadServerTest {
             body = body
         )
 
-        // The delegate changed the format, so the uploader must receive the new
+        // The processor changed the format, so the uploader must receive the new
         // metadata — not the original video/quicktime + clip.mov.
         assertTrue(mockUploader.uploadCalled)
         assertEquals("video/mp4", mockUploader.lastUploadMimeType)
@@ -279,11 +299,11 @@ class MediaUploadServerTest {
     }
 
     @Test
-    fun `deletes the delegate's processed file after upload`() {
-        val delegate = TranscodingDelegate()
+    fun `deletes the processor's processed file after upload`() {
+        val processor = TranscodingProcessor()
         val mockUploader = MockDefaultUploader()
         server.stop()
-        server = MediaUploadServer(uploadDelegate = delegate, defaultUploader = mockUploader, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = processor, uploader = null, defaultUploader = mockUploader, cacheDir = tempFolder.root)
 
         val boundary = "test-boundary-cleanup"
         val body = buildMultipartBody(boundary, "clip.mov", "video/quicktime", "movie".toByteArray())
@@ -298,10 +318,10 @@ class MediaUploadServerTest {
             body = body
         )
 
-        // The server owns the file the delegate produced and must delete it once the
+        // The server owns the file the processor produced and must delete it once the
         // upload finishes — the finally in processAndUpload covers success and throw
         // paths alike. A leaked processed file is a full-size temp per upload.
-        val processed = requireNotNull(delegate.producedFile) { "processFile was not called" }
+        val processed = requireNotNull(processor.producedFile) { "processFile was not called" }
         assertFalse("Processed temp file should be deleted after upload", processed.exists())
     }
 
@@ -321,7 +341,8 @@ class MediaUploadServerTest {
         // one — a flipped comparison would do the opposite and wipe an in-flight upload.
         server.stop()
         server = MediaUploadServer(
-            uploadDelegate = null,
+            processor = null,
+            uploader = null,
             defaultUploader = null,
             cacheDir = tempFolder.root,
             ioDispatcher = Dispatchers.Unconfined
@@ -334,12 +355,12 @@ class MediaUploadServerTest {
     // MARK: - Fallback to default uploader
 
     @Test
-    fun `uses passthrough when delegate does not modify file`() {
-        val delegate = ProcessOnlyDelegate()
+    fun `uses passthrough when the processor does not modify the file`() {
+        val processor = PassthroughProcessor()
         val mockUploader = MockDefaultUploader()
 
         server.stop()
-        server = MediaUploadServer(uploadDelegate = delegate, defaultUploader = mockUploader, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = processor, uploader = null, defaultUploader = mockUploader, cacheDir = tempFolder.root)
 
         val boundary = "test-boundary-456"
         val body = buildMultipartBody(boundary, "doc.pdf", "application/pdf", "fake pdf data".toByteArray())
@@ -355,7 +376,7 @@ class MediaUploadServerTest {
         )
 
         assertTrue("Expected 201 but got: ${response.statusLine}", response.statusLine.contains("201"))
-        assertTrue(delegate.processFileCalled)
+        assertTrue(processor.processFileCalled)
         // Passthrough: original body forwarded directly, not re-encoded.
         assertTrue(mockUploader.passthroughUploadCalled)
         assertFalse(mockUploader.uploadCalled)
@@ -365,12 +386,12 @@ class MediaUploadServerTest {
     }
 
     @Test
-    fun `skips processing and the temp copy when the delegate declines by metadata`() {
-        val delegate = DeclineByMetadataDelegate()
+    fun `skips processing and the temp copy when the processor declines by metadata`() {
+        val processor = DecliningProcessor()
         val mockUploader = MockDefaultUploader()
 
         server.stop()
-        server = MediaUploadServer(uploadDelegate = delegate, defaultUploader = mockUploader, cacheDir = tempFolder.root)
+        server = MediaUploadServer(processor = processor, uploader = null, defaultUploader = mockUploader, cacheDir = tempFolder.root)
 
         val boundary = "test-boundary-decline"
         val body = buildMultipartBody(boundary, "clip.mov", "video/quicktime", "fake movie".toByteArray())
@@ -386,9 +407,9 @@ class MediaUploadServerTest {
         )
 
         assertTrue("Expected 201 but got: ${response.statusLine}", response.statusLine.contains("201"))
-        // Declined by metadata → the delegate is never asked to process (so the
+        // Declined by metadata → the processor is never asked to process (so the
         // file was never materialized), and the upload is passed through directly.
-        assertFalse(delegate.processFileCalled)
+        assertFalse(processor.processFileCalled)
         assertTrue(mockUploader.passthroughUploadCalled)
         assertFalse(mockUploader.uploadCalled)
     }
@@ -773,54 +794,27 @@ class MediaUploadServerTest {
 
     // MARK: - Mocks
 
-    private class MockUploadDelegate : MediaUploadDelegate {
-        @Volatile var processFileCalled = false
-        @Volatile var uploadFileCalled = false
+    /**
+     * A host uploader: it performs the upload on its own stack. `upload` returns the
+     * finished attachment JSON (or throws).
+     */
+    private class MockUploader(
+        private val uploadBody: ByteArray =
+            """{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}""".toByteArray()
+    ) : MediaUploader {
+        @Volatile var uploadCalled = false
         @Volatile var lastMimeType: String? = null
         @Volatile var lastFilename: String? = null
 
-        override suspend fun processFile(file: File, mimeType: String, filename: String): ProcessedProxyFile {
-            processFileCalled = true
+        override suspend fun upload(file: File, mimeType: String, filename: String): ByteArray {
+            uploadCalled = true
             lastMimeType = mimeType
-            return ProcessedProxyFile.Original
-        }
-
-        override suspend fun uploadFile(file: File, mimeType: String, filename: String): MediaUploadResponse? {
-            uploadFileCalled = true
             lastFilename = filename
-            val json = """{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}"""
-            return MediaUploadResponse(201, json.toByteArray())
+            return uploadBody
         }
     }
 
-    /**
-     * A delegate that handles deletions itself, as a host uploading to its own
-     * media service would.
-     */
-    private class DeletingDelegate : MediaUploadDelegate {
-        @Volatile var deletedAttachmentId: String? = null
-
-        override suspend fun deleteFile(attachmentId: String): MediaUploadResponse? {
-            deletedAttachmentId = attachmentId
-            return MediaUploadResponse(200, """{"deleted":true}""".toByteArray())
-        }
-    }
-
-    /**
-     * A delegate that sets its own `Content-Type`, lowercased, so the relay must
-     * override the JSON default rather than emit the header twice.
-     */
-    private class ContentTypeDeletingDelegate : MediaUploadDelegate {
-        override suspend fun deleteFile(attachmentId: String): MediaUploadResponse? {
-            return MediaUploadResponse(
-                200,
-                "deleted".toByteArray(),
-                mapOf("content-type" to "text/plain")
-            )
-        }
-    }
-
-    private class ProcessOnlyDelegate : MediaUploadDelegate {
+    private class PassthroughProcessor : MediaProcessor {
         @Volatile var processFileCalled = false
 
         override suspend fun processFile(file: File, mimeType: String, filename: String): ProcessedProxyFile {
@@ -833,7 +827,7 @@ class MediaUploadServerTest {
      * Declines every file by metadata via [handlesFile], so the server must pass
      * through without materializing the file or calling [processFile].
      */
-    private class DeclineByMetadataDelegate : MediaUploadDelegate {
+    private class DecliningProcessor : MediaProcessor {
         @Volatile var processFileCalled = false
 
         override fun handlesFile(mimeType: String, filename: String): Boolean = false
@@ -844,9 +838,9 @@ class MediaUploadServerTest {
         }
     }
 
-    /** A delegate that produces a new file with changed metadata (e.g. a transcode). */
-    private class TranscodingDelegate : MediaUploadDelegate {
-        /** The processed file this delegate wrote, for cleanup assertions. */
+    /** A processor that produces a new file with changed metadata (e.g. a transcode). */
+    private class TranscodingProcessor : MediaProcessor {
+        /** The processed file this processor wrote, for cleanup assertions. */
         @Volatile var producedFile: File? = null
 
         override suspend fun processFile(file: File, mimeType: String, filename: String): ProcessedProxyFile {
@@ -857,7 +851,13 @@ class MediaUploadServerTest {
         }
     }
 
-    private class MockDefaultUploader : DefaultMediaUploader(
+    private class MockDefaultUploader(
+        /** The response `upload`/`passthroughUpload` return. Defaults to a 201 success. */
+        private val uploadResponse: MediaUploadResponse = MediaUploadResponse(
+            201,
+            """{"id":99,"source_url":"https://example.com/doc.pdf","media_type":"file"}""".toByteArray()
+        )
+    ) : DefaultMediaUploader(
         httpClient = okhttp3.OkHttpClient(),
         siteApiRoot = "https://example.com/wp-json/",
         authHeader = "Bearer mock"
@@ -867,6 +867,8 @@ class MediaUploadServerTest {
         @Volatile var lastUploadMimeType: String? = null
         @Volatile var lastUploadFilename: String? = null
         @Volatile var lastQuery: String? = null
+        @Volatile var deleteMediaCalled = false
+        @Volatile var deletedAttachmentId: String? = null
 
         override suspend fun upload(
             file: File, mimeType: String, filename: String,
@@ -876,7 +878,7 @@ class MediaUploadServerTest {
             lastUploadMimeType = mimeType
             lastUploadFilename = filename
             lastQuery = query
-            return mockResponse()
+            return uploadResponse
         }
 
         override suspend fun passthroughUpload(
@@ -886,13 +888,14 @@ class MediaUploadServerTest {
         ): MediaUploadResponse {
             passthroughUploadCalled = true
             lastQuery = query
-            return mockResponse()
+            return uploadResponse
         }
 
-        private fun mockResponse() = MediaUploadResponse(
-            201,
-            """{"id":99,"source_url":"https://example.com/doc.pdf","media_type":"file"}""".toByteArray()
-        )
+        override suspend fun deleteMedia(attachmentId: String, query: String): MediaUploadResponse {
+            deleteMediaCalled = true
+            deletedAttachmentId = attachmentId
+            return MediaUploadResponse(200, """{"deleted":true}""".toByteArray())
+        }
     }
 
 }

--- a/android/app/src/main/java/com/example/gutenbergkit/DemoMediaProcessor.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/DemoMediaProcessor.kt
@@ -5,19 +5,18 @@ import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.media.ExifInterface
 import android.util.Log
-import org.wordpress.gutenberg.MediaUploadDelegate
+import org.wordpress.gutenberg.MediaProcessor
 import org.wordpress.gutenberg.ProcessedProxyFile
 import java.io.File
 import java.io.IOException
 
 /**
- * Demo media upload delegate that resizes images to a maximum dimension of 2000px.
- *
- * Only overrides [processFile] — [uploadFile] returns null so the default uploader is used.
+ * Demo media processor that resizes images to a maximum dimension of 2000px, then
+ * lets GutenbergKit deliver the result to the configured site.
  */
-class DemoMediaUploadDelegate : MediaUploadDelegate {
+class DemoMediaProcessor : MediaProcessor {
     companion object {
-        private const val TAG = "DemoMediaUploadDelegate"
+        private const val TAG = "DemoMediaProcessor"
     }
 
     // Only non-GIF images are ever resized (see processFile), so decline

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -338,7 +338,7 @@ fun EditorScreen(
                         }
                     })
                     if (enableNativeMediaUpload) {
-                        mediaUploadDelegate = DemoMediaUploadDelegate()
+                        mediaProcessor = DemoMediaProcessor()
                     }
                     onGutenbergViewCreated(this)
                 }

--- a/bin/wp-env-media-failure.sh
+++ b/bin/wp-env-media-failure.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# wp-env-media-failure.sh — Read or set the media upload failure simulation mode.
+#
+# Drives the `gutenbergkit-media-failure` mu-plugin, which fatals during image
+# sub-size generation so the editor's post-process retry can be exercised
+# locally. See docs/code/local-wordpress.md.
+#
+# Usage:
+#   bash bin/wp-env-media-failure.sh                # Report the current mode
+#   MODE=recover bash bin/wp-env-media-failure.sh   # Fail once, then succeed
+#   MODE=always  bash bin/wp-env-media-failure.sh   # Fail every attempt
+#   MODE=off     bash bin/wp-env-media-failure.sh   # Normal uploads
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CREDENTIALS_FILE="$PROJECT_ROOT/.wp-env.credentials.json"
+
+# Addressed to localhost rather than the credentials file's siteUrl: after
+# `make wp-env-android` that URL points at 10.0.2.2, which only resolves inside
+# the emulator. The server is always reachable on localhost from the host.
+ENDPOINT="http://localhost:8888/wp-json/gutenbergkit/v1/media-failure"
+
+VALID_MODES="off recover always"
+MODE="${MODE:-}"
+
+# ---------------------------------------------------------------------------
+# Validate the requested mode before touching the network
+# ---------------------------------------------------------------------------
+
+if [ -n "$MODE" ]; then
+    case " $VALID_MODES " in
+        *" $MODE "*) ;;
+        *)
+            echo "Error: invalid MODE '$MODE'." >&2
+            echo "Valid modes: $VALID_MODES" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+
+if [ ! -f "$CREDENTIALS_FILE" ]; then
+    echo "Error: credentials not found at $CREDENTIALS_FILE" >&2
+    echo 'Run "make wp-env-start" to provision the local WordPress environment.' >&2
+    exit 1
+fi
+
+AUTH_HEADER=$(node -e "
+    const fs = require('fs');
+    try {
+        const c = JSON.parse(fs.readFileSync('$CREDENTIALS_FILE', 'utf8'));
+        if (!c.authHeader) process.exit(1);
+        process.stdout.write(c.authHeader);
+    } catch {
+        process.exit(1);
+    }
+") || {
+    echo "Error: could not read authHeader from $CREDENTIALS_FILE" >&2
+    echo 'The file may be malformed. Run "make wp-env-start RESET=1" to regenerate it.' >&2
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Request
+# ---------------------------------------------------------------------------
+
+if [ -n "$MODE" ]; then
+    METHOD="POST"
+    URL="$ENDPOINT?mode=$MODE"
+else
+    METHOD="GET"
+    URL="$ENDPOINT"
+fi
+
+# Separate the body from the status code so each failure can be reported with
+# the fix that actually applies to it.
+RESPONSE=$(curl -sS -X "$METHOD" -H "Authorization: $AUTH_HEADER" \
+    -w $'\n%{http_code}' "$URL" 2>/dev/null) || {
+    echo "Error: could not reach wp-env at $ENDPOINT" >&2
+    echo 'Run "make wp-env-start" to start the local WordPress environment.' >&2
+    exit 1
+}
+
+STATUS="${RESPONSE##*$'\n'}"
+BODY="${RESPONSE%$'\n'*}"
+
+case "$STATUS" in
+    200) ;;
+    401|403)
+        echo "Error: credentials were rejected (HTTP $STATUS)." >&2
+        echo 'They are likely stale. Run "make wp-env-start RESET=1" to regenerate them.' >&2
+        exit 1
+        ;;
+    404)
+        echo "Error: the media-failure endpoint is not registered (HTTP 404)." >&2
+        echo 'Check that wp-env/mu-plugins/gutenbergkit-media-failure.php exists,' >&2
+        echo 'then restart with "make wp-env-start".' >&2
+        exit 1
+        ;;
+    *)
+        echo "Error: unexpected response (HTTP $STATUS) from $ENDPOINT" >&2
+        echo "$BODY" >&2
+        exit 1
+        ;;
+esac
+
+CURRENT=$(echo "$BODY" | node -e "
+    let input = '';
+    process.stdin.on('data', (chunk) => { input += chunk; });
+    process.stdin.on('end', () => {
+        try {
+            process.stdout.write(JSON.parse(input).mode ?? 'unknown');
+        } catch {
+            process.stdout.write('unknown');
+        }
+    });
+")
+
+if [ -n "$MODE" ]; then
+    echo "Media upload failure mode set to: $CURRENT"
+else
+    echo "Media upload failure mode: $CURRENT"
+fi
+
+case "$CURRENT" in
+    recover)
+        echo "Uploads fail once per attachment, then succeed on the post-process retry."
+        ;;
+    always)
+        echo "Uploads fail every attempt, exhausting all five retries before the orphan is deleted."
+        ;;
+esac

--- a/bin/wp-env-media-failure.sh
+++ b/bin/wp-env-media-failure.sh
@@ -51,16 +51,19 @@ if [ ! -f "$CREDENTIALS_FILE" ]; then
     exit 1
 fi
 
-AUTH_HEADER=$(node -e "
-    const fs = require('fs');
+# The path arrives as an argument rather than interpolated into the source: a
+# checkout under a path containing a quote or backslash would otherwise produce
+# a syntax error instead of the failure message below.
+AUTH_HEADER=$(node -e '
+    const fs = require("fs");
     try {
-        const c = JSON.parse(fs.readFileSync('$CREDENTIALS_FILE', 'utf8'));
+        const c = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
         if (!c.authHeader) process.exit(1);
         process.stdout.write(c.authHeader);
     } catch {
         process.exit(1);
     }
-") || {
+' "$CREDENTIALS_FILE") || {
     echo "Error: could not read authHeader from $CREDENTIALS_FILE" >&2
     echo 'The file may be malformed. Run "make wp-env-start RESET=1" to regenerate it.' >&2
     exit 1

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -129,12 +129,6 @@ The mode is stored server-side, so it persists across uploads and retries until 
 
 Then upload an image from a demo app and watch the network requests. In `recover` mode the upload 500s and the following `post-process` call succeeds, leaving a complete attachment; in `always` mode you should see five `post-process` attempts followed by a `DELETE`.
 
-The mode is stored as an option rather than per-request state, because the upload and each retry are separate requests — and an upload routed through the native upload server is relayed by URLSession/OkHttp, which carries no browser cookie.
-
-**Note:** the plugin sets the 500 status itself. A real PHP fatal under FPM surfaces as a 500, but the Playground runtime wp-env uses returns 200, which the editor's `status >= 500` check would ignore.
-
-**Note:** a simulated fatal aborts the request before WordPress adds CORS headers, so a cross-origin editor reports these responses as CORS errors with provisional request headers rather than as a readable 500. That is expected for the upload and `post-process` responses — the editor only needs their status and the attachment ID header. It is why the plugin never fails a `DELETE`, including the `POST` + `X-Http-Method-Override: DELETE` form api-fetch actually sends: failing the orphan cleanup would make a correctly working retry look broken.
-
 **Only the native upload server path recovers locally.** Reading `X-WP-Upload-Attachment-ID` cross-origin requires the site to list it in `Access-Control-Expose-Headers`, and WordPress core's `rest_send_cors_headers()` does not. Uploads routed through the native upload server recover on both platforms, since that server exposes the header itself.
 
 A **direct** upload (native media upload disabled) never recovers on iOS, which loads the editor from `file://`. It does not recover against wp-env on Android either: `GutenbergView` derives the asset domain from the site's _host_, which drops the port, so the editor at `http://10.0.2.2` is cross-origin with the site at `http://10.0.2.2:8888`. Direct uploads are only same-origin — and therefore only recover — when the site runs on the scheme's default port, as production sites do.
@@ -160,21 +154,6 @@ Another service is using port 8888. Stop the conflicting service or change the w
 {
 	"port": 9999
 }
-```
-
-Under the Playground runtime the culprit is often a previous wp-env server that outlived `make wp-env-stop`, which then makes every subsequent start fail with `EADDRINUSE`:
-
-```bash
-lsof -ti:8888              # confirm what holds the port
-pkill -f "wp-playground.js"
-```
-
-### Credentials rejected with HTTP 401
-
-The Playground runtime starts from a fresh database on each start, so an existing `.wp-env.credentials.json` no longer matches the site's application password. Regenerate it:
-
-```bash
-make wp-env-start RESET=1
 ```
 
 ### Resetting the environment

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -133,6 +133,8 @@ The mode is stored as an option rather than per-request state, because the uploa
 
 **Note:** the plugin sets the 500 status itself. A real PHP fatal under FPM surfaces as a 500, but the Playground runtime wp-env uses returns 200, which the editor's `status >= 500` check would ignore.
 
+**Note:** a simulated fatal aborts the request before WordPress adds CORS headers, so a cross-origin editor reports these responses as CORS errors with provisional request headers rather than as a readable 500. That is expected for the upload and `post-process` responses — the editor only needs their status and the attachment ID header. It is why the plugin never fails a `DELETE`, including the `POST` + `X-Http-Method-Override: DELETE` form api-fetch actually sends: failing the orphan cleanup would make a correctly working retry look broken.
+
 **Only the native upload server path recovers locally.** Reading `X-WP-Upload-Attachment-ID` cross-origin requires the site to list it in `Access-Control-Expose-Headers`, and WordPress core's `rest_send_cors_headers()` does not. Uploads routed through the native upload server recover on both platforms, since that server exposes the header itself.
 
 A **direct** upload (native media upload disabled) never recovers on iOS, which loads the editor from `file://`. It does not recover against wp-env on Android either: `GutenbergView` derives the asset domain from the site's _host_, which drops the port, so the editor at `http://10.0.2.2` is cross-origin with the site at `http://10.0.2.2:8888`. Direct uploads are only same-origin — and therefore only recover — when the site runs on the scheme's default port, as production sites do.

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -43,6 +43,7 @@ The `.wp-env.json` file at the project root configures the environment:
 -   **Gutenberg plugin** is installed for the `/wp-block-editor/v1/settings` editor settings REST API endpoint.
 -   **Jetpack plugin** is installed with the blocks module auto-activated via a mu-plugin (`wp-env/mu-plugins/gutenbergkit-jetpack-blocks.php`), providing the `/wpcom/v2/editor-assets` endpoint and additional editor blocks.
 -   A **CORS mu-plugin** (`wp-env/mu-plugins/gutenbergkit-cors.php`) adds CORS headers to REST API responses, allowing requests from the Vite dev server, preview server, and native WebViews.
+-   A **media failure mu-plugin** (`wp-env/mu-plugins/gutenbergkit-media-failure.php`) can simulate a server-side image processing fatal on demand. Inactive by default — see [Simulating media upload failures](#simulating-media-upload-failures).
 -   **WP_DEBUG** and **WP_DEBUG_LOG** are enabled for development.
 
 ### Credential Provisioning
@@ -103,6 +104,36 @@ Physical devices cannot reach `localhost`. You'll need to:
 1. Find your machine's local IP address (e.g., `192.168.1.100`).
 2. Update the CORS mu-plugin to allow your IP.
 3. Manually create or edit `.wp-env.credentials.json` with the correct IP-based URLs.
+
+## Simulating Media Upload Failures
+
+When `wp_generate_attachment_metadata()` fatals server-side — commonly a PHP `memory_limit` or `max_execution_time` fatal on a large image — WordPress has already created the attachment row and sent an `X-WP-Upload-Attachment-ID` header. The editor reads that header off the resulting 5xx and retries `POST /wp/v2/media/<id>/post-process` up to five times, deleting the orphaned attachment if every attempt fails.
+
+`gutenbergkit-media-failure.php` reproduces that failure on demand so the retry can be exercised without a large image or a resource-starved host. Set the mode over the REST API (the `authHeader` value is in `.wp-env.credentials.json`):
+
+```bash
+AUTH=$(python3 -c "import json;print(json.load(open('.wp-env.credentials.json'))['authHeader'])")
+
+# Fail once per attachment, then succeed: the retry recovers the upload.
+curl -s -X POST -H "Authorization: $AUTH" \
+  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=recover'
+
+# Fail every time: exhausts all five retries, then the orphan is deleted.
+curl -s -X POST -H "Authorization: $AUTH" \
+  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=always'
+
+# Restore normal uploads.
+curl -s -X POST -H "Authorization: $AUTH" \
+  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=off'
+```
+
+Then upload an image from a demo app and watch the network requests. In `recover` mode the upload 500s and the following `post-process` call succeeds, leaving a complete attachment; in `always` mode you should see five `post-process` attempts followed by a `DELETE`.
+
+The mode is stored as an option rather than per-request state, because the upload and each retry are separate requests — and an upload routed through the native upload server is relayed by URLSession/OkHttp, which carries no browser cookie.
+
+**Note:** the plugin sets the 500 status itself. A real PHP fatal under FPM surfaces as a 500, but the Playground runtime wp-env uses returns 200, which the editor's `status >= 500` check would ignore.
+
+**Direct uploads on iOS cannot recover, by design of the platform rather than a bug here.** Reading `X-WP-Upload-Attachment-ID` cross-origin requires the site to list it in `Access-Control-Expose-Headers`, and WordPress core's `rest_send_cors_headers()` does not. Uploads routed through the native upload server recover on both platforms, since that server exposes the header itself. Android also recovers on direct uploads, because its editor is served from the site's own host and is therefore same-origin. Do not "fix" this by adding the header to the CORS mu-plugin — that would make local testing diverge from production.
 
 ## WordPress Admin
 

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -133,7 +133,9 @@ The mode is stored as an option rather than per-request state, because the uploa
 
 **Note:** the plugin sets the 500 status itself. A real PHP fatal under FPM surfaces as a 500, but the Playground runtime wp-env uses returns 200, which the editor's `status >= 500` check would ignore.
 
-**Direct uploads on iOS cannot recover, by design of the platform rather than a bug here.** Reading `X-WP-Upload-Attachment-ID` cross-origin requires the site to list it in `Access-Control-Expose-Headers`, and WordPress core's `rest_send_cors_headers()` does not. Uploads routed through the native upload server recover on both platforms, since that server exposes the header itself. Android also recovers on direct uploads, because its editor is served from the site's own host and is therefore same-origin. Do not "fix" this by adding the header to the CORS mu-plugin — that would make local testing diverge from production.
+**Only the native upload server path recovers locally.** Reading `X-WP-Upload-Attachment-ID` cross-origin requires the site to list it in `Access-Control-Expose-Headers`, and WordPress core's `rest_send_cors_headers()` does not. Uploads routed through the native upload server recover on both platforms, since that server exposes the header itself.
+
+A **direct** upload (native media upload disabled) never recovers on iOS, which loads the editor from `file://`. It does not recover against wp-env on Android either: `GutenbergView` derives the asset domain from the site's _host_, which drops the port, so the editor at `http://10.0.2.2` is cross-origin with the site at `http://10.0.2.2:8888`. Direct uploads are only same-origin — and therefore only recover — when the site runs on the scheme's default port, as production sites do.
 
 ## WordPress Admin
 

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -109,23 +109,23 @@ Physical devices cannot reach `localhost`. You'll need to:
 
 When `wp_generate_attachment_metadata()` fatals server-side — commonly a PHP `memory_limit` or `max_execution_time` fatal on a large image — WordPress has already created the attachment row and sent an `X-WP-Upload-Attachment-ID` header. The editor reads that header off the resulting 5xx and retries `POST /wp/v2/media/<id>/post-process` up to five times, deleting the orphaned attachment if every attempt fails.
 
-`gutenbergkit-media-failure.php` reproduces that failure on demand so the retry can be exercised without a large image or a resource-starved host. Set the mode over the REST API (the `authHeader` value is in `.wp-env.credentials.json`):
+`gutenbergkit-media-failure.php` reproduces that failure on demand so the retry can be exercised without a large image or a resource-starved host:
 
 ```bash
-AUTH=$(python3 -c "import json;print(json.load(open('.wp-env.credentials.json'))['authHeader'])")
+# Report the current mode.
+make wp-env-media-failure
 
 # Fail once per attachment, then succeed: the retry recovers the upload.
-curl -s -X POST -H "Authorization: $AUTH" \
-  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=recover'
+make wp-env-media-failure MODE=recover
 
 # Fail every time: exhausts all five retries, then the orphan is deleted.
-curl -s -X POST -H "Authorization: $AUTH" \
-  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=always'
+make wp-env-media-failure MODE=always
 
 # Restore normal uploads.
-curl -s -X POST -H "Authorization: $AUTH" \
-  'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=off'
+make wp-env-media-failure MODE=off
 ```
+
+The mode is stored server-side, so it persists across uploads and retries until changed. It does not survive restarting wp-env — the Playground runtime starts from a fresh database, so the mode returns to `off` (and credentials need `make wp-env-start RESET=1`).
 
 Then upload an image from a demo app and watch the network requests. In `recover` mode the upload 500s and the following `post-process` call succeeds, leaving a complete attachment; in `always` mode you should see five `post-process` attempts followed by a `DELETE`.
 
@@ -156,6 +156,21 @@ Another service is using port 8888. Stop the conflicting service or change the w
 {
 	"port": 9999
 }
+```
+
+Under the Playground runtime the culprit is often a previous wp-env server that outlived `make wp-env-stop`, which then makes every subsequent start fail with `EADDRINUSE`:
+
+```bash
+lsof -ti:8888              # confirm what holds the port
+pkill -f "wp-playground.js"
+```
+
+### Credentials rejected with HTTP 401
+
+The Playground runtime starts from a fresh database on each start, so an existing `.wp-env.credentials.json` no longer matches the site's application password. Regenerate it:
+
+```bash
+make wp-env-start RESET=1
 ```
 
 ### Resetting the environment

--- a/ios/Demo-iOS/Sources/Views/EditorView.swift
+++ b/ios/Demo-iOS/Sources/Views/EditorView.swift
@@ -136,7 +136,7 @@ private struct _EditorView: UIViewControllerRepresentable {
         let viewController = EditorViewController(configuration: configuration, dependencies: dependencies)
         viewController.delegate = context.coordinator
         if enableNativeMediaUpload {
-            viewController.mediaUploadDelegate = context.coordinator
+            viewController.mediaProcessor = context.coordinator
         }
         viewController.webView.isInspectable = true
 
@@ -189,7 +189,7 @@ private struct _EditorView: UIViewControllerRepresentable {
     }
 
     @MainActor
-    class Coordinator: NSObject, EditorViewControllerDelegate, MediaUploadDelegate {
+    class Coordinator: NSObject, EditorViewControllerDelegate, MediaProcessor {
         let viewModel: EditorViewModel
 
         init(viewModel: EditorViewModel) {
@@ -295,11 +295,11 @@ private struct _EditorView: UIViewControllerRepresentable {
             return nil
         }
 
-        // MARK: - MediaUploadDelegate
+        // MARK: - MediaProcessor
 
         /// Only non-GIF images are ever resized (see `processFile`), so decline
         /// everything else by metadata — the server then skips copying a file
-        /// this delegate would only pass through.
+        /// this processor would only pass through.
         nonisolated func handlesFile(ofType mimeType: String, named _: String) -> Bool {
             mimeType.hasPrefix("image/") && mimeType != "image/gif"
         }

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -470,10 +470,13 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         // An InternalMediaClient does two jobs: it delivers GutenbergKit-owned
         // uploads (when no `mediaUploader` is set), and it relays the editor's media
         // DELETEs to the configured site — every attachment lives there, even one a
-        // host uploader delivered, so that's where its deletion goes. It needs an auth
-        // header (the editor injects it because the WebView has no auth cookies).
+        // host uploader delivered, so that's where its deletion goes. It needs both a
+        // site API root to address and an auth header (the editor injects the latter
+        // because the WebView has no auth cookies); with either missing, every media
+        // request it makes fails.
         //
-        // Without one there's no internal media client, so the behavior forks by intent:
+        // Without them there's no usable internal media client, so the behavior forks
+        // by intent:
         //
         // - A `mediaProcessor` only enhances GutenbergKit-owned uploads. With no
         //   credentials there's nothing to deliver through, so nothing to process —
@@ -483,13 +486,20 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         //   would silently drop it, and its media deletes still need the default
         //   uploader to reach the configured site. A host that sets an uploader must
         //   provide credentials too; omitting them is a configuration error, so trap
-        //   rather than start a server whose every delete would 500.
-        if configuration.authHeader.isEmpty {
+        //   rather than start a server whose every delete would fail.
+        //
+        // `siteApiRoot` is a `URL` here where Android types it as a `String`, so the
+        // equivalent of Android's `isEmpty()` check is "not absolute" — a URL with no
+        // scheme or host can't address the site, and every request built from it fails
+        // at the URLSession layer.
+        let siteApiRootIsUsable = configuration.siteApiRoot.scheme != nil
+            && configuration.siteApiRoot.host() != nil
+        if !siteApiRootIsUsable || configuration.authHeader.isEmpty {
             precondition(
                 mediaUploader == nil,
                 "A mediaUploader needs site credentials so GutenbergKit can relay the "
-                    + "editor's media deletes to the configured site. Set the auth header "
-                    + "in the editor configuration."
+                    + "editor's media deletes to the configured site. Set an absolute "
+                    + "siteApiRoot and the auth header in the editor configuration."
             )
             return
         }

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -109,12 +109,6 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     /// longer take effect, so their setters trap if written.
     private var hasStartedLoading = false
 
-    /// Whether a non-nil ``mediaProcessor``/``mediaUploader`` was ever assigned. Lets
-    /// the load path tell "the host object was released before load" (a retention
-    /// mistake to trap) apart from "none was configured" (a valid opt-out).
-    private var mediaProcessorWasAssigned = false
-    private var mediaUploaderWasAssigned = false
-
     /// Transforms media (resize, transcode, …) before GutenbergKit delivers it to
     /// the configured site. The safe, common extension point — a processor never
     /// performs the upload itself, so it cannot deliver media to the wrong place.
@@ -123,13 +117,12 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     /// is captured once, when the editor begins loading; setting it afterward has no
     /// effect, so the setter traps.
     ///
-    /// - Important: This is a `weak` reference — hold a strong reference to your
-    ///   processor until the editor has loaded, or native media handling is silently
-    ///   disabled. The editor traps at load time if a processor assigned here has
-    ///   already been deallocated.
-    public weak var mediaProcessor: (any MediaProcessor)? {
+    /// The editor **owns** this for its lifetime and releases it on `deinit`, so you
+    /// don't need to keep a reference after assigning it. The one rule: your processor
+    /// must not strongly retain this `EditorViewController` in return, or the two form
+    /// a retain cycle and neither is freed.
+    public var mediaProcessor: (any MediaProcessor)? {
         didSet {
-            mediaProcessorWasAssigned = mediaProcessor != nil
             precondition(!hasStartedLoading, Self.lateMediaAssignmentMessage("mediaProcessor"))
         }
     }
@@ -138,11 +131,16 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     /// queue, resumable transport). Setting it makes the host own every upload and
     /// its whole lifecycle; GutenbergKit stays out of the network entirely for media.
     ///
-    /// Same lifecycle rules as ``mediaProcessor``: set it before the editor loads,
-    /// and hold a strong reference until then.
-    public weak var mediaUploader: (any MediaUploader)? {
+    /// Same lifecycle rules as ``mediaProcessor``: set it before the editor loads.
+    /// The editor owns it for its lifetime (releasing it on `deinit`), so you needn't
+    /// retain it yourself — just don't strongly retain this `EditorViewController`
+    /// from your uploader.
+    ///
+    /// Requires site credentials in the editor configuration: media deletes always
+    /// relay to the configured site, so an uploader set without an auth header is a
+    /// configuration error and traps at load.
+    public var mediaUploader: (any MediaUploader)? {
         didSet {
-            mediaUploaderWasAssigned = mediaUploader != nil
             precondition(!hasStartedLoading, Self.lateMediaAssignmentMessage("mediaUploader"))
         }
     }
@@ -394,8 +392,8 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     ///
     @MainActor
     private func loadEditor(dependencies: EditorDependencies) async throws {
-        // From here on the editor configuration — including `mediaUploadDelegate` —
-        // is captured, so the delegate setter traps if written after this point.
+        // From here on the editor configuration — including `mediaProcessor` and
+        // `mediaUploader` — is captured, so their setters trap if written after this point.
         self.hasStartedLoading = true
 
         self.displayActivityView()
@@ -461,52 +459,52 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     /// falls back to Gutenberg's default upload behavior (the JS override won't activate
     /// because `nativeUploadPort` will be nil in GBKit).
     private func startUploadServer() async {
-        // A processor/uploader that was provided but is already nil here was
-        // deallocated before the editor finished loading — the host didn't hold a
-        // strong reference. That silently disables native media handling, so trap.
-        precondition(
-            !(mediaProcessorWasAssigned && mediaProcessor == nil),
-            "mediaProcessor was released before the editor loaded — hold a strong reference to it."
-        )
-        precondition(
-            !(mediaUploaderWasAssigned && mediaUploader == nil),
-            "mediaUploader was released before the editor loaded — hold a strong reference to it."
-        )
-
         // Nothing to route through the native server unless the host provided a
-        // processor or an uploader.
+        // processor or an uploader. The editor owns whichever it was given — its
+        // `mediaProcessor`/`mediaUploader` are strong — so there's no
+        // released-before-load case to guard against; they live as long as it does.
         guard mediaProcessor != nil || mediaUploader != nil else {
             return
         }
 
-        // A DefaultMediaUploader does two jobs: it delivers GutenbergKit-owned
+        // An InternalMediaClient does two jobs: it delivers GutenbergKit-owned
         // uploads (when no `mediaUploader` is set), and it relays the editor's media
         // DELETEs to the configured site — every attachment lives there, even one a
-        // host uploader delivered, so that's where its deletion goes. It needs a site
-        // root and an auth header (every host provides one — the editor injects it
-        // because the WebView has no auth cookies).
+        // host uploader delivered, so that's where its deletion goes. It needs an auth
+        // header (the editor injects it because the WebView has no auth cookies).
         //
-        // If GutenbergKit would have to deliver uploads itself but has no auth
-        // header, there's nothing to upload through: leave the server down and let
-        // uploads fall to the default WebView path rather than start a server that
-        // could only fail.
-        if mediaUploader == nil && configuration.authHeader.isEmpty {
+        // Without one there's no internal media client, so the behavior forks by intent:
+        //
+        // - A `mediaProcessor` only enhances GutenbergKit-owned uploads. With no
+        //   credentials there's nothing to deliver through, so nothing to process —
+        //   leave the server down and let uploads fall to the default WebView path.
+        //
+        // - A `mediaUploader` means the host is *taking over* uploads. Falling back
+        //   would silently drop it, and its media deletes still need the default
+        //   uploader to reach the configured site. A host that sets an uploader must
+        //   provide credentials too; omitting them is a configuration error, so trap
+        //   rather than start a server whose every delete would 500.
+        if configuration.authHeader.isEmpty {
+            precondition(
+                mediaUploader == nil,
+                "A mediaUploader needs site credentials so GutenbergKit can relay the "
+                    + "editor's media deletes to the configured site. Set the auth header "
+                    + "in the editor configuration."
+            )
             return
         }
-        var defaultUploader: DefaultMediaUploader?
-        if !configuration.authHeader.isEmpty {
-            defaultUploader = DefaultMediaUploader(
-                httpClient: httpClient.uploadClient(),
-                siteApiRoot: configuration.siteApiRoot,
-                siteApiNamespace: configuration.siteApiNamespace
-            )
-        }
+
+        let internalClient = InternalMediaClient(
+            httpClient: httpClient.uploadClient(),
+            siteApiRoot: configuration.siteApiRoot,
+            siteApiNamespace: configuration.siteApiNamespace
+        )
 
         do {
             self.uploadServer = try await MediaUploadServer.start(
                 processor: mediaProcessor,
                 uploader: mediaUploader,
-                defaultUploader: defaultUploader
+                internalClient: internalClient
             )
         } catch {
             Logger.uploadServer.error("Failed to start upload server: \(error). Falling back to default upload behavior.")

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -105,50 +105,60 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     private let isWarmupMode: Bool
 
     /// Set once the editor has begun loading and captured its configuration
-    /// (including ``mediaUploadDelegate``). After this, that delegate can no longer
-    /// take effect, so its setter traps if written.
+    /// (including ``mediaProcessor`` and ``mediaUploader``). After this, they can no
+    /// longer take effect, so their setters trap if written.
     private var hasStartedLoading = false
 
-    /// Whether a non-nil ``mediaUploadDelegate`` was ever assigned. Lets the load
-    /// path tell "the delegate was released before load" (a retention mistake to
-    /// trap) apart from "no delegate was configured" (a valid opt-out).
-    private var mediaUploadDelegateWasAssigned = false
+    /// Whether a non-nil ``mediaProcessor``/``mediaUploader`` was ever assigned. Lets
+    /// the load path tell "the host object was released before load" (a retention
+    /// mistake to trap) apart from "none was configured" (a valid opt-out).
+    private var mediaProcessorWasAssigned = false
+    private var mediaUploaderWasAssigned = false
 
-    /// Delegate for customizing media file processing and upload behavior.
+    /// Transforms media (resize, transcode, …) before GutenbergKit delivers it to
+    /// the configured site. The safe, common extension point — a processor never
+    /// performs the upload itself, so it cannot deliver media to the wrong place.
     ///
-    /// Provide this **before the editor loads** — typically right after `init`, the
-    /// same way the rest of the editor configuration is supplied. It is captured
-    /// once, when the editor begins loading, and injected into the page's initial
-    /// configuration; setting it afterward has no effect, so the setter traps.
+    /// Provide this **before the editor loads** — typically right after `init`. It
+    /// is captured once, when the editor begins loading; setting it afterward has no
+    /// effect, so the setter traps.
     ///
-    /// - Important: This is a `weak` reference — you must hold a strong reference to
-    ///   your delegate until the editor has loaded, or native uploads are silently
-    ///   disabled. To surface that mistake, the editor traps at load time if a
-    ///   delegate that was assigned here has already been deallocated.
-    public weak var mediaUploadDelegate: (any MediaUploadDelegate)? {
+    /// - Important: This is a `weak` reference — hold a strong reference to your
+    ///   processor until the editor has loaded, or native media handling is silently
+    ///   disabled. The editor traps at load time if a processor assigned here has
+    ///   already been deallocated.
+    public weak var mediaProcessor: (any MediaProcessor)? {
         didSet {
-            // Record whether a delegate was provided so the load path can tell a
-            // premature deallocation apart from a deliberate opt-out (see
-            // `startUploadServer`).
-            mediaUploadDelegateWasAssigned = mediaUploadDelegate != nil
-            // Deliberate fail-fast, not a defensive check. The delegate is captured
-            // into the page's initial configuration when the editor begins loading,
-            // so a delegate assigned afterward would silently never take effect;
-            // trapping surfaces that misuse loudly instead of failing quietly.
-            //
-            // `hasStartedLoading` flips at the start of the async load (see
-            // `loadEditor`), which runs at or after `viewDidLoad` — so this only
-            // *widens* the safe window versus a synchronous flip. A host that
-            // follows the documented contract (set right after `init`, before
-            // presenting) can never race it; the trap fires only on a genuinely
-            // late assignment. Do not soften this to a no-op or a log — silently
-            // dropping the delegate is exactly the failure this is here to catch.
-            precondition(
-                !hasStartedLoading,
-                "mediaUploadDelegate must be set before the editor loads (e.g. right after init). "
-                    + "It is captured into the editor configuration at load; setting it afterward has no effect."
-            )
+            mediaProcessorWasAssigned = mediaProcessor != nil
+            precondition(!hasStartedLoading, Self.lateMediaAssignmentMessage("mediaProcessor"))
         }
+    }
+
+    /// Takes over media upload on the host's own stack (background session, offline
+    /// queue, resumable transport). Setting it makes the host own every upload and
+    /// its whole lifecycle; GutenbergKit stays out of the network entirely for media.
+    ///
+    /// Same lifecycle rules as ``mediaProcessor``: set it before the editor loads,
+    /// and hold a strong reference until then.
+    public weak var mediaUploader: (any MediaUploader)? {
+        didSet {
+            mediaUploaderWasAssigned = mediaUploader != nil
+            precondition(!hasStartedLoading, Self.lateMediaAssignmentMessage("mediaUploader"))
+        }
+    }
+
+    /// Message for the fail-fast when media handling is assigned too late.
+    ///
+    /// Deliberate fail-fast, not a defensive check: the processor/uploader is
+    /// captured into the page's initial configuration when the editor begins
+    /// loading, so one assigned afterward would silently never take effect.
+    /// `hasStartedLoading` flips at the start of the async load, which runs at or
+    /// after `viewDidLoad`, so a host that follows the contract (set right after
+    /// `init`) can never race it. Do not soften this to a no-op or a log — silently
+    /// dropping the host's media handling is exactly the failure this catches.
+    private static func lateMediaAssignmentMessage(_ name: String) -> String {
+        "\(name) must be set before the editor loads (e.g. right after init). "
+            + "It is captured into the editor configuration at load; setting it afterward has no effect."
     }
 
     // MARK: - Private Properties (Services)
@@ -451,36 +461,51 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
     /// falls back to Gutenberg's default upload behavior (the JS override won't activate
     /// because `nativeUploadPort` will be nil in GBKit).
     private func startUploadServer() async {
-        // A delegate that was provided but is already nil here was deallocated before
-        // the editor finished loading — the host didn't hold a strong reference to it.
-        // That silently disables native uploads, so trap loudly instead.
+        // A processor/uploader that was provided but is already nil here was
+        // deallocated before the editor finished loading — the host didn't hold a
+        // strong reference. That silently disables native media handling, so trap.
         precondition(
-            !(mediaUploadDelegateWasAssigned && mediaUploadDelegate == nil),
-            "mediaUploadDelegate was released before the editor loaded — hold a strong reference to it."
+            !(mediaProcessorWasAssigned && mediaProcessor == nil),
+            "mediaProcessor was released before the editor loaded — hold a strong reference to it."
+        )
+        precondition(
+            !(mediaUploaderWasAssigned && mediaUploader == nil),
+            "mediaUploader was released before the editor loaded — hold a strong reference to it."
         )
 
-        guard mediaUploadDelegate != nil else {
+        // Nothing to route through the native server unless the host provided a
+        // processor or an uploader.
+        guard mediaProcessor != nil || mediaUploader != nil else {
             return
         }
 
-        // The native upload server relays through DefaultMediaUploader, which needs a
-        // site root and an auth header (every host provides one — the editor injects
-        // it because the WebView has no auth cookies). Without both there is nothing
-        // to upload through, so leave the server down and let uploads fall to the
-        // default WebView path rather than start a server that could only fail.
-        guard !configuration.authHeader.isEmpty else {
+        // A DefaultMediaUploader does two jobs: it delivers GutenbergKit-owned
+        // uploads (when no `mediaUploader` is set), and it relays the editor's media
+        // DELETEs to the configured site — every attachment lives there, even one a
+        // host uploader delivered, so that's where its deletion goes. It needs a site
+        // root and an auth header (every host provides one — the editor injects it
+        // because the WebView has no auth cookies).
+        //
+        // If GutenbergKit would have to deliver uploads itself but has no auth
+        // header, there's nothing to upload through: leave the server down and let
+        // uploads fall to the default WebView path rather than start a server that
+        // could only fail.
+        if mediaUploader == nil && configuration.authHeader.isEmpty {
             return
         }
-
-        let defaultUploader = DefaultMediaUploader(
-            httpClient: httpClient.uploadClient(),
-            siteApiRoot: configuration.siteApiRoot,
-            siteApiNamespace: configuration.siteApiNamespace
-        )
+        var defaultUploader: DefaultMediaUploader?
+        if !configuration.authHeader.isEmpty {
+            defaultUploader = DefaultMediaUploader(
+                httpClient: httpClient.uploadClient(),
+                siteApiRoot: configuration.siteApiRoot,
+                siteApiNamespace: configuration.siteApiNamespace
+            )
+        }
 
         do {
             self.uploadServer = try await MediaUploadServer.start(
-                uploadDelegate: mediaUploadDelegate,
+                processor: mediaProcessor,
+                uploader: mediaUploader,
                 defaultUploader: defaultUploader
             )
         } catch {

--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -475,32 +475,13 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         // because the WebView has no auth cookies); with either missing, every media
         // request it makes fails.
         //
-        // Without them there's no usable internal media client, so the behavior forks
-        // by intent:
-        //
-        // - A `mediaProcessor` only enhances GutenbergKit-owned uploads. With no
-        //   credentials there's nothing to deliver through, so nothing to process —
-        //   leave the server down and let uploads fall to the default WebView path.
-        //
-        // - A `mediaUploader` means the host is *taking over* uploads. Falling back
-        //   would silently drop it, and its media deletes still need the default
-        //   uploader to reach the configured site. A host that sets an uploader must
-        //   provide credentials too; omitting them is a configuration error, so trap
-        //   rather than start a server whose every delete would fail.
-        //
-        // `siteApiRoot` is a `URL` here where Android types it as a `String`, so the
-        // equivalent of Android's `isEmpty()` check is "not absolute" — a URL with no
-        // scheme or host can't address the site, and every request built from it fails
-        // at the URLSession layer.
-        let siteApiRootIsUsable = configuration.siteApiRoot.scheme != nil
-            && configuration.siteApiRoot.host() != nil
-        if !siteApiRootIsUsable || configuration.authHeader.isEmpty {
-            precondition(
-                mediaUploader == nil,
-                "A mediaUploader needs site credentials so GutenbergKit can relay the "
-                    + "editor's media deletes to the configured site. Set an absolute "
-                    + "siteApiRoot and the auth header in the editor configuration."
-            )
+        // `MediaServerCredentials` owns that check and the fail-fast behind it, so the
+        // policy is reachable from the host test suite — this file is not.
+        guard MediaServerCredentials.canStartServer(
+            siteApiRoot: configuration.siteApiRoot,
+            authHeader: configuration.authHeader,
+            hasUploader: mediaUploader != nil
+        ) else {
             return
         }
 

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaHandlers.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaHandlers.swift
@@ -74,6 +74,25 @@ public protocol MediaProcessor: AnyObject, Sendable {
     func processFile(at url: URL, mimeType: String, filename: String) async throws -> ProcessedProxyFile
 }
 
+/// One of the editor's non-file form fields, as sent with a media upload.
+///
+/// A named type rather than a `(name, value)` tuple: tuples are not nominal, so a
+/// tuple-typed property would permanently block `Equatable`/`Hashable`/`Codable`
+/// synthesis on ``MediaUpload`` — including inside GutenbergKit, and not fixable
+/// later without a source break for every host.
+public struct MediaUploadField: Sendable, Hashable, Codable {
+    /// The field name, e.g. `post`. Not unique — a `field[]` array repeats it.
+    public let name: String
+
+    /// The field's value, decoded as UTF-8.
+    public let value: String
+
+    public init(name: String, value: String) {
+        self.name = name
+        self.value = value
+    }
+}
+
 /// Everything a ``MediaUploader`` needs to reproduce a native upload: the file to
 /// send, its metadata, the editor's non-file form fields, and the request's query.
 public struct MediaUpload: Sendable {
@@ -88,10 +107,10 @@ public struct MediaUpload: Sendable {
 
     /// The editor's non-file form fields, in order, each decoded as UTF-8 — most
     /// importantly `post`, the parent post's ID, without which the attachment is created
-    /// unattached. A list of `(name, value)` pairs, not a dictionary, so repeated field
-    /// names (e.g. a `field[]` array) survive verbatim. Send each as a form part on your
-    /// `POST /wp/v2/media`, in the given order.
-    public let fields: [(name: String, value: String)]
+    /// unattached. A list, not a dictionary, so repeated field names (e.g. a `field[]`
+    /// array) survive verbatim. Send each as a form part on your `POST /wp/v2/media`,
+    /// in the given order.
+    public let fields: [MediaUploadField]
 
     /// The request's query string (leading `?`, e.g. `?_embed=wp:featuredmedia`), or
     /// empty. Carry it on your request so the editor gets the response it expects.

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaHandlers.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaHandlers.swift
@@ -74,6 +74,28 @@ public protocol MediaProcessor: AnyObject, Sendable {
     func processFile(at url: URL, mimeType: String, filename: String) async throws -> ProcessedProxyFile
 }
 
+/// Everything a ``MediaUploader`` needs to reproduce a native upload: the file to
+/// send, its metadata, the editor's non-file form fields, and the request's query.
+public struct MediaUpload: Sendable {
+    /// The file to upload — already processed, if a ``MediaProcessor`` ran.
+    public let fileURL: URL
+
+    /// The file's MIME type.
+    public let mimeType: String
+
+    /// The file's name.
+    public let filename: String
+
+    /// The editor's non-file form fields, decoded as UTF-8 — most importantly `post`,
+    /// the parent post's ID, without which the attachment is created unattached. Send
+    /// each as a form part on your `POST /wp/v2/media`.
+    public let fields: [String: String]
+
+    /// The request's query string (leading `?`, e.g. `?_embed=wp:featuredmedia`), or
+    /// empty. Carry it on your request so the editor gets the response it expects.
+    public let query: String
+}
+
 /// Takes over *performing* a media upload — on the host's own stack: its own
 /// networking (say, to log every request), a background session, an offline queue,
 /// a resumable transport, its own retry policy.
@@ -93,6 +115,10 @@ public protocol MediaUploader: AnyObject, Sendable {
     /// or `throw` on terminal failure: a returned value is taken as a completed
     /// attachment, and there is no GutenbergKit recovery behind you.
     ///
+    /// The ``MediaUpload`` carries the file plus the editor's form fields (e.g.
+    /// `post`) and query — send them all so the created attachment matches a native
+    /// upload rather than landing as an unattached orphan.
+    ///
     /// That recovery is yours to run. When `POST /wp/v2/media` fatals in server-side
     /// post-processing it returns a 5xx carrying the attachment's ID in
     /// `x-wp-upload-attachment-id` — the attachment exists but is unfinished. Don't
@@ -104,7 +130,7 @@ public protocol MediaUploader: AnyObject, Sendable {
     /// can't be recovered, force-delete the orphan
     /// (`DELETE /wp/v2/media/<id>?force=true`) before you `throw`, or it stays on the
     /// site — neither GutenbergKit nor core cleans up behind you.
-    func upload(fileAt url: URL, mimeType: String, filename: String) async throws -> Data
+    func upload(_ upload: MediaUpload) async throws -> Data
 }
 
 /// Default implementations for the optional ``MediaProcessor`` methods.

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaHandlers.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaHandlers.swift
@@ -86,10 +86,12 @@ public struct MediaUpload: Sendable {
     /// The file's name.
     public let filename: String
 
-    /// The editor's non-file form fields, decoded as UTF-8 — most importantly `post`,
-    /// the parent post's ID, without which the attachment is created unattached. Send
-    /// each as a form part on your `POST /wp/v2/media`.
-    public let fields: [String: String]
+    /// The editor's non-file form fields, in order, each decoded as UTF-8 — most
+    /// importantly `post`, the parent post's ID, without which the attachment is created
+    /// unattached. A list of `(name, value)` pairs, not a dictionary, so repeated field
+    /// names (e.g. a `field[]` array) survive verbatim. Send each as a form part on your
+    /// `POST /wp/v2/media`, in the given order.
+    public let fields: [(name: String, value: String)]
 
     /// The request's query string (leading `?`, e.g. `?_embed=wp:featuredmedia`), or
     /// empty. Carry it on your request so the editor gets the response it expects.

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaServerCredentials.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaServerCredentials.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Whether the editor configuration can reach the configured site for media, and the
+/// fail-fast that enforces it.
+///
+/// Deliberately outside `EditorViewController`. That type is `#if canImport(UIKit)`,
+/// so on the macOS host it does not exist and nothing in it can be tested — including
+/// this policy, which is a *crash* policy and already diverged silently between iOS
+/// and Android once. Living here, it is reachable from the host test suite, where
+/// Swift Testing's exit tests (unavailable on iOS/simulator) can assert the trap
+/// itself rather than only the predicate.
+enum MediaServerCredentials {
+    /// Whether an ``InternalMediaClient`` built from this configuration could actually
+    /// reach the site.
+    ///
+    /// Both fields are required. The client delivers GutenbergKit-owned uploads and
+    /// relays every media delete to the configured site, so it needs somewhere to send
+    /// them and credentials to be accepted; with either missing, every media request it
+    /// makes fails.
+    ///
+    /// `siteApiRoot` is a `URL` here where Android types it as a `String`, so the
+    /// equivalent of Android's `isEmpty()` check is "not absolute" — a URL with no
+    /// scheme or host cannot address the site, and every request built from it fails at
+    /// the URLSession layer.
+    static func areUsable(siteApiRoot: URL, authHeader: String) -> Bool {
+        siteApiRoot.scheme != nil && siteApiRoot.host() != nil && !authHeader.isEmpty
+    }
+
+    /// Returns whether the upload server can start, trapping if the host set a
+    /// ``MediaUploader`` without usable credentials.
+    ///
+    /// The behavior forks by intent:
+    ///
+    /// - A ``MediaProcessor`` only enhances GutenbergKit-owned uploads. With no
+    ///   credentials there is nothing to deliver through, so nothing to process — the
+    ///   caller leaves the server down and uploads fall to the default WebView path.
+    ///
+    /// - A ``MediaUploader`` means the host is *taking over* uploads. Falling back would
+    ///   silently drop it, and its media deletes still need the internal media client to
+    ///   reach the configured site. A host that sets an uploader must provide credentials
+    ///   too; omitting them is a configuration error, so trap rather than start a server
+    ///   whose every delete would fail. (Matches Android's `check`.)
+    static func canStartServer(siteApiRoot: URL, authHeader: String, hasUploader: Bool) -> Bool {
+        if areUsable(siteApiRoot: siteApiRoot, authHeader: authHeader) {
+            return true
+        }
+        precondition(
+            !hasUploader,
+            "A mediaUploader needs site credentials so GutenbergKit can relay the "
+                + "editor's media deletes to the configured site. Set an absolute "
+                + "siteApiRoot and the auth header in the editor configuration."
+        )
+        return false
+    }
+}

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadDelegate.swift
@@ -82,6 +82,19 @@ public protocol MediaUploadDelegate: AnyObject, Sendable {
     /// host that uploads to WordPress should return the exact response it
     /// received so the editor sees a complete attachment object.
     func uploadFile(at url: URL, mimeType: String, filename: String) async throws -> MediaUploadResponse?
+
+    /// Delete a previously uploaded attachment.
+    ///
+    /// The editor deletes the attachment when an upload's server-side
+    /// post-processing fails past recovery, so it does not leave an orphan
+    /// behind. A delegate that uploaded the attachment itself via
+    /// ``uploadFile(at:mimeType:filename:)`` owns an ID only it can resolve, so
+    /// it must delete the attachment itself too — the default uploader would
+    /// address the wrong site.
+    ///
+    /// Return the raw response (status code + body), which GutenbergKit relays
+    /// to the editor unchanged, or `nil` to use the default uploader.
+    func deleteFile(attachmentId: String) async throws -> MediaUploadResponse?
 }
 
 /// Default implementations.
@@ -95,6 +108,10 @@ extension MediaUploadDelegate {
     }
 
     public func uploadFile(at url: URL, mimeType: String, filename: String) async throws -> MediaUploadResponse? {
+        nil
+    }
+
+    public func deleteFile(attachmentId: String) async throws -> MediaUploadResponse? {
         nil
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadDelegate.swift
@@ -7,13 +7,13 @@ import Foundation
 /// or WordPress REST error object (on failure) it would get from a direct
 /// upload, so every consumer — image sub-sizes, attachment links, error notices —
 /// behaves identically to a non-native upload.
-public struct MediaUploadResponse: Sendable {
-    /// The HTTP status code WordPress (or the host's upload service) returned.
-    public let statusCode: Int
+struct MediaUploadResponse: Sendable {
+    /// The HTTP status code WordPress returned.
+    let statusCode: Int
 
     /// The raw response body — a WordPress REST attachment on success, or a
     /// WordPress REST error object (`{ "code", "message", "data" }`) on failure.
-    public let body: Data
+    let body: Data
 
     /// The response headers to relay to the editor.
     ///
@@ -22,16 +22,16 @@ public struct MediaUploadResponse: Sendable {
     /// metadata generation fataled, and the editor's api-fetch middleware reads
     /// it to retry `post-process` and clean up the orphan. Dropping it turns a
     /// recoverable upload into a permanent failure.
-    public let headers: [String: String]
+    let headers: [String: String]
 
-    public init(statusCode: Int, body: Data, headers: [String: String] = [:]) {
+    init(statusCode: Int, body: Data, headers: [String: String] = [:]) {
         self.statusCode = statusCode
         self.body = body
         self.headers = headers
     }
 }
 
-/// The result of a delegate's ``MediaUploadDelegate/processFile(at:mimeType:filename:)``.
+/// The result of a ``MediaProcessor/processFile(at:mimeType:filename:)``.
 public enum ProcessedProxyFile: Sendable {
     /// The delegate did not modify the file; the original upload is forwarded
     /// to WordPress unchanged.
@@ -44,84 +44,76 @@ public enum ProcessedProxyFile: Sendable {
     case processed(URL, mimeType: String, filename: String)
 }
 
-/// Protocol for customizing media upload behavior.
+/// Transforms media before GutenbergKit delivers it.
 ///
-/// The native host app can provide an implementation to resize images,
-/// transcode video, or use its own upload service. Default implementations
-/// pass files through unchanged and upload via the WordPress REST API.
-public protocol MediaUploadDelegate: AnyObject, Sendable {
-    /// Whether this delegate might handle a file with the given metadata — either
-    /// processing it (``processFile(at:mimeType:filename:)``) or uploading it
-    /// itself (``uploadFile(at:mimeType:filename:)``).
+/// A processor only changes *bytes* — GutenbergKit still uploads the result to
+/// the configured site and owns the whole lifecycle (retries, cleanup). Because
+/// it never performs the upload itself, a processor cannot deliver media to the
+/// wrong place. Set ``EditorViewController/mediaProcessor`` to resize images,
+/// transcode video, strip EXIF, etc.
+///
+/// This is the safe, common extension point: most hosts want only this.
+public protocol MediaProcessor: AnyObject, Sendable {
+    /// Whether this processor might transform a file with the given metadata.
     ///
     /// A cheap, metadata-only gate the server consults *before* materializing the
-    /// upload to a temp file. Return `false` to decline a file by type — e.g. an
-    /// image-only delegate returning `false` for a video — so the server forwards
-    /// the original upload to WordPress without first copying a file the delegate
-    /// won't touch. Because it gates the temp-file copy needed by *both*
-    /// `processFile` and `uploadFile`, return `true` for any file the delegate
-    /// will either process or upload itself.
+    /// upload to a temp file. Return `false` to pass a file straight through
+    /// untouched — e.g. an image-only processor returning `false` for a video —
+    /// so the server never copies a file the processor won't touch.
     ///
-    /// Defaults to `true`: every file is materialized and the full pipeline runs.
-    /// A `true` here is not a commitment — `processFile` may still return
-    /// `.original` after inspecting the file's contents.
+    /// Defaults to `true`. A `true` here is not a commitment — `processFile` may
+    /// still return `.original` after inspecting the file's contents.
     func handlesFile(ofType mimeType: String, named filename: String) -> Bool
 
-    /// Process a file before upload (e.g., resize image, transcode video).
+    /// Transform a file before upload (e.g., resize image, transcode video).
     ///
     /// Return ``ProcessedProxyFile/original`` to upload the file unchanged, or
     /// ``ProcessedProxyFile/processed(_:mimeType:filename:)`` with the processed
     /// file and its metadata. When the format changes, report the new mimeType
     /// and filename so WordPress stores it with the correct extension and type.
     func processFile(at url: URL, mimeType: String, filename: String) async throws -> ProcessedProxyFile
-
-    /// Upload a processed file to the remote WordPress site.
-    ///
-    /// Return the raw WordPress response (status code + body), which GutenbergKit
-    /// relays to the editor unchanged, or `nil` to use the default uploader. A
-    /// host that uploads to WordPress should return the exact response it
-    /// received so the editor sees a complete attachment object.
-    func uploadFile(at url: URL, mimeType: String, filename: String) async throws -> MediaUploadResponse?
-
-    /// Delete a previously uploaded attachment.
-    ///
-    /// The editor deletes the attachment when an upload's server-side
-    /// post-processing fails past recovery, so it does not leave an orphan
-    /// behind. A delegate that uploaded the attachment itself via
-    /// ``uploadFile(at:mimeType:filename:)`` owns an ID only it can resolve, so
-    /// it must delete the attachment itself too — the default uploader would
-    /// address the wrong site.
-    ///
-    /// Return the raw response (status code + body), which GutenbergKit relays
-    /// to the editor unchanged, or `nil` to use the default uploader.
-    ///
-    /// Return `nil` for any ID the delegate does not recognize. Unlike the upload
-    /// path, there is no ``handlesFile(ofType:named:)`` gate here — an attachment
-    /// ID carries no MIME type or filename — so this method is called for *every*
-    /// deletion, including attachments the delegate declined at upload time and
-    /// WordPress therefore created itself. Returning a response for one of those
-    /// (an error from the host's own media service, say) leaves the real
-    /// WordPress attachment undeleted — precisely the orphan this cleanup exists
-    /// to remove. `nil` hands it to the default uploader, which addresses the
-    /// right site.
-    func deleteFile(attachmentId: String) async throws -> MediaUploadResponse?
 }
 
-/// Default implementations.
-extension MediaUploadDelegate {
+/// Takes over *performing* a media upload — on the host's own stack: its own
+/// networking (say, to log every request), a background session, an offline queue,
+/// a resumable transport, its own retry policy.
+///
+/// This is a choice of *who executes the requests*, not where they go: an uploader
+/// and GutenbergKit's built-in default both target the same configured site.
+/// Setting ``EditorViewController/mediaUploader`` makes the host own that upload
+/// end-to-end — the request, its own retries, and its recovery and cleanup — with
+/// GutenbergKit out of the network entirely. Because the host does the retries
+/// itself, there's no raw response left for core to retry behind it. The attachment
+/// you return lives on that same configured site, where the editor reads and
+/// updates it by ID.
+public protocol MediaUploader: AnyObject, Sendable {
+    /// Upload a (possibly processed) file and return the finished WordPress
+    /// attachment JSON the editor inserts — the same object a direct
+    /// `POST /wp/v2/media` returns. Return only once the upload is genuinely done,
+    /// or `throw` on terminal failure: a returned value is taken as a completed
+    /// attachment, and there is no GutenbergKit recovery behind you.
+    ///
+    /// That recovery is yours to run. When `POST /wp/v2/media` fatals in server-side
+    /// post-processing it returns a 5xx carrying the attachment's ID in
+    /// `x-wp-upload-attachment-id` — the attachment exists but is unfinished. Don't
+    /// re-upload; drive `POST /wp/v2/media/<id>/post-process` to completion, the way
+    /// core recovers its own uploads (up to 5 attempts), then return the finished
+    /// attachment.
+    ///
+    /// Owning the upload means owning cleanup on the server too: if post-process
+    /// can't be recovered, force-delete the orphan
+    /// (`DELETE /wp/v2/media/<id>?force=true`) before you `throw`, or it stays on the
+    /// site — neither GutenbergKit nor core cleans up behind you.
+    func upload(fileAt url: URL, mimeType: String, filename: String) async throws -> Data
+}
+
+/// Default implementations for the optional ``MediaProcessor`` methods.
+extension MediaProcessor {
     public func handlesFile(ofType mimeType: String, named filename: String) -> Bool {
         true
     }
 
     public func processFile(at url: URL, mimeType: String, filename: String) async throws -> ProcessedProxyFile {
         .original
-    }
-
-    public func uploadFile(at url: URL, mimeType: String, filename: String) async throws -> MediaUploadResponse? {
-        nil
-    }
-
-    public func deleteFile(attachmentId: String) async throws -> MediaUploadResponse? {
-        nil
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadDelegate.swift
@@ -94,6 +94,16 @@ public protocol MediaUploadDelegate: AnyObject, Sendable {
     ///
     /// Return the raw response (status code + body), which GutenbergKit relays
     /// to the editor unchanged, or `nil` to use the default uploader.
+    ///
+    /// Return `nil` for any ID the delegate does not recognize. Unlike the upload
+    /// path, there is no ``handlesFile(ofType:named:)`` gate here — an attachment
+    /// ID carries no MIME type or filename — so this method is called for *every*
+    /// deletion, including attachments the delegate declined at upload time and
+    /// WordPress therefore created itself. Returning a response for one of those
+    /// (an error from the host's own media service, say) leaves the real
+    /// WordPress attachment undeleted — precisely the orphan this cleanup exists
+    /// to remove. `nil` hands it to the default uploader, which addresses the
+    /// right site.
     func deleteFile(attachmentId: String) async throws -> MediaUploadResponse?
 }
 

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadDelegate.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadDelegate.swift
@@ -15,9 +15,19 @@ public struct MediaUploadResponse: Sendable {
     /// WordPress REST error object (`{ "code", "message", "data" }`) on failure.
     public let body: Data
 
-    public init(statusCode: Int, body: Data) {
+    /// The response headers to relay to the editor.
+    ///
+    /// `x-wp-upload-attachment-id` is the one that carries behavior: WordPress
+    /// sets it on a failed upload whose attachment row was created before
+    /// metadata generation fataled, and the editor's api-fetch middleware reads
+    /// it to retry `post-process` and clean up the orphan. Dropping it turns a
+    /// recoverable upload into a permanent failure.
+    public let headers: [String: String]
+
+    public init(statusCode: Int, body: Data, headers: [String: String] = [:]) {
         self.statusCode = statusCode
         self.body = body
+        self.headers = headers
     }
 }
 

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -357,13 +357,14 @@ final class MediaUploadServer: Sendable {
         }
     }
 
-    /// Decodes the editor's non-file form parts (e.g. `post`, additionalData) into
-    /// name→value pairs for a host uploader, so it can send them on its own
-    /// `POST /wp/v2/media`. Values are WordPress form fields — UTF-8 text.
-    private static func formFields(from parts: [MultipartPart]) async throws -> [String: String] {
-        var fields: [String: String] = [:]
+    /// Decodes the editor's non-file form parts (e.g. `post`, additionalData) into an
+    /// ordered list of name/value pairs for a host uploader, so it can send them on its
+    /// own `POST /wp/v2/media`. A list, not a dictionary, so repeated field names survive
+    /// in order. Values are WordPress form fields — UTF-8 text.
+    private static func formFields(from parts: [MultipartPart]) async throws -> [(name: String, value: String)] {
+        var fields: [(name: String, value: String)] = []
         for part in parts {
-            fields[part.name] = String(decoding: try await part.body.data, as: UTF8.self)
+            fields.append((name: part.name, value: String(decoding: try await part.body.data, as: UTF8.self)))
         }
         return fields
     }

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -392,10 +392,10 @@ final class MediaUploadServer: Sendable {
         /// ordered list of name/value pairs for a host uploader, so it can send them on its
         /// own `POST /wp/v2/media`. A list, not a dictionary, so repeated field names survive
         /// in order. Values are WordPress form fields — UTF-8 text.
-        private static func formFields(from parts: [MultipartPart]) async throws -> [(name: String, value: String)] {
-            var fields: [(name: String, value: String)] = []
+        private static func formFields(from parts: [MultipartPart]) async throws -> [MediaUploadField] {
+            var fields: [MediaUploadField] = []
             for part in parts {
-                fields.append((name: part.name, value: String(decoding: try await part.body.data, as: UTF8.self)))
+                fields.append(MediaUploadField(name: part.name, value: String(decoding: try await part.body.data, as: UTF8.self)))
             }
             return fields
         }

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -87,15 +87,21 @@ final class MediaUploadServer: Sendable {
     private static func handleRequest(_ request: HTTPServer.Request, context: UploadContext) async -> HTTPResponse {
         let parsed = request.parsed
 
-        // Route: only POST /upload is handled. (OPTIONS preflight is answered by
-        // the HTTP library under its permissive CORS policy.) Match on the path
-        // alone — the target carries a query string (e.g. `?_embed`) that the
-        // upload handler relays on to WordPress.
-        guard parsed.method.uppercased() == "POST", parsed.path == "/upload" else {
-            return errorResponse(status: 404, message: "Not found")
+        // Routes: POST /upload, and DELETE /media/<id> for the editor's orphan
+        // cleanup. (OPTIONS preflight is answered by the HTTP library under its
+        // permissive CORS policy.) Match on the path alone — the target carries
+        // a query string (e.g. `?_embed`, `?force=true`) relayed to WordPress.
+        let method = parsed.method.uppercased()
+
+        if method == "POST", parsed.path == "/upload" {
+            return await handleUpload(request, context: context)
         }
 
-        return await handleUpload(request, context: context)
+        if method == "DELETE", let attachmentId = attachmentId(fromPath: parsed.path) {
+            return await handleDelete(attachmentId, query: parsed.query, context: context)
+        }
+
+        return errorResponse(status: 404, message: "Not found")
     }
 
     private static func handleUpload(_ request: HTTPServer.Request, context: UploadContext) async -> HTTPResponse {
@@ -188,6 +194,39 @@ final class MediaUploadServer: Sendable {
         }
         let response = try await defaultUploader.passthroughUpload(body: body, contentType: contentType, query: query)
         return relayResponse(response)
+    }
+
+    /// The attachment ID in a `/media/<id>` path, or `nil` if the path is not one.
+    ///
+    /// Deliberately narrow: this server relays media operations, not arbitrary
+    /// REST requests, so only a numeric attachment ID under `/media/` matches.
+    private static func attachmentId(fromPath path: String) -> String? {
+        let components = path.split(separator: "/", omittingEmptySubsequences: true)
+        guard components.count == 2, components[0] == "media" else { return nil }
+        let id = String(components[1])
+        guard !id.isEmpty, id.allSatisfy(\.isNumber) else { return nil }
+        return id
+    }
+
+    /// Relays the editor's orphan cleanup to WordPress.
+    ///
+    /// Core's media upload middleware deletes the attachment when every
+    /// `post-process` retry fails. A cross-origin editor cannot issue that
+    /// request directly — api-fetch tunnels `DELETE` as a `POST` carrying
+    /// `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
+    /// browser blocks it at preflight. Relaying it here lets the cleanup run.
+    private static func handleDelete(
+        _ attachmentId: String, query: String, context: UploadContext
+    ) async -> HTTPResponse {
+        guard let defaultUploader = context.defaultUploader else {
+            return errorResponse(status: 500, message: UploadError.noUploader.localizedDescription)
+        }
+        do {
+            let response = try await defaultUploader.deleteMedia(attachmentId: attachmentId, query: query)
+            return relayResponse(response)
+        } catch {
+            return uploadErrorResponse(error)
+        }
     }
 
     /// Relays WordPress's exact status, body, and relayable headers to the editor
@@ -447,8 +486,9 @@ class DefaultMediaUploader: @unchecked Sendable {
     /// The WordPress media endpoint URL, built through the shared
     /// ``WordPressRESTURL`` namespacing (so it matches every other REST URL) and
     /// carrying the original request query (e.g. `?_embed`) through to WordPress.
-    private func mediaEndpointURL(query: String) -> URL {
-        let base = WordPressRESTURL.namespaced(apiRoot: siteApiRoot, path: "/wp/v2/media", namespace: siteApiNamespace)
+    private func mediaEndpointURL(query: String, attachmentId: String? = nil) -> URL {
+        let path = attachmentId.map { "/wp/v2/media/\($0)" } ?? "/wp/v2/media"
+        let base = WordPressRESTURL.namespaced(apiRoot: siteApiRoot, path: path, namespace: siteApiNamespace)
         guard !query.isEmpty else { return base }
         // `query` is the raw request query in wire form (leading "?"). Set it via
         // `percentEncodedQuery` so a value that isn't URL-safe can't make
@@ -493,6 +533,23 @@ class DefaultMediaUploader: @unchecked Sendable {
         request.httpBodyStream = try body.makeInputStream()
 
         return try await performUpload(request)
+    }
+
+    /// Deletes an attachment, relaying WordPress's response verbatim.
+    ///
+    /// Carries the editor's query through unchanged — core's cleanup sends
+    /// `?force=true`, without which WordPress trashes rather than deletes.
+    func deleteMedia(attachmentId: String, query: String) async throws -> MediaUploadResponse {
+        var request = URLRequest(url: mediaEndpointURL(query: query, attachmentId: attachmentId))
+        request.httpMethod = "DELETE"
+
+        // Authorization is applied centrally by the HTTP client, as for uploads.
+        let (data, response) = try await httpClient.performRaw(request)
+        return MediaUploadResponse(
+            statusCode: response.statusCode,
+            body: data,
+            headers: Self.relayableHeaders(from: response)
+        )
     }
 
     /// Sends the assembled upload request to WordPress and relays the response.

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -490,29 +490,28 @@ enum UploadError: Error, LocalizedError {
 // MARK: - Upload Context
 
 /// Container for the media processor, uploader, and internal media client, captured by
-/// the HTTPServer handler closure and re-read on each request.
+/// the HTTPServer handler closure and read on each request.
 ///
-/// The processor and uploader are held **weakly**. `EditorViewController` owns them
-/// for its lifetime — its `mediaProcessor` / `.mediaUploader` are strong — and owns
-/// this server too, so they stay alive for every request. The weak reference here is
-/// solely to break the cycle the server would otherwise close (`EditorViewController →
-/// uploadServer → HTTPServer → handler → UploadContext → host object →
-/// EditorViewController`) whenever the host object retains the view controller:
-/// capturing strongly would keep the view controller — and therefore the server —
-/// alive forever, so `deinit` would never stop it.
+/// Everything here is held **strongly**, so a handler that admitted a file for
+/// processing will process it, and one that gated on an uploader will deliver through
+/// it — the reads can't disagree within a request, and an in-flight upload keeps the
+/// host's handlers alive until it unwinds. This matches Android, which holds its
+/// `processor`/`uploader` as plain `val`s for the same reason.
 ///
-/// `@unchecked Sendable`: `processor`/`uploader` are assigned once at init and only
-/// read afterwards; weak-reference reads are thread-safe at runtime.
-private final class UploadContext: @unchecked Sendable {
-    weak var processor: (any MediaProcessor)?
-    weak var uploader: (any MediaUploader)?
+/// Strong is safe because `EditorViewController` owns `mediaProcessor` /
+/// `mediaUploader` strongly too. A host object that retains the view controller back
+/// already forms `EditorViewController → mediaUploader → EditorViewController`, a
+/// cycle this container can neither create nor prevent — so holding weak here bought
+/// no leak protection, only the risk of a reference vanishing mid-request. (It *was*
+/// load-bearing when the view controller held its delegate `weak` and this was the
+/// only strong path; that changed when those properties became strong.)
+///
+/// A `struct`, so it is implicitly `Sendable`: `MediaProcessor` and `MediaUploader`
+/// are `Sendable` protocols and `InternalMediaClient` is `@unchecked Sendable`.
+private struct UploadContext: Sendable {
+    let processor: (any MediaProcessor)?
+    let uploader: (any MediaUploader)?
     let internalClient: InternalMediaClient
-
-    init(processor: (any MediaProcessor)?, uploader: (any MediaUploader)?, internalClient: InternalMediaClient) {
-        self.processor = processor
-        self.uploader = uploader
-        self.internalClient = internalClient
-    }
 }
 
 // MARK: - Default Media Uploader

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -101,7 +101,7 @@ final class MediaUploadServer: Sendable {
         }
 
         if method == "DELETE", let attachmentId = attachmentId(fromPath: parsed.path) {
-            return await handleMediaDelete(attachmentId, query: parsed.query, context: context)
+            return await handleMediaDelete(attachmentId, query: parsed.query, internalClient: context.internalClient)
         }
 
         return errorResponse(status: 404, message: "Not found")
@@ -137,7 +137,7 @@ final class MediaUploadServer: Sendable {
         let processorWantsFile = context.processor?.handlesFile(ofType: mimeType, named: filename) ?? false
         if context.uploader == nil, !processorWantsFile {
             do {
-                return try await passthroughResponse(request, query: query, context: context)
+                return try await passthroughResponse(request, query: query, internalClient: context.internalClient)
             } catch {
                 return uploadErrorResponse(error)
             }
@@ -178,7 +178,7 @@ final class MediaUploadServer: Sendable {
             case .passthrough:
                 // Delegate didn't modify the file — forward the original request
                 // body to WordPress without re-encoding.
-                return try await passthroughResponse(request, query: query, context: context)
+                return try await passthroughResponse(request, query: query, internalClient: context.internalClient)
             }
         } catch {
             return uploadErrorResponse(error)
@@ -190,7 +190,7 @@ final class MediaUploadServer: Sendable {
     /// processor won't touch the file — it declined by metadata (`handlesFile`
     /// returned false) or `processFile` returned `.original`.
     private static func passthroughResponse(
-        _ request: HTTPServer.Request, query: String, context: UploadContext
+        _ request: HTTPServer.Request, query: String, internalClient: InternalMediaClient
     ) async throws -> HTTPResponse {
         // As in `processAndUpload`: don't put bytes on the wire for a torn-down
         // editor, regardless of whether the HTTP client honors cancellation.
@@ -201,7 +201,7 @@ final class MediaUploadServer: Sendable {
               let contentType = request.parsed.header("Content-Type") else {
             return errorResponse(status: 500, message: "Passthrough upload requires a request body and Content-Type")
         }
-        let response = try await context.internalClient.passthroughUpload(body: body, contentType: contentType, query: query)
+        let response = try await internalClient.passthroughUpload(body: body, contentType: contentType, query: query)
         return relayResponse(response)
     }
 
@@ -229,7 +229,7 @@ final class MediaUploadServer: Sendable {
     /// delivered — so its deletion is relayed to the internal media client there. See
     /// the accepted-risk note in the body.
     private static func handleMediaDelete(
-        _ attachmentId: String, query: String, context: UploadContext
+        _ attachmentId: String, query: String, internalClient: InternalMediaClient
     ) async -> HTTPResponse {
         do {
             // Relay to the internal media client (the configured site) — every attachment
@@ -241,7 +241,7 @@ final class MediaUploadServer: Sendable {
             // access, and a server-side compromise (a malicious plugin) deletes media
             // directly without the editor, so scoping this with a per-session ledger
             // buys little for the cost.
-            let response = try await context.internalClient.deleteMedia(attachmentId: attachmentId, query: query)
+            let response = try await internalClient.deleteMedia(attachmentId: attachmentId, query: query)
             return relayResponse(response)
         } catch {
             return uploadErrorResponse(error)

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -98,7 +98,7 @@ final class MediaUploadServer: Sendable {
         }
 
         if method == "DELETE", let attachmentId = attachmentId(fromPath: parsed.path) {
-            return await handleDelete(attachmentId, query: parsed.query, context: context)
+            return await handleMediaDelete(attachmentId, query: parsed.query, context: context)
         }
 
         return errorResponse(status: 404, message: "Not found")
@@ -208,20 +208,28 @@ final class MediaUploadServer: Sendable {
         return id
     }
 
-    /// Relays the editor's orphan cleanup to WordPress.
+    /// Relays the editor's orphan cleanup.
     ///
     /// Core's media upload middleware deletes the attachment when every
     /// `post-process` retry fails. A cross-origin editor cannot issue that
     /// request directly — api-fetch tunnels `DELETE` as a `POST` carrying
     /// `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
     /// browser blocks it at preflight. Relaying it here lets the cleanup run.
-    private static func handleDelete(
+    ///
+    /// Offers the deletion to the delegate first, as ``handleUpload(_:context:)``
+    /// does, so a host that uploaded the attachment itself deletes it from the
+    /// same place.
+    private static func handleMediaDelete(
         _ attachmentId: String, query: String, context: UploadContext
     ) async -> HTTPResponse {
-        guard let defaultUploader = context.defaultUploader else {
-            return errorResponse(status: 500, message: UploadError.noUploader.localizedDescription)
-        }
         do {
+            if let response = try await context.uploadDelegate?.deleteFile(attachmentId: attachmentId) {
+                return relayResponse(response)
+            }
+
+            guard let defaultUploader = context.defaultUploader else {
+                return errorResponse(status: 500, message: UploadError.noUploader.localizedDescription)
+            }
             let response = try await defaultUploader.deleteMedia(attachmentId: attachmentId, query: query)
             return relayResponse(response)
         } catch {

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -48,7 +48,7 @@ final class MediaUploadServer: Sendable {
             cleanOrphanedUploads()
         }
 
-        let context = UploadContext(processor: processor, uploader: uploader, internalClient: internalClient)
+        let handler = Handler(processor: processor, uploader: uploader, internalClient: internalClient)
 
         // A generous ceiling for receiving the upload body. The body read is
         // primarily bounded by the per-read idle timeout (which reaps a stalled
@@ -65,9 +65,7 @@ final class MediaUploadServer: Sendable {
             bodyReadTimeout: bodyReadTimeout,
             cors: .permissive,
             delegate: ServerDelegate(),
-            handler: { request in
-                await Self.handleRequest(request, context: context)
-            }
+            handler: handler
         )
 
         return MediaUploadServer(server: server, cleanupTask: cleanupTask)
@@ -87,297 +85,320 @@ final class MediaUploadServer: Sendable {
 
     // MARK: - Request Handling
 
-    private static func handleRequest(_ request: HTTPServer.Request, context: UploadContext) async -> HTTPResponse {
-        let parsed = request.parsed
+    /// Serves each upload request, holding the media collaborators it needs.
+    ///
+    /// A value type, and deliberately separate from ``MediaUploadServer``: the handler
+    /// is captured by the `HTTPServer` that the server itself owns, so a handler that
+    /// *was* the server would form `MediaUploadServer -> HTTPServer -> handler ->
+    /// MediaUploadServer` and `deinit` would never run `stop()`. A struct can't
+    /// participate in a reference cycle, so that question doesn't arise — and its
+    /// dependencies are stored properties, so the request methods are ordinary
+    /// instance methods rather than statics threading a context through every call.
+    ///
+    /// Everything is held strongly. `EditorViewController` owns `mediaProcessor` /
+    /// `mediaUploader` strongly too, so a host object retaining the view controller
+    /// already cycles through the view controller's own properties — something this
+    /// handler can neither create nor prevent. Holding weak here bought no leak
+    /// protection, only the risk of a reference vanishing mid-request. Immutable
+    /// strong references also make the admission gate and delivery agree by
+    /// construction. (Matches Android, which holds plain `val`s.)
+    private struct Handler: HTTPRequestHandler {
+        let processor: (any MediaProcessor)?
+        let uploader: (any MediaUploader)?
+        let internalClient: InternalMediaClient
 
-        // Routes: POST /upload, and DELETE /media/<id> for the editor's orphan
-        // cleanup. (OPTIONS preflight is answered by the HTTP library under its
-        // permissive CORS policy.) Match on the path alone — the target carries
-        // a query string (e.g. `?_embed`, `?force=true`) relayed to WordPress.
-        let method = parsed.method.uppercased()
+        func handle(_ request: HTTPServer.Request) async -> HTTPResponse {
+            let parsed = request.parsed
 
-        if method == "POST", parsed.path == "/upload" {
-            return await handleUpload(request, context: context)
+            // Routes: POST /upload, and DELETE /media/<id> for the editor's orphan
+            // cleanup. (OPTIONS preflight is answered by the HTTP library under its
+            // permissive CORS policy.) Match on the path alone — the target carries
+            // a query string (e.g. `?_embed`, `?force=true`) relayed to WordPress.
+            let method = parsed.method.uppercased()
+
+            if method == "POST", parsed.path == "/upload" {
+                return await handleUpload(request)
+            }
+
+            if method == "DELETE", let attachmentId = Self.attachmentId(fromPath: parsed.path) {
+                return await handleMediaDelete(attachmentId, query: parsed.query)
+            }
+
+            return MediaUploadServer.errorResponse(status: 404, message: "Not found")
         }
 
-        if method == "DELETE", let attachmentId = attachmentId(fromPath: parsed.path) {
-            return await handleMediaDelete(attachmentId, query: parsed.query, internalClient: context.internalClient)
-        }
-
-        return errorResponse(status: 404, message: "Not found")
-    }
-
-    private static func handleUpload(_ request: HTTPServer.Request, context: UploadContext) async -> HTTPResponse {
-        let parts: [MultipartPart]
-        do {
-            parts = try request.parsed.multipartParts()
-        } catch {
-            Logger.uploadServer.error("Multipart parse failed: \(error)")
-            return errorResponse(status: 400, message: "Expected multipart/form-data")
-        }
-
-        // Find the file part (the first part with a filename).
-        guard let filePart = parts.first(where: { $0.filename != nil }) else {
-            return errorResponse(status: 400, message: "No file found in request")
-        }
-
-        // The non-file parts (post, additionalData) and the original query
-        // (e.g. ?_embed) must reach WordPress too — relay them alongside the file.
-        let extraParts = parts.filter { $0.filename == nil }
-        let query = request.parsed.query
-
-        let filename = filePart.filename ?? "upload"
-        let mimeType = filePart.contentType
-
-        // Materialize a temp file only if someone will touch it: a processor that
-        // claims this file, or an uploader (which always delivers the file itself).
-        // If GutenbergKit will deliver (no uploader) and no processor wants the
-        // file, forward the original request body directly, skipping a temp copy of
-        // a file nobody will process (e.g. a video handed to an image-only processor).
-        let processorWantsFile = context.processor?.handlesFile(ofType: mimeType, named: filename) ?? false
-        if context.uploader == nil, !processorWantsFile {
+        private func handleUpload(_ request: HTTPServer.Request) async -> HTTPResponse {
+            let parts: [MultipartPart]
             do {
-                return try await passthroughResponse(request, query: query, internalClient: context.internalClient)
+                parts = try request.parsed.multipartParts()
             } catch {
-                return uploadErrorResponse(error)
+                Logger.uploadServer.error("Multipart parse failed: \(error)")
+                return MediaUploadServer.errorResponse(status: 400, message: "Expected multipart/form-data")
+            }
+
+            // Find the file part (the first part with a filename).
+            guard let filePart = parts.first(where: { $0.filename != nil }) else {
+                return MediaUploadServer.errorResponse(status: 400, message: "No file found in request")
+            }
+
+            // The non-file parts (post, additionalData) and the original query
+            // (e.g. ?_embed) must reach WordPress too — relay them alongside the file.
+            let extraParts = parts.filter { $0.filename == nil }
+            let query = request.parsed.query
+
+            let filename = filePart.filename ?? "upload"
+            let mimeType = filePart.contentType
+
+            // Materialize a temp file only if someone will touch it: a processor that
+            // claims this file, or an uploader (which always delivers the file itself).
+            // If GutenbergKit will deliver (no uploader) and no processor wants the
+            // file, forward the original request body directly, skipping a temp copy of
+            // a file nobody will process (e.g. a video handed to an image-only processor).
+            let processorWantsFile = processor?.handlesFile(ofType: mimeType, named: filename) ?? false
+            if uploader == nil, !processorWantsFile {
+                do {
+                    return try await passthroughResponse(request, query: query)
+                } catch {
+                    return Self.uploadErrorResponse(error)
+                }
+            }
+
+            // The delegate wants the file. Stream the part body to a dedicated temp
+            // file for it — the library's RequestBody may be a byte-range slice of a
+            // larger temp file whose lifecycle is tied to ARC, so the delegate needs a
+            // standalone file that outlives the handler return.
+            let tempDir = MediaUploadServer.uploadsTempDirectory
+            try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+            let fileURL = tempDir.appending(component: "\(UUID().uuidString)-\(MediaUploadServer.sanitizeFilename(filename))")
+            do {
+                let inputStream = try filePart.body.makeInputStream()
+                try MediaUploadServer.writeStream(inputStream, to: fileURL)
+            } catch {
+                try? FileManager.default.removeItem(at: fileURL)
+                Logger.uploadServer.error("Failed to write upload to disk: \(error)")
+                return MediaUploadServer.errorResponse(status: 500, message: "Failed to save file")
+            }
+
+            // From here on always clean up the original temp file. The processed
+            // file (if the delegate produced a new one) is cleaned up inside
+            // processAndUpload so its throw paths are covered too.
+            defer { try? FileManager.default.removeItem(at: fileURL) }
+
+            do {
+                let uploadResult = try await processAndUpload(
+                    fileURL: fileURL, mimeType: mimeType, filename: filename,
+                    extraParts: extraParts, query: query,
+                    processorWantsFile: processorWantsFile
+                )
+                switch uploadResult {
+                case .uploaded(let uploaded):
+                    Logger.uploadServer.debug("Uploaded file to WordPress")
+                    return Self.relayResponse(uploaded)
+                case .passthrough:
+                    // Delegate didn't modify the file — forward the original request
+                    // body to WordPress without re-encoding.
+                    return try await passthroughResponse(request, query: query)
+                }
+            } catch {
+                return Self.uploadErrorResponse(error)
             }
         }
 
-        // The delegate wants the file. Stream the part body to a dedicated temp
-        // file for it — the library's RequestBody may be a byte-range slice of a
-        // larger temp file whose lifecycle is tied to ARC, so the delegate needs a
-        // standalone file that outlives the handler return.
-        let tempDir = uploadsTempDirectory
-        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        /// Forwards the original request body to WordPress unchanged (no multipart
+        /// re-encoding) and relays the response. Used on the no-uploader path when the
+        /// processor won't touch the file — it declined by metadata (`handlesFile`
+        /// returned false) or `processFile` returned `.original`.
+        private func passthroughResponse(
+            _ request: HTTPServer.Request, query: String
+        ) async throws -> HTTPResponse {
+            // As in `processAndUpload`: don't put bytes on the wire for a torn-down
+            // editor, regardless of whether the HTTP client honors cancellation.
+            try Task.checkCancellation()
 
-        let fileURL = tempDir.appending(component: "\(UUID().uuidString)-\(sanitizeFilename(filename))")
-        do {
-            let inputStream = try filePart.body.makeInputStream()
-            try writeStream(inputStream, to: fileURL)
-        } catch {
-            try? FileManager.default.removeItem(at: fileURL)
-            Logger.uploadServer.error("Failed to write upload to disk: \(error)")
-            return errorResponse(status: 500, message: "Failed to save file")
+            Logger.uploadServer.debug("Passthrough: forwarding original request body to WordPress")
+            guard let body = request.parsed.body,
+                  let contentType = request.parsed.header("Content-Type") else {
+                return MediaUploadServer.errorResponse(status: 500, message: "Passthrough upload requires a request body and Content-Type")
+            }
+            let response = try await internalClient.passthroughUpload(body: body, contentType: contentType, query: query)
+            return Self.relayResponse(response)
         }
 
-        // From here on always clean up the original temp file. The processed
-        // file (if the delegate produced a new one) is cleaned up inside
-        // processAndUpload so its throw paths are covered too.
-        defer { try? FileManager.default.removeItem(at: fileURL) }
+        /// The attachment ID in a `/media/<id>` path, or `nil` if the path is not one.
+        ///
+        /// Deliberately narrow: this server relays media operations, not arbitrary
+        /// REST requests, so only a numeric attachment ID under `/media/` matches.
+        private static func attachmentId(fromPath path: String) -> String? {
+            let components = path.split(separator: "/", omittingEmptySubsequences: true)
+            guard components.count == 2, components[0] == "media" else { return nil }
+            let id = String(components[1])
+            guard !id.isEmpty, id.allSatisfy(\.isNumber) else { return nil }
+            return id
+        }
 
-        do {
-            let uploadResult = try await processAndUpload(
-                fileURL: fileURL, mimeType: mimeType, filename: filename,
-                extraParts: extraParts, query: query,
-                processorWantsFile: processorWantsFile, context: context
+        /// Relays a media deletion.
+        ///
+        /// The editor deletes an attachment when the user removes it, and core deletes
+        /// an upload's orphan when every `post-process` retry fails. A cross-origin
+        /// editor cannot issue `DELETE` directly — api-fetch tunnels it as a `POST`
+        /// carrying `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
+        /// browser blocks it at preflight; relaying it here lets the deletion run.
+        ///
+        /// Every attachment lives on the configured site — even one a host uploader
+        /// delivered — so its deletion is relayed to the internal media client there. See
+        /// the accepted-risk note in the body.
+        private func handleMediaDelete(
+            _ attachmentId: String, query: String
+        ) async -> HTTPResponse {
+            do {
+                // Relay to the internal media client (the configured site) — every attachment
+                // lives there, even one a host uploader delivered. Core issues this only
+                // as orphan cleanup after failed recovery, but the relay can't tell that
+                // from any other DELETE the WebView sends: a compromised editor script
+                // holding the loopback token could force-delete arbitrary media on the
+                // configured site. Accepted risk — such a script already has broad write
+                // access, and a server-side compromise (a malicious plugin) deletes media
+                // directly without the editor, so scoping this with a per-session ledger
+                // buys little for the cost.
+                let response = try await internalClient.deleteMedia(attachmentId: attachmentId, query: query)
+                return Self.relayResponse(response)
+            } catch {
+                return Self.uploadErrorResponse(error)
+            }
+        }
+
+        /// Relays WordPress's exact status, body, and relayable headers to the editor
+        /// so it sees the same attachment object (or error) as a direct upload.
+        ///
+        /// The headers matter for recovery: `x-wp-upload-attachment-id` is what lets
+        /// the editor retry `post-process` for an upload whose metadata generation
+        /// fataled server-side, rather than surfacing a permanent failure and
+        /// leaving an orphaned attachment behind.
+        ///
+        /// The relayed body is always WordPress REST JSON — an attachment, or a
+        /// `{code, message, data}` error — so the response is always `application/json`.
+        /// The relayed headers are a content-type-free allowlist (`relayableHeaderNames`),
+        /// so prepending the JSON default never collides with them.
+        private static func relayResponse(_ response: MediaUploadResponse) -> HTTPResponse {
+            return HTTPResponse(
+                status: response.statusCode,
+                headers: [("Content-Type", "application/json")] + response.headers.map { ($0.key, $0.value) },
+                body: response.body
             )
-            switch uploadResult {
-            case .uploaded(let uploaded):
-                Logger.uploadServer.debug("Uploaded file to WordPress")
-                return relayResponse(uploaded)
-            case .passthrough:
-                // Delegate didn't modify the file — forward the original request
-                // body to WordPress without re-encoding.
-                return try await passthroughResponse(request, query: query, internalClient: context.internalClient)
+        }
+
+        /// Builds the 500 response for a failed upload. A cancelled connection task
+        /// (editor abort / server stop) surfaces here too — as CancellationError or
+        /// URLError.cancelled — but isn't a failure and the server closes the
+        /// connection without sending this response (see HTTPServer's cancellation
+        /// check), so log that quietly.
+        private static func uploadErrorResponse(_ error: any Error) -> HTTPResponse {
+            if Task.isCancelled {
+                Logger.uploadServer.debug("Upload cancelled")
+            } else {
+                Logger.uploadServer.error("Upload processing failed: \(error)")
             }
-        } catch {
-            return uploadErrorResponse(error)
-        }
-    }
-
-    /// Forwards the original request body to WordPress unchanged (no multipart
-    /// re-encoding) and relays the response. Used on the no-uploader path when the
-    /// processor won't touch the file — it declined by metadata (`handlesFile`
-    /// returned false) or `processFile` returned `.original`.
-    private static func passthroughResponse(
-        _ request: HTTPServer.Request, query: String, internalClient: InternalMediaClient
-    ) async throws -> HTTPResponse {
-        // As in `processAndUpload`: don't put bytes on the wire for a torn-down
-        // editor, regardless of whether the HTTP client honors cancellation.
-        try Task.checkCancellation()
-
-        Logger.uploadServer.debug("Passthrough: forwarding original request body to WordPress")
-        guard let body = request.parsed.body,
-              let contentType = request.parsed.header("Content-Type") else {
-            return errorResponse(status: 500, message: "Passthrough upload requires a request body and Content-Type")
-        }
-        let response = try await internalClient.passthroughUpload(body: body, contentType: contentType, query: query)
-        return relayResponse(response)
-    }
-
-    /// The attachment ID in a `/media/<id>` path, or `nil` if the path is not one.
-    ///
-    /// Deliberately narrow: this server relays media operations, not arbitrary
-    /// REST requests, so only a numeric attachment ID under `/media/` matches.
-    private static func attachmentId(fromPath path: String) -> String? {
-        let components = path.split(separator: "/", omittingEmptySubsequences: true)
-        guard components.count == 2, components[0] == "media" else { return nil }
-        let id = String(components[1])
-        guard !id.isEmpty, id.allSatisfy(\.isNumber) else { return nil }
-        return id
-    }
-
-    /// Relays a media deletion.
-    ///
-    /// The editor deletes an attachment when the user removes it, and core deletes
-    /// an upload's orphan when every `post-process` retry fails. A cross-origin
-    /// editor cannot issue `DELETE` directly — api-fetch tunnels it as a `POST`
-    /// carrying `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
-    /// browser blocks it at preflight; relaying it here lets the deletion run.
-    ///
-    /// Every attachment lives on the configured site — even one a host uploader
-    /// delivered — so its deletion is relayed to the internal media client there. See
-    /// the accepted-risk note in the body.
-    private static func handleMediaDelete(
-        _ attachmentId: String, query: String, internalClient: InternalMediaClient
-    ) async -> HTTPResponse {
-        do {
-            // Relay to the internal media client (the configured site) — every attachment
-            // lives there, even one a host uploader delivered. Core issues this only
-            // as orphan cleanup after failed recovery, but the relay can't tell that
-            // from any other DELETE the WebView sends: a compromised editor script
-            // holding the loopback token could force-delete arbitrary media on the
-            // configured site. Accepted risk — such a script already has broad write
-            // access, and a server-side compromise (a malicious plugin) deletes media
-            // directly without the editor, so scoping this with a per-session ledger
-            // buys little for the cost.
-            let response = try await internalClient.deleteMedia(attachmentId: attachmentId, query: query)
-            return relayResponse(response)
-        } catch {
-            return uploadErrorResponse(error)
-        }
-    }
-
-    /// Relays WordPress's exact status, body, and relayable headers to the editor
-    /// so it sees the same attachment object (or error) as a direct upload.
-    ///
-    /// The headers matter for recovery: `x-wp-upload-attachment-id` is what lets
-    /// the editor retry `post-process` for an upload whose metadata generation
-    /// fataled server-side, rather than surfacing a permanent failure and
-    /// leaving an orphaned attachment behind.
-    ///
-    /// The relayed body is always WordPress REST JSON — an attachment, or a
-    /// `{code, message, data}` error — so the response is always `application/json`.
-    /// The relayed headers are a content-type-free allowlist (`relayableHeaderNames`),
-    /// so prepending the JSON default never collides with them.
-    private static func relayResponse(_ response: MediaUploadResponse) -> HTTPResponse {
-        return HTTPResponse(
-            status: response.statusCode,
-            headers: [("Content-Type", "application/json")] + response.headers.map { ($0.key, $0.value) },
-            body: response.body
-        )
-    }
-
-    /// Builds the 500 response for a failed upload. A cancelled connection task
-    /// (editor abort / server stop) surfaces here too — as CancellationError or
-    /// URLError.cancelled — but isn't a failure and the server closes the
-    /// connection without sending this response (see HTTPServer's cancellation
-    /// check), so log that quietly.
-    private static func uploadErrorResponse(_ error: any Error) -> HTTPResponse {
-        if Task.isCancelled {
-            Logger.uploadServer.debug("Upload cancelled")
-        } else {
-            Logger.uploadServer.error("Upload processing failed: \(error)")
-        }
-        return errorResponse(status: 500, message: error.localizedDescription)
-    }
-
-    // MARK: - Delegate Pipeline
-
-    /// Result of the process + deliver pipeline.
-    private enum UploadResult {
-        /// The uploader or internal media client completed the upload; carries the
-        /// response to relay.
-        case uploaded(MediaUploadResponse)
-        /// No uploader is set and the processor left the file unmodified, so the
-        /// caller should forward the original request body to the configured site.
-        case passthrough
-    }
-
-    private static func processAndUpload(
-        fileURL: URL, mimeType: String, filename: String,
-        extraParts: [MultipartPart], query: String,
-        processorWantsFile: Bool, context: UploadContext
-    ) async throws -> UploadResult {
-        // Step 1: transform (resize, transcode, …) if a processor claims the file.
-        // Reuse the gate's `handlesFile` decision from `handleUpload` rather than
-        // asking again — one metadata call per upload, and the admit and transform
-        // steps can't disagree.
-        let processed: ProcessedProxyFile
-        if processorWantsFile, let processor = context.processor {
-            processed = try await processor.processFile(at: fileURL, mimeType: mimeType, filename: filename)
-        } else {
-            processed = .original
+            return MediaUploadServer.errorResponse(status: 500, message: error.localizedDescription)
         }
 
-        // Resolve the file to upload and its metadata. `.processed` uses the
-        // processor's values verbatim, so a format change is reported to WordPress.
-        let uploadURL: URL
-        let uploadMimeType: String
-        let uploadFilename: String
-        switch processed {
-        case .original:
-            uploadURL = fileURL
-            uploadMimeType = mimeType
-            uploadFilename = filename
-        case let .processed(url, processedMimeType, processedFilename):
-            uploadURL = url
-            uploadMimeType = processedMimeType
-            uploadFilename = processedFilename
+        // MARK: - Delegate Pipeline
+
+        /// Result of the process + deliver pipeline.
+        private enum UploadResult {
+            /// The uploader or internal media client completed the upload; carries the
+            /// response to relay.
+            case uploaded(MediaUploadResponse)
+            /// No uploader is set and the processor left the file unmodified, so the
+            /// caller should forward the original request body to the configured site.
+            case passthrough
         }
 
-        // The processed file (if the processor produced a new one) is ours to
-        // clean up — on success it has been uploaded, on failure it is abandoned.
-        // Cleaning up here rather than in the caller covers the throw paths too.
-        defer {
-            if uploadURL != fileURL {
-                try? FileManager.default.removeItem(at: uploadURL)
+        private func processAndUpload(
+            fileURL: URL, mimeType: String, filename: String,
+            extraParts: [MultipartPart], query: String,
+            processorWantsFile: Bool
+        ) async throws -> UploadResult {
+            // Step 1: transform (resize, transcode, …) if a processor claims the file.
+            // Reuse the gate's `handlesFile` decision from `handleUpload` rather than
+            // asking again — one metadata call per upload, and the admit and transform
+            // steps can't disagree.
+            let processed: ProcessedProxyFile
+            if processorWantsFile, let processor {
+                processed = try await processor.processFile(at: fileURL, mimeType: mimeType, filename: filename)
+            } else {
+                processed = .original
+            }
+
+            // Resolve the file to upload and its metadata. `.processed` uses the
+            // processor's values verbatim, so a format change is reported to WordPress.
+            let uploadURL: URL
+            let uploadMimeType: String
+            let uploadFilename: String
+            switch processed {
+            case .original:
+                uploadURL = fileURL
+                uploadMimeType = mimeType
+                uploadFilename = filename
+            case let .processed(url, processedMimeType, processedFilename):
+                uploadURL = url
+                uploadMimeType = processedMimeType
+                uploadFilename = processedFilename
+            }
+
+            // The processed file (if the processor produced a new one) is ours to
+            // clean up — on success it has been uploaded, on failure it is abandoned.
+            // Cleaning up here rather than in the caller covers the throw paths too.
+            defer {
+                if uploadURL != fileURL {
+                    try? FileManager.default.removeItem(at: uploadURL)
+                }
+            }
+
+            // The editor was torn down (or the client disconnected) while we processed.
+            // Don't start an outbound upload whose response nobody will read — it would
+            // create an attachment neither GutenbergKit nor the host knows to clean up.
+            // Checking here rather than relying on the HTTP client to notice cancellation
+            // keeps this true for a host-injected `URLSessionProtocol` that doesn't.
+            try Task.checkCancellation()
+
+            // Step 2: deliver. An uploader owns delivery on the host's own stack and
+            // returns the finished attachment JSON (or throws); GutenbergKit relays that
+            // as a success and never runs its own recovery behind it. Otherwise the
+            // internal media client delivers to the configured site.
+            if let uploader {
+                // Hand the host the editor's non-file fields (e.g. `post`) and query too,
+                // so its own POST can reproduce a native upload — otherwise the attachment
+                // is created unattached and `?_embed` is lost.
+                let fields = try await Self.formFields(from: extraParts)
+                let upload = MediaUpload(
+                    fileURL: uploadURL, mimeType: uploadMimeType, filename: uploadFilename,
+                    fields: fields, query: query
+                )
+                let body = try await uploader.upload(upload)
+                return .uploaded(MediaUploadResponse(statusCode: 201, body: body))
+            } else {
+                // Unmodified — forward the original request body directly, skipping
+                // multipart re-encoding.
+                if case .original = processed {
+                    return .passthrough
+                }
+                let result = try await internalClient.upload(fileURL: uploadURL, mimeType: uploadMimeType, filename: uploadFilename, extraParts: extraParts, query: query)
+                return .uploaded(result)
             }
         }
 
-        // The editor was torn down (or the client disconnected) while we processed.
-        // Don't start an outbound upload whose response nobody will read — it would
-        // create an attachment neither GutenbergKit nor the host knows to clean up.
-        // Checking here rather than relying on the HTTP client to notice cancellation
-        // keeps this true for a host-injected `URLSessionProtocol` that doesn't.
-        try Task.checkCancellation()
-
-        // Step 2: deliver. An uploader owns delivery on the host's own stack and
-        // returns the finished attachment JSON (or throws); GutenbergKit relays that
-        // as a success and never runs its own recovery behind it. Otherwise the
-        // internal media client delivers to the configured site.
-        if let uploader = context.uploader {
-            // Hand the host the editor's non-file fields (e.g. `post`) and query too,
-            // so its own POST can reproduce a native upload — otherwise the attachment
-            // is created unattached and `?_embed` is lost.
-            let fields = try await formFields(from: extraParts)
-            let upload = MediaUpload(
-                fileURL: uploadURL, mimeType: uploadMimeType, filename: uploadFilename,
-                fields: fields, query: query
-            )
-            let body = try await uploader.upload(upload)
-            return .uploaded(MediaUploadResponse(statusCode: 201, body: body))
-        } else {
-            // Unmodified — forward the original request body directly, skipping
-            // multipart re-encoding.
-            if case .original = processed {
-                return .passthrough
+        /// Decodes the editor's non-file form parts (e.g. `post`, additionalData) into an
+        /// ordered list of name/value pairs for a host uploader, so it can send them on its
+        /// own `POST /wp/v2/media`. A list, not a dictionary, so repeated field names survive
+        /// in order. Values are WordPress form fields — UTF-8 text.
+        private static func formFields(from parts: [MultipartPart]) async throws -> [(name: String, value: String)] {
+            var fields: [(name: String, value: String)] = []
+            for part in parts {
+                fields.append((name: part.name, value: String(decoding: try await part.body.data, as: UTF8.self)))
             }
-            let result = try await context.internalClient.upload(fileURL: uploadURL, mimeType: uploadMimeType, filename: uploadFilename, extraParts: extraParts, query: query)
-            return .uploaded(result)
+            return fields
         }
-    }
-
-    /// Decodes the editor's non-file form parts (e.g. `post`, additionalData) into an
-    /// ordered list of name/value pairs for a host uploader, so it can send them on its
-    /// own `POST /wp/v2/media`. A list, not a dictionary, so repeated field names survive
-    /// in order. Values are WordPress form fields — UTF-8 text.
-    private static func formFields(from parts: [MultipartPart]) async throws -> [(name: String, value: String)] {
-        var fields: [(name: String, value: String)] = []
-        for part in parts {
-            fields.append((name: part.name, value: String(decoding: try await part.body.data, as: UTF8.self)))
-        }
-        return fields
     }
 
     private static func errorResponse(status: Int, message: String) -> HTTPResponse {
@@ -496,33 +517,6 @@ enum UploadError: Error, LocalizedError {
         case .streamWriteFailed: "Failed to write upload to disk"
         }
     }
-}
-
-// MARK: - Upload Context
-
-/// Container for the media processor, uploader, and internal media client, captured by
-/// the HTTPServer handler closure and read on each request.
-///
-/// Everything here is held **strongly**, so a handler that admitted a file for
-/// processing will process it, and one that gated on an uploader will deliver through
-/// it — the reads can't disagree within a request, and an in-flight upload keeps the
-/// host's handlers alive until it unwinds. This matches Android, which holds its
-/// `processor`/`uploader` as plain `val`s for the same reason.
-///
-/// Strong is safe because `EditorViewController` owns `mediaProcessor` /
-/// `mediaUploader` strongly too. A host object that retains the view controller back
-/// already forms `EditorViewController → mediaUploader → EditorViewController`, a
-/// cycle this container can neither create nor prevent — so holding weak here bought
-/// no leak protection, only the risk of a reference vanishing mid-request. (It *was*
-/// load-bearing when the view controller held its delegate `weak` and this was the
-/// only strong path; that changed when those properties became strong.)
-///
-/// A `struct`, so it is implicitly `Sendable`: `MediaProcessor` and `MediaUploader`
-/// are `Sendable` protocols and `InternalMediaClient` is `@unchecked Sendable`.
-private struct UploadContext: Sendable {
-    let processor: (any MediaProcessor)?
-    let uploader: (any MediaUploader)?
-    let internalClient: InternalMediaClient
 }
 
 // MARK: - Default Media Uploader

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -391,7 +391,22 @@ final class MediaUploadServer: Sendable {
         /// Decodes the editor's non-file form parts (e.g. `post`, additionalData) into an
         /// ordered list of name/value pairs for a host uploader, so it can send them on its
         /// own `POST /wp/v2/media`. A list, not a dictionary, so repeated field names survive
-        /// in order. Values are WordPress form fields — UTF-8 text.
+        /// in order.
+        ///
+        /// The UTF-8 decode is lossless here because of an invariant worth stating, since
+        /// nothing in the type system enforces it: **the only client is the editor's
+        /// browser `FormData`.** The server binds to loopback behind a per-session token,
+        /// so nothing else can reach it; a `FormData` string value is a `USVString`, which
+        /// the browser has already made well-formed at `append` time; and its only way to
+        /// carry arbitrary bytes is a Blob, which always gets a filename and is therefore
+        /// filtered out of `extraParts` by `handleUpload`. Valid UTF-8 — including emoji
+        /// and any non-Latin script — round-trips exactly, so real captions and titles are
+        /// unaffected.
+        ///
+        /// If that ever stops holding, this decode starts substituting U+FFFD *and* the two
+        /// platforms disagree about how: for `ED A0 80`, Swift's maximal-subpart rule yields
+        /// three replacement characters where Java's decoder yields one. `MediaUploadServerTests`
+        /// pins the partition that keeps binary parts out of here.
         private static func formFields(from parts: [MultipartPart]) async throws -> [MediaUploadField] {
             var fields: [MediaUploadField] = []
             for part in parts {
@@ -674,9 +689,16 @@ class InternalMediaClient: @unchecked Sendable {
     ) throws -> (InputStream, Int) {
         // Serialize the non-file parts (post, additionalData) into the preamble
         // ahead of the streamed file. They are small, so keeping them in memory is
-        // fine; `contentLength` counts them via `preamble.count`. Field values are
-        // appended as raw bytes (not through String) so a non-UTF-8 value is
-        // forwarded verbatim rather than coerced to empty.
+        // fine; `contentLength` counts them via `preamble.count`.
+        //
+        // Field values are appended as raw bytes rather than round-tripped through
+        // `String`. This is not because malformed values are expected — they can't
+        // reach here; see the invariant on `formFields`. It is because the failable
+        // `String(data:encoding:)` returns nil on invalid UTF-8, and the obvious
+        // `?? ""` behind it would silently drop a whole field's value. Appending the
+        // bytes keeps this re-encode byte-identical to the passthrough it stands in
+        // for, so a user's upload doesn't change shape just because a processor
+        // resized the image.
         var preamble = Data()
         for field in extraFields {
             preamble.append(Data("--\(boundary)\r\n".utf8))

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -190,12 +190,18 @@ final class MediaUploadServer: Sendable {
         return relayResponse(response)
     }
 
-    /// Relays WordPress's exact status and body to the editor so it sees the same
-    /// attachment object (or error) as a direct upload.
+    /// Relays WordPress's exact status, body, and relayable headers to the editor
+    /// so it sees the same attachment object (or error) as a direct upload.
+    ///
+    /// The headers matter for recovery: `x-wp-upload-attachment-id` is what lets
+    /// the editor retry `post-process` for an upload whose metadata generation
+    /// fataled server-side, rather than surfacing a permanent failure and
+    /// leaving an orphaned attachment behind.
     private static func relayResponse(_ response: MediaUploadResponse) -> HTTPResponse {
         HTTPResponse(
             status: response.statusCode,
-            headers: [("Content-Type", "application/json")],
+            headers: [("Content-Type", "application/json")]
+                + response.headers.map { ($0.key, $0.value) },
             body: response.body
         )
     }
@@ -517,7 +523,30 @@ class DefaultMediaUploader: @unchecked Sendable {
         // the editor sees WordPress's real status and error body, exactly as a
         // direct upload would. `performRaw` does not throw on non-2xx.
         let (data, response) = try await httpClient.performRaw(request)
-        return MediaUploadResponse(statusCode: response.statusCode, body: data)
+        return MediaUploadResponse(
+            statusCode: response.statusCode,
+            body: data,
+            headers: Self.relayableHeaders(from: response)
+        )
+    }
+
+    /// The upstream headers worth relaying to the editor.
+    ///
+    /// Deliberately an allowlist rather than a filtered passthrough: the body is
+    /// re-sent with a recomputed length, so relaying upstream entity or
+    /// transport headers wholesale would risk contradicting what the server
+    /// actually sends.
+    private static let relayableHeaderNames = ["x-wp-upload-attachment-id"]
+
+    /// Picks the headers to relay out of an upstream response.
+    private static func relayableHeaders(from response: HTTPURLResponse) -> [String: String] {
+        var headers: [String: String] = [:]
+        for name in relayableHeaderNames {
+            if let value = response.value(forHTTPHeaderField: name) {
+                headers[name] = value
+            }
+        }
+        return headers
     }
 
     // MARK: - Streaming Multipart Body

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -29,12 +29,14 @@ final class MediaUploadServer: Sendable {
     /// Creates and starts a new upload server.
     ///
     /// - Parameters:
-    ///   - uploadDelegate: Optional delegate for customizing file processing and upload.
-    ///   - defaultUploader: Fallback uploader used when no delegate provides `uploadFile`.
+    ///   - processor: Optional processor for transforming files before upload.
+    ///   - uploader: Optional uploader that takes over delivery on the host's own stack.
+    ///   - defaultUploader: Delivers to the configured site when no uploader is set.
     ///   - maxRequestBodySize: The maximum allowed request body size in bytes.
     ///     Requests exceeding this limit receive a 413 response. Defaults to 4 GB.
     static func start(
-        uploadDelegate: (any MediaUploadDelegate)? = nil,
+        processor: (any MediaProcessor)? = nil,
+        uploader: (any MediaUploader)? = nil,
         defaultUploader: DefaultMediaUploader? = nil,
         maxRequestBodySize: Int64 = HTTPRequestParser.defaultMaxBodySize
     ) async throws -> MediaUploadServer {
@@ -45,7 +47,7 @@ final class MediaUploadServer: Sendable {
             cleanOrphanedUploads()
         }
 
-        let context = UploadContext(uploadDelegate: uploadDelegate, defaultUploader: defaultUploader)
+        let context = UploadContext(processor: processor, uploader: uploader, defaultUploader: defaultUploader)
 
         // A generous ceiling for receiving the upload body. The body read is
         // primarily bounded by the per-read idle timeout (which reaps a stalled
@@ -126,11 +128,13 @@ final class MediaUploadServer: Sendable {
         let filename = filePart.filename ?? "upload"
         let mimeType = filePart.contentType
 
-        // Ask the delegate — from metadata alone — whether it will touch a file
-        // like this. If not, forward the original upload to WordPress directly,
-        // skipping a full temp-file copy of a file the delegate won't process or
-        // upload (e.g. a video handed to an image-only delegate).
-        guard context.uploadDelegate?.handlesFile(ofType: mimeType, named: filename) ?? false else {
+        // Materialize a temp file only if someone will touch it: a processor that
+        // claims this file, or an uploader (which always delivers the file itself).
+        // If GutenbergKit will deliver (no uploader) and no processor wants the
+        // file, forward the original request body directly, skipping a temp copy of
+        // a file nobody will process (e.g. a video handed to an image-only processor).
+        let processorWantsFile = context.processor?.handlesFile(ofType: mimeType, named: filename) ?? false
+        if context.uploader == nil, !processorWantsFile {
             do {
                 return try await passthroughResponse(request, query: query, context: context)
             } catch {
@@ -180,9 +184,9 @@ final class MediaUploadServer: Sendable {
     }
 
     /// Forwards the original request body to WordPress unchanged (no multipart
-    /// re-encoding) and relays the response. Used when the delegate won't touch
-    /// the file — it declined by metadata (`handlesFile` returned false) or
-    /// `processFile` returned `.original`.
+    /// re-encoding) and relays the response. Used on the no-uploader path when the
+    /// processor won't touch the file — it declined by metadata (`handlesFile`
+    /// returned false) or `processFile` returned `.original`.
     private static func passthroughResponse(
         _ request: HTTPServer.Request, query: String, context: UploadContext
     ) async throws -> HTTPResponse {
@@ -208,25 +212,30 @@ final class MediaUploadServer: Sendable {
         return id
     }
 
-    /// Relays the editor's orphan cleanup.
+    /// Relays a media deletion.
     ///
-    /// Core's media upload middleware deletes the attachment when every
-    /// `post-process` retry fails. A cross-origin editor cannot issue that
-    /// request directly — api-fetch tunnels `DELETE` as a `POST` carrying
-    /// `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
-    /// browser blocks it at preflight. Relaying it here lets the cleanup run.
+    /// The editor deletes an attachment when the user removes it, and core deletes
+    /// an upload's orphan when every `post-process` retry fails. A cross-origin
+    /// editor cannot issue `DELETE` directly — api-fetch tunnels it as a `POST`
+    /// carrying `X-HTTP-Method-Override`, which core's CORS allow-list omits, so the
+    /// browser blocks it at preflight; relaying it here lets the deletion run.
     ///
-    /// Offers the deletion to the delegate first, as ``handleUpload(_:context:)``
-    /// does, so a host that uploaded the attachment itself deletes it from the
-    /// same place.
+    /// Every attachment lives on the configured site — even one a host uploader
+    /// delivered — so its deletion is relayed to the default uploader there. See
+    /// the accepted-risk note in the body.
     private static func handleMediaDelete(
         _ attachmentId: String, query: String, context: UploadContext
     ) async -> HTTPResponse {
         do {
-            if let response = try await context.uploadDelegate?.deleteFile(attachmentId: attachmentId) {
-                return relayResponse(response)
-            }
-
+            // Relay to the default uploader (the configured site) — every attachment
+            // lives there, even one a host uploader delivered. Core issues this only
+            // as orphan cleanup after failed recovery, but the relay can't tell that
+            // from any other DELETE the WebView sends: a compromised editor script
+            // holding the loopback token could force-delete arbitrary media on the
+            // configured site. Accepted risk — such a script already has broad write
+            // access, and a server-side compromise (a malicious plugin) deletes media
+            // directly without the editor, so scoping this with a per-session ledger
+            // buys little for the cost.
             guard let defaultUploader = context.defaultUploader else {
                 return errorResponse(status: 500, message: UploadError.noUploader.localizedDescription)
             }
@@ -274,13 +283,13 @@ final class MediaUploadServer: Sendable {
 
     // MARK: - Delegate Pipeline
 
-    /// Result of the delegate processing + upload pipeline.
+    /// Result of the process + deliver pipeline.
     private enum UploadResult {
-        /// The delegate (or default uploader) completed the upload; carries the
-        /// raw WordPress response to relay.
+        /// The uploader or default uploader completed the upload; carries the
+        /// response to relay.
         case uploaded(MediaUploadResponse)
-        /// The delegate didn't modify the file and `uploadFile` returned nil.
-        /// The caller should forward the original request body to WordPress.
+        /// No uploader is set and the processor left the file unmodified, so the
+        /// caller should forward the original request body to the configured site.
         case passthrough
     }
 
@@ -288,16 +297,16 @@ final class MediaUploadServer: Sendable {
         fileURL: URL, mimeType: String, filename: String,
         extraParts: [MultipartPart], query: String, context: UploadContext
     ) async throws -> UploadResult {
-        // Step 1: Process (resize, transcode, etc.)
+        // Step 1: transform (resize, transcode, …) if a processor claims the file.
         let processed: ProcessedProxyFile
-        if let delegate = context.uploadDelegate {
-            processed = try await delegate.processFile(at: fileURL, mimeType: mimeType, filename: filename)
+        if let processor = context.processor, processor.handlesFile(ofType: mimeType, named: filename) {
+            processed = try await processor.processFile(at: fileURL, mimeType: mimeType, filename: filename)
         } else {
             processed = .original
         }
 
         // Resolve the file to upload and its metadata. `.processed` uses the
-        // delegate's values verbatim, so a format change is reported to WordPress.
+        // processor's values verbatim, so a format change is reported to WordPress.
         let uploadURL: URL
         let uploadMimeType: String
         let uploadFilename: String
@@ -312,7 +321,7 @@ final class MediaUploadServer: Sendable {
             uploadFilename = processedFilename
         }
 
-        // The processed file (if the delegate produced a new one) is ours to
+        // The processed file (if the processor produced a new one) is ours to
         // clean up — on success it has been uploaded, on failure it is abandoned.
         // Cleaning up here rather than in the caller covers the throw paths too.
         defer {
@@ -321,10 +330,13 @@ final class MediaUploadServer: Sendable {
             }
         }
 
-        // Step 2: Upload to remote WordPress
-        if let delegate = context.uploadDelegate,
-           let result = try await delegate.uploadFile(at: uploadURL, mimeType: uploadMimeType, filename: uploadFilename) {
-            return .uploaded(result)
+        // Step 2: deliver. An uploader owns delivery on the host's own stack and
+        // returns the finished attachment JSON (or throws); GutenbergKit relays that
+        // as a success and never runs its own recovery behind it. Otherwise the
+        // default uploader delivers to the configured site.
+        if let uploader = context.uploader {
+            let body = try await uploader.upload(fileAt: uploadURL, mimeType: uploadMimeType, filename: uploadFilename)
+            return .uploaded(MediaUploadResponse(statusCode: 201, body: body))
         } else if let defaultUploader = context.defaultUploader {
             // Unmodified — forward the original request body directly, skipping
             // multipart re-encoding.
@@ -460,24 +472,26 @@ enum UploadError: Error, LocalizedError {
 
 // MARK: - Upload Context
 
-/// Container for the upload delegate and default uploader, captured by the
-/// HTTPServer handler closure and re-read on each request.
+/// Container for the media processor, uploader, and default uploader, captured by
+/// the HTTPServer handler closure and re-read on each request.
 ///
-/// The delegate is held **weakly**. `EditorViewController.mediaUploadDelegate` is
-/// declared `weak` — the host owns the delegate's lifetime. Capturing it strongly
-/// here would silently defeat that contract and, worse, risk a retain cycle
-/// (`EditorViewController → uploadServer → HTTPServer → handler → UploadContext →
-/// delegate → EditorViewController`) that would keep the view controller — and
-/// therefore the server — alive forever, so `deinit` would never stop it.
+/// The processor and uploader are held **weakly** — the host owns their lifetime
+/// (`EditorViewController.mediaProcessor` / `.mediaUploader` are `weak`). Capturing
+/// them strongly here would risk a retain cycle (`EditorViewController →
+/// uploadServer → HTTPServer → handler → UploadContext → host object →
+/// EditorViewController`) that would keep the view controller — and therefore the
+/// server — alive forever, so `deinit` would never stop it.
 ///
-/// `@unchecked Sendable`: `uploadDelegate` is assigned once at init and only read
-/// afterwards; weak-reference reads are thread-safe at runtime.
+/// `@unchecked Sendable`: `processor`/`uploader` are assigned once at init and only
+/// read afterwards; weak-reference reads are thread-safe at runtime.
 private final class UploadContext: @unchecked Sendable {
-    weak var uploadDelegate: (any MediaUploadDelegate)?
+    weak var processor: (any MediaProcessor)?
+    weak var uploader: (any MediaUploader)?
     let defaultUploader: DefaultMediaUploader?
 
-    init(uploadDelegate: (any MediaUploadDelegate)?, defaultUploader: DefaultMediaUploader?) {
-        self.uploadDelegate = uploadDelegate
+    init(processor: (any MediaProcessor)?, uploader: (any MediaUploader)?, defaultUploader: DefaultMediaUploader?) {
+        self.processor = processor
+        self.uploader = uploader
         self.defaultUploader = defaultUploader
     }
 }

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -244,10 +244,15 @@ final class MediaUploadServer: Sendable {
     /// the editor retry `post-process` for an upload whose metadata generation
     /// fataled server-side, rather than surfacing a permanent failure and
     /// leaving an orphaned attachment behind.
+    ///
+    /// The response's own `Content-Type` wins over the JSON default. `HTTPResponse`
+    /// serializes every header it is given, so appending the default unconditionally
+    /// would emit the name twice for a delegate that sets it.
     private static func relayResponse(_ response: MediaUploadResponse) -> HTTPResponse {
-        HTTPResponse(
+        let hasContentType = response.headers.keys.contains { $0.lowercased() == "content-type" }
+        return HTTPResponse(
             status: response.statusCode,
-            headers: [("Content-Type", "application/json")]
+            headers: (hasContentType ? [] : [("Content-Type", "application/json")])
                 + response.headers.map { ($0.key, $0.value) },
             body: response.body
         )

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -31,13 +31,14 @@ final class MediaUploadServer: Sendable {
     /// - Parameters:
     ///   - processor: Optional processor for transforming files before upload.
     ///   - uploader: Optional uploader that takes over delivery on the host's own stack.
-    ///   - defaultUploader: Delivers to the configured site when no uploader is set.
+    ///   - internalClient: GutenbergKit's client for the configured site — delivers
+    ///     GutenbergKit's own uploads (when no uploader is set) and relays every delete.
     ///   - maxRequestBodySize: The maximum allowed request body size in bytes.
     ///     Requests exceeding this limit receive a 413 response. Defaults to 4 GB.
     static func start(
         processor: (any MediaProcessor)? = nil,
         uploader: (any MediaUploader)? = nil,
-        defaultUploader: DefaultMediaUploader? = nil,
+        internalClient: InternalMediaClient,
         maxRequestBodySize: Int64 = HTTPRequestParser.defaultMaxBodySize
     ) async throws -> MediaUploadServer {
         // Sweep temp files orphaned by a prior crash, off the editor-startup
@@ -47,7 +48,7 @@ final class MediaUploadServer: Sendable {
             cleanOrphanedUploads()
         }
 
-        let context = UploadContext(processor: processor, uploader: uploader, defaultUploader: defaultUploader)
+        let context = UploadContext(processor: processor, uploader: uploader, internalClient: internalClient)
 
         // A generous ceiling for receiving the upload body. The body read is
         // primarily bounded by the per-read idle timeout (which reaps a stalled
@@ -167,7 +168,8 @@ final class MediaUploadServer: Sendable {
         do {
             let uploadResult = try await processAndUpload(
                 fileURL: fileURL, mimeType: mimeType, filename: filename,
-                extraParts: extraParts, query: query, context: context
+                extraParts: extraParts, query: query,
+                processorWantsFile: processorWantsFile, context: context
             )
             switch uploadResult {
             case .uploaded(let uploaded):
@@ -192,11 +194,10 @@ final class MediaUploadServer: Sendable {
     ) async throws -> HTTPResponse {
         Logger.uploadServer.debug("Passthrough: forwarding original request body to WordPress")
         guard let body = request.parsed.body,
-              let contentType = request.parsed.header("Content-Type"),
-              let defaultUploader = context.defaultUploader else {
-            return errorResponse(status: 500, message: UploadError.noUploader.localizedDescription)
+              let contentType = request.parsed.header("Content-Type") else {
+            return errorResponse(status: 500, message: "Passthrough upload requires a request body and Content-Type")
         }
-        let response = try await defaultUploader.passthroughUpload(body: body, contentType: contentType, query: query)
+        let response = try await context.internalClient.passthroughUpload(body: body, contentType: contentType, query: query)
         return relayResponse(response)
     }
 
@@ -221,13 +222,13 @@ final class MediaUploadServer: Sendable {
     /// browser blocks it at preflight; relaying it here lets the deletion run.
     ///
     /// Every attachment lives on the configured site — even one a host uploader
-    /// delivered — so its deletion is relayed to the default uploader there. See
+    /// delivered — so its deletion is relayed to the internal media client there. See
     /// the accepted-risk note in the body.
     private static func handleMediaDelete(
         _ attachmentId: String, query: String, context: UploadContext
     ) async -> HTTPResponse {
         do {
-            // Relay to the default uploader (the configured site) — every attachment
+            // Relay to the internal media client (the configured site) — every attachment
             // lives there, even one a host uploader delivered. Core issues this only
             // as orphan cleanup after failed recovery, but the relay can't tell that
             // from any other DELETE the WebView sends: a compromised editor script
@@ -236,10 +237,7 @@ final class MediaUploadServer: Sendable {
             // access, and a server-side compromise (a malicious plugin) deletes media
             // directly without the editor, so scoping this with a per-session ledger
             // buys little for the cost.
-            guard let defaultUploader = context.defaultUploader else {
-                return errorResponse(status: 500, message: UploadError.noUploader.localizedDescription)
-            }
-            let response = try await defaultUploader.deleteMedia(attachmentId: attachmentId, query: query)
+            let response = try await context.internalClient.deleteMedia(attachmentId: attachmentId, query: query)
             return relayResponse(response)
         } catch {
             return uploadErrorResponse(error)
@@ -254,15 +252,14 @@ final class MediaUploadServer: Sendable {
     /// fataled server-side, rather than surfacing a permanent failure and
     /// leaving an orphaned attachment behind.
     ///
-    /// The response's own `Content-Type` wins over the JSON default. `HTTPResponse`
-    /// serializes every header it is given, so appending the default unconditionally
-    /// would emit the name twice for a delegate that sets it.
+    /// The relayed body is always WordPress REST JSON — an attachment, or a
+    /// `{code, message, data}` error — so the response is always `application/json`.
+    /// The relayed headers are a content-type-free allowlist (`relayableHeaderNames`),
+    /// so prepending the JSON default never collides with them.
     private static func relayResponse(_ response: MediaUploadResponse) -> HTTPResponse {
-        let hasContentType = response.headers.keys.contains { $0.lowercased() == "content-type" }
         return HTTPResponse(
             status: response.statusCode,
-            headers: (hasContentType ? [] : [("Content-Type", "application/json")])
-                + response.headers.map { ($0.key, $0.value) },
+            headers: [("Content-Type", "application/json")] + response.headers.map { ($0.key, $0.value) },
             body: response.body
         )
     }
@@ -285,7 +282,7 @@ final class MediaUploadServer: Sendable {
 
     /// Result of the process + deliver pipeline.
     private enum UploadResult {
-        /// The uploader or default uploader completed the upload; carries the
+        /// The uploader or internal media client completed the upload; carries the
         /// response to relay.
         case uploaded(MediaUploadResponse)
         /// No uploader is set and the processor left the file unmodified, so the
@@ -295,11 +292,15 @@ final class MediaUploadServer: Sendable {
 
     private static func processAndUpload(
         fileURL: URL, mimeType: String, filename: String,
-        extraParts: [MultipartPart], query: String, context: UploadContext
+        extraParts: [MultipartPart], query: String,
+        processorWantsFile: Bool, context: UploadContext
     ) async throws -> UploadResult {
         // Step 1: transform (resize, transcode, …) if a processor claims the file.
+        // Reuse the gate's `handlesFile` decision from `handleUpload` rather than
+        // asking again — one metadata call per upload, and the admit and transform
+        // steps can't disagree.
         let processed: ProcessedProxyFile
-        if let processor = context.processor, processor.handlesFile(ofType: mimeType, named: filename) {
+        if processorWantsFile, let processor = context.processor {
             processed = try await processor.processFile(at: fileURL, mimeType: mimeType, filename: filename)
         } else {
             processed = .original
@@ -333,21 +334,38 @@ final class MediaUploadServer: Sendable {
         // Step 2: deliver. An uploader owns delivery on the host's own stack and
         // returns the finished attachment JSON (or throws); GutenbergKit relays that
         // as a success and never runs its own recovery behind it. Otherwise the
-        // default uploader delivers to the configured site.
+        // internal media client delivers to the configured site.
         if let uploader = context.uploader {
-            let body = try await uploader.upload(fileAt: uploadURL, mimeType: uploadMimeType, filename: uploadFilename)
+            // Hand the host the editor's non-file fields (e.g. `post`) and query too,
+            // so its own POST can reproduce a native upload — otherwise the attachment
+            // is created unattached and `?_embed` is lost.
+            let fields = try await formFields(from: extraParts)
+            let upload = MediaUpload(
+                fileURL: uploadURL, mimeType: uploadMimeType, filename: uploadFilename,
+                fields: fields, query: query
+            )
+            let body = try await uploader.upload(upload)
             return .uploaded(MediaUploadResponse(statusCode: 201, body: body))
-        } else if let defaultUploader = context.defaultUploader {
+        } else {
             // Unmodified — forward the original request body directly, skipping
             // multipart re-encoding.
             if case .original = processed {
                 return .passthrough
             }
-            let result = try await defaultUploader.upload(fileURL: uploadURL, mimeType: uploadMimeType, filename: uploadFilename, extraParts: extraParts, query: query)
+            let result = try await context.internalClient.upload(fileURL: uploadURL, mimeType: uploadMimeType, filename: uploadFilename, extraParts: extraParts, query: query)
             return .uploaded(result)
-        } else {
-            throw UploadError.noUploader
         }
+    }
+
+    /// Decodes the editor's non-file form parts (e.g. `post`, additionalData) into
+    /// name→value pairs for a host uploader, so it can send them on its own
+    /// `POST /wp/v2/media`. Values are WordPress form fields — UTF-8 text.
+    private static func formFields(from parts: [MultipartPart]) async throws -> [String: String] {
+        var fields: [String: String] = [:]
+        for part in parts {
+            fields[part.name] = String(decoding: try await part.body.data, as: UTF8.self)
+        }
+        return fields
     }
 
     private static func errorResponse(status: Int, message: String) -> HTTPResponse {
@@ -457,13 +475,11 @@ final class MediaUploadServer: Sendable {
 
 /// Errors from the native media upload pipeline.
 enum UploadError: Error, LocalizedError {
-    case noUploader
     case streamReadFailed
     case streamWriteFailed
 
     var errorDescription: String? {
         switch self {
-        case .noUploader: "No upload delegate or default uploader configured"
         case .streamReadFailed: "Failed to read upload stream"
         case .streamWriteFailed: "Failed to write upload to disk"
         }
@@ -472,34 +488,36 @@ enum UploadError: Error, LocalizedError {
 
 // MARK: - Upload Context
 
-/// Container for the media processor, uploader, and default uploader, captured by
+/// Container for the media processor, uploader, and internal media client, captured by
 /// the HTTPServer handler closure and re-read on each request.
 ///
-/// The processor and uploader are held **weakly** — the host owns their lifetime
-/// (`EditorViewController.mediaProcessor` / `.mediaUploader` are `weak`). Capturing
-/// them strongly here would risk a retain cycle (`EditorViewController →
+/// The processor and uploader are held **weakly**. `EditorViewController` owns them
+/// for its lifetime — its `mediaProcessor` / `.mediaUploader` are strong — and owns
+/// this server too, so they stay alive for every request. The weak reference here is
+/// solely to break the cycle the server would otherwise close (`EditorViewController →
 /// uploadServer → HTTPServer → handler → UploadContext → host object →
-/// EditorViewController`) that would keep the view controller — and therefore the
-/// server — alive forever, so `deinit` would never stop it.
+/// EditorViewController`) whenever the host object retains the view controller:
+/// capturing strongly would keep the view controller — and therefore the server —
+/// alive forever, so `deinit` would never stop it.
 ///
 /// `@unchecked Sendable`: `processor`/`uploader` are assigned once at init and only
 /// read afterwards; weak-reference reads are thread-safe at runtime.
 private final class UploadContext: @unchecked Sendable {
     weak var processor: (any MediaProcessor)?
     weak var uploader: (any MediaUploader)?
-    let defaultUploader: DefaultMediaUploader?
+    let internalClient: InternalMediaClient
 
-    init(processor: (any MediaProcessor)?, uploader: (any MediaUploader)?, defaultUploader: DefaultMediaUploader?) {
+    init(processor: (any MediaProcessor)?, uploader: (any MediaUploader)?, internalClient: InternalMediaClient) {
         self.processor = processor
         self.uploader = uploader
-        self.defaultUploader = defaultUploader
+        self.internalClient = internalClient
     }
 }
 
 // MARK: - Default Media Uploader
 
 /// Uploads files to the WordPress REST API using site credentials from EditorConfiguration.
-class DefaultMediaUploader: @unchecked Sendable {
+class InternalMediaClient: @unchecked Sendable {
     private let httpClient: EditorHTTPClientProtocol
     private let siteApiRoot: URL
     private let siteApiNamespace: String?

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaUploadServer.swift
@@ -192,6 +192,10 @@ final class MediaUploadServer: Sendable {
     private static func passthroughResponse(
         _ request: HTTPServer.Request, query: String, context: UploadContext
     ) async throws -> HTTPResponse {
+        // As in `processAndUpload`: don't put bytes on the wire for a torn-down
+        // editor, regardless of whether the HTTP client honors cancellation.
+        try Task.checkCancellation()
+
         Logger.uploadServer.debug("Passthrough: forwarding original request body to WordPress")
         guard let body = request.parsed.body,
               let contentType = request.parsed.header("Content-Type") else {
@@ -330,6 +334,13 @@ final class MediaUploadServer: Sendable {
                 try? FileManager.default.removeItem(at: uploadURL)
             }
         }
+
+        // The editor was torn down (or the client disconnected) while we processed.
+        // Don't start an outbound upload whose response nobody will read — it would
+        // create an attachment neither GutenbergKit nor the host knows to clean up.
+        // Checking here rather than relying on the HTTP client to notice cancellation
+        // keeps this true for a host-injected `URLSessionProtocol` that doesn't.
+        try Task.checkCancellation()
 
         // Step 2: deliver. An uploader owns delivery on the host's own stack and
         // returns the finished attachment JSON (or throws); GutenbergKit relays that

--- a/ios/Sources/GutenbergKitHTTP/CORSPolicy.swift
+++ b/ios/Sources/GutenbergKitHTTP/CORSPolicy.swift
@@ -33,6 +33,12 @@ public enum CORSPolicy: Sendable {
                 ("Access-Control-Allow-Origin", "*"),
                 ("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS"),
                 ("Access-Control-Allow-Headers", "Authorization, Relay-Authorization, Content-Type"),
+                // Only CORS-safelisted response headers are readable
+                // cross-origin by default. The editor needs to read
+                // `x-wp-upload-attachment-id` off a relayed media upload
+                // response to retry `post-process` and clean up an orphaned
+                // attachment, so it has to be exposed explicitly.
+                ("Access-Control-Expose-Headers", "x-wp-upload-attachment-id"),
                 ("Access-Control-Max-Age", "86400"),
             ]
         }

--- a/ios/Sources/GutenbergKitHTTP/HTTPRequestHandler.swift
+++ b/ios/Sources/GutenbergKitHTTP/HTTPRequestHandler.swift
@@ -1,0 +1,35 @@
+#if canImport(Network)
+
+import Foundation
+
+/// Serves requests for an ``HTTPServer``.
+///
+/// The closure form of
+/// ``HTTPServer/start(name:port:listenOnAllInterfaces:requiresAuthentication:maxRequestBodySize:maxConnections:readTimeout:bodyReadTimeout:idleTimeout:startTimeout:cors:delegate:handler:)-(_,_,_,_,_,_,_,_,_,_,_,_,@escaping@Sendable(HTTPServer.Request)async->HTTPResponse)``
+/// is the right tool for a handler that needs no state. Conform to this instead when
+/// the handler has dependencies: they become stored properties, and the request
+/// methods become ordinary instance methods rather than statics threading a context
+/// parameter through every call.
+///
+/// ## Lifetimes
+///
+/// The server retains its handler for its lifetime, and the handler must not be the
+/// object that owns the server: `owner → HTTPServer → handler → owner` is a cycle,
+/// so the owner's `deinit` would never run and `stop()` would never be called.
+///
+/// This protocol is deliberately **not** `AnyObject`-constrained, because the
+/// straightforward way to avoid that is a `struct` handler holding the dependencies
+/// it needs. A value type cannot participate in a reference cycle at all, so the
+/// question doesn't arise. A `final class` conformer is fine too — just keep it a
+/// leaf, the same discipline ``HTTPServerDelegate`` documents.
+public protocol HTTPRequestHandler: Sendable {
+    /// The response for a request the server has parsed and authenticated.
+    ///
+    /// Called once per request, concurrently across connections — hence `Sendable`.
+    /// Cancellation is cooperative: the server cancels this task when the client
+    /// disconnects or the server stops, and discards whatever a cancelled task
+    /// returns, so check `Task.isCancelled` before any side effect you can't undo.
+    func handle(_ request: HTTPServer.Request) async -> HTTPResponse
+}
+
+#endif // canImport(Network)

--- a/ios/Sources/GutenbergKitHTTP/HTTPServer.swift
+++ b/ios/Sources/GutenbergKitHTTP/HTTPServer.swift
@@ -277,6 +277,46 @@ public final class HTTPServer: Sendable {
         }
     }
 
+    /// Starts a server that serves requests from an ``HTTPRequestHandler`` object
+    /// rather than a closure.
+    ///
+    /// Everything else behaves identically — this forwards to the closure form. Reach
+    /// for it when the handler has dependencies to hold: a `struct` conformer stores
+    /// them and serves from instance methods, instead of statics threading a context
+    /// parameter through every call. See ``HTTPRequestHandler`` for the (short)
+    /// lifetime rules.
+    public static func start(
+        name: String,
+        port: UInt16? = nil,
+        listenOnAllInterfaces: Bool = false,
+        requiresAuthentication: Bool = true,
+        maxRequestBodySize: Int64 = HTTPRequestParser.defaultMaxBodySize,
+        maxConnections: Int = HTTPServer.defaultMaxConnections,
+        readTimeout: Duration = HTTPServer.defaultReadTimeout,
+        bodyReadTimeout: Duration? = nil,
+        idleTimeout: Duration = HTTPServer.defaultIdleTimeout,
+        startTimeout: Duration = HTTPServer.defaultStartTimeout,
+        cors: CORSPolicy = .none,
+        delegate: HTTPServerDelegate? = nil,
+        handler: some HTTPRequestHandler
+    ) async throws -> HTTPServer {
+        try await start(
+            name: name,
+            port: port,
+            listenOnAllInterfaces: listenOnAllInterfaces,
+            requiresAuthentication: requiresAuthentication,
+            maxRequestBodySize: maxRequestBodySize,
+            maxConnections: maxConnections,
+            readTimeout: readTimeout,
+            bodyReadTimeout: bodyReadTimeout,
+            idleTimeout: idleTimeout,
+            startTimeout: startTimeout,
+            cors: cors,
+            delegate: delegate,
+            handler: { await handler.handle($0) }
+        )
+    }
+
     /// Races `operation` against `timeout`, throwing ``HTTPServerError/startTimeout``
     /// if the timeout wins. Used to bound the wait for the listener to become ready
     /// so a caller — such as the editor load awaiting the upload server's bind —

--- a/ios/Sources/GutenbergKitHTTP/README.md
+++ b/ios/Sources/GutenbergKitHTTP/README.md
@@ -46,6 +46,24 @@ server.stop()
 
 Pass `nil` (or omit `port`) to let the system assign an available port — useful for tests or when running multiple servers.
 
+#### Handlers with state
+
+A closure is right for a handler that needs no state. When the handler has dependencies, conform a type to `HTTPRequestHandler` and pass it as `handler:` instead — the dependencies become stored properties and the request logic becomes instance methods, rather than statics threading a context parameter through every call.
+
+```swift
+struct MediaHandler: HTTPRequestHandler {
+    let uploader: Uploader
+
+    func handle(_ request: HTTPServer.Request) async -> HTTPResponse {
+        await uploader.upload(request.parsed.body)
+    }
+}
+
+let server = try await HTTPServer.start(name: "media", handler: MediaHandler(uploader: uploader))
+```
+
+The server retains its handler, so the handler must not be the object that owns the server — `owner → HTTPServer → handler → owner` is a cycle, and the owner's `deinit` would never run. `HTTPRequestHandler` is deliberately not `AnyObject`-constrained so a `struct` conformer sidesteps this entirely; a `final class` works too, as long as it stays a leaf.
+
 When `requiresAuthentication` is enabled (the default), each request must include a `Proxy-Authorization: Bearer <token>` header carrying the server's randomly-generated token. The server uses `Proxy-Authorization` per RFC 9110 §11.7.1 rather than `Authorization`, so the client's `Authorization` header remains available for upstream credentials (e.g. HTTP Basic auth to the remote server). Unauthenticated requests receive a `407 Proxy Authentication Required` response with a `Proxy-Authenticate: Bearer` challenge header.
 
 ### Proxying via URLSession

--- a/ios/Tests/GutenbergKitHTTPTests/HTTPServerStartTests.swift
+++ b/ios/Tests/GutenbergKitHTTPTests/HTTPServerStartTests.swift
@@ -38,6 +38,35 @@ struct HTTPServerStartTests {
         // rather than suspending its caller indefinitely.
         #expect(elapsed < .seconds(5))
     }
+
+    @Test("serves requests from an HTTPRequestHandler object, carrying its state")
+    func servesFromRequestHandlerObject() async throws {
+        // The point of the object overload: the handler holds its dependencies as
+        // stored properties and serves from an instance method, so a consumer with
+        // state doesn't need statics threading a context through every call.
+        let server = try await HTTPServer.start(
+            name: "handler-object-test",
+            requiresAuthentication: false,
+            handler: EchoHandler(greeting: "hello from a struct")
+        )
+        defer { server.stop() }
+
+        let url = URL(string: "http://127.0.0.1:\(server.port)/anything")!
+        let (data, response) = try await URLSession.shared.data(from: url)
+
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        #expect(String(decoding: data, as: UTF8.self) == "hello from a struct")
+    }
+}
+
+/// A value-type handler — it cannot form a reference cycle back to whatever owns
+/// the server, which is why ``HTTPRequestHandler`` isn't `AnyObject`-constrained.
+private struct EchoHandler: HTTPRequestHandler {
+    let greeting: String
+
+    func handle(_ request: HTTPServer.Request) async -> HTTPResponse {
+        HTTPResponse(status: 200, body: Data(greeting.utf8))
+    }
 }
 
 #endif

--- a/ios/Tests/GutenbergKitTests/Media/EditorMediaHandlerOwnershipTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/EditorMediaHandlerOwnershipTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+@testable import GutenbergKit
+
+#if canImport(UIKit)
+
+/// The editor takes **strong** ownership of the media handlers it is given, so a host
+/// can assign one and immediately drop its own reference. These pin that ownership: if
+/// the properties regressed to `weak`, the handler would deallocate the moment the host
+/// released it and the expectations below would fail.
+///
+/// The mirror invariant — that the upload *server* holds them **weakly**, so it can't
+/// form a retain cycle back through the view controller — lives in
+/// `MediaUploadServerTests.doesNotStronglyRetainProcessor`.
+@Suite("Editor media-handler ownership")
+struct EditorMediaHandlerOwnershipTests: MakesTestFixtures {
+    static let testSiteURL = URL(string: "https://test.example.com")!
+    static let testApiRoot = URL(string: "https://test.example.com/wp-json/wp/v2")!
+
+    @MainActor
+    @Test("the editor retains its mediaProcessor after the host releases it")
+    func editorRetainsMediaProcessor() {
+        let editor = EditorViewController(configuration: makeConfiguration())
+        weak var weakProcessor: OwnershipTestProcessor?
+        do {
+            let processor = OwnershipTestProcessor()
+            weakProcessor = processor
+            editor.mediaProcessor = processor
+        }
+        withExtendedLifetime(editor) {
+            #expect(weakProcessor != nil, "the editor must own its mediaProcessor for its lifetime")
+        }
+    }
+
+    @MainActor
+    @Test("the editor retains its mediaUploader after the host releases it")
+    func editorRetainsMediaUploader() {
+        let editor = EditorViewController(configuration: makeConfiguration())
+        weak var weakUploader: OwnershipTestUploader?
+        do {
+            let uploader = OwnershipTestUploader()
+            weakUploader = uploader
+            editor.mediaUploader = uploader
+        }
+        withExtendedLifetime(editor) {
+            #expect(weakUploader != nil, "the editor must own its mediaUploader for its lifetime")
+        }
+    }
+}
+
+private final class OwnershipTestProcessor: MediaProcessor, @unchecked Sendable {
+    func handlesFile(ofType mimeType: String, named filename: String) -> Bool { false }
+    func processFile(at url: URL, mimeType: String, filename: String) async throws -> ProcessedProxyFile { .original }
+}
+
+private final class OwnershipTestUploader: MediaUploader, @unchecked Sendable {
+    func upload(_ upload: MediaUpload) async throws -> Data { Data() }
+}
+
+#endif

--- a/ios/Tests/GutenbergKitTests/Media/MediaServerCredentialsTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaServerCredentialsTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+@testable import GutenbergKit
+
+/// The upload server's start policy: both a site API root and an auth header are
+/// required, and a `mediaUploader` set without them is a configuration error rather
+/// than a silent fallback.
+///
+/// These run on the **host**, which is the point of `MediaServerCredentials` being
+/// outside `EditorViewController` — that type is UIKit-gated and so untestable here,
+/// and Swift Testing's exit tests (which is how the trap below is asserted) are
+/// unavailable on iOS and the simulator. The Android counterparts live in
+/// `GutenbergViewUploadServerTest`.
+@Suite("Media server credentials")
+struct MediaServerCredentialsTests {
+    static let apiRoot = URL(string: "https://example.com/wp-json/")!
+
+    @Test("both a site API root and an auth header are usable")
+    func bothPresentIsUsable() {
+        #expect(MediaServerCredentials.areUsable(siteApiRoot: Self.apiRoot, authHeader: "Bearer t"))
+    }
+
+    @Test("an empty auth header is not usable")
+    func emptyAuthHeaderIsNotUsable() {
+        #expect(!MediaServerCredentials.areUsable(siteApiRoot: Self.apiRoot, authHeader: ""))
+    }
+
+    @Test("a relative site API root is not usable")
+    func relativeSiteApiRootIsNotUsable() {
+        // The iOS analogue of Android's `siteApiRoot.isEmpty()`. A host can't pass "",
+        // because the type is `URL` — but it can pass one with no scheme or host, which
+        // is just as unusable: every request built from it fails at the URLSession layer.
+        #expect(!MediaServerCredentials.areUsable(siteApiRoot: URL(string: "/wp-json/")!, authHeader: "Bearer t"))
+    }
+
+    @Test("a scheme without a host is not usable")
+    func schemeWithoutHostIsNotUsable() {
+        #expect(!MediaServerCredentials.areUsable(siteApiRoot: URL(string: "https:///wp-json/")!, authHeader: "Bearer t"))
+    }
+
+    @Test("a processor without credentials leaves the server down rather than trapping")
+    func processorWithoutCredentialsDoesNotTrap() {
+        // The other half of the fork: a processor only enhances GutenbergKit-owned
+        // uploads, so with nothing to deliver through there's nothing to process. The
+        // caller leaves the server down and uploads fall to the default WebView path.
+        #expect(!MediaServerCredentials.canStartServer(siteApiRoot: Self.apiRoot, authHeader: "", hasUploader: false))
+    }
+
+    @Test("credentials present means the server can start")
+    func credentialsPresentCanStart() {
+        #expect(MediaServerCredentials.canStartServer(siteApiRoot: Self.apiRoot, authHeader: "Bearer t", hasUploader: true))
+    }
+
+    @Test("an uploader without an auth header traps")
+    func uploaderWithoutAuthHeaderTraps() async {
+        await #expect(processExitsWith: .failure) {
+            _ = MediaServerCredentials.canStartServer(
+                siteApiRoot: MediaServerCredentialsTests.apiRoot, authHeader: "", hasUploader: true
+            )
+        }
+    }
+
+    @Test("an uploader without a usable site API root traps")
+    func uploaderWithoutSiteApiRootTraps() async {
+        await #expect(processExitsWith: .failure) {
+            _ = MediaServerCredentials.canStartServer(
+                siteApiRoot: URL(string: "/wp-json/")!, authHeader: "Bearer t", hasUploader: true
+            )
+        }
+    }
+}

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -593,6 +593,58 @@ struct MediaUploadServerTests {
     #expect(!mockClient.passthroughUploadCalled)
   }
 
+  @Test("keeps a filename-bearing part out of the fields handed to an uploader")
+  func filenameBearingPartsNeverReachFields() async throws {
+    // This pins the invariant that makes the UTF-8 decode in `formFields` lossless.
+    // A browser FormData can only carry arbitrary bytes as a Blob, and a Blob always
+    // gets a filename, so `handleUpload`'s partition on `filename == nil` is what keeps
+    // binary out of `fields`. Change that partition and the decode silently starts
+    // substituting U+FFFD — differently on each platform.
+    //
+    // Deliberately *not* asserted: what becomes of the second filename-bearing part.
+    // It is currently dropped rather than relayed, which is a separate open question;
+    // this test is about what must never reach `fields`.
+    let uploader = MockUploader()
+    let mockClient = MockInternalMediaClient()
+    let server = try await MediaUploadServer.start(uploader: uploader, internalClient: mockClient)
+    defer { server.stop() }
+
+    let boundary = UUID().uuidString
+    var body = Data()
+    // A plain field — no filename, so it belongs in `fields`.
+    body.append("--\(boundary)\r\n")
+    body.append("Content-Disposition: form-data; name=\"post\"\r\n\r\n")
+    body.append("123")
+    body.append("\r\n")
+    // The file.
+    body.append("--\(boundary)\r\n")
+    body.append("Content-Disposition: form-data; name=\"file\"; filename=\"photo.jpg\"\r\n")
+    body.append("Content-Type: image/jpeg\r\n\r\n")
+    body.append(Data("fake image data".utf8))
+    body.append("\r\n")
+    // A Blob-shaped sidecar: has a filename, and carries bytes that are not valid
+    // UTF-8. If the partition ever admitted this to `fields`, the lone 0xFF would
+    // become U+FFFD and the value would be silently corrupted.
+    body.append("--\(boundary)\r\n")
+    body.append("Content-Disposition: form-data; name=\"sidecar\"; filename=\"blob\"\r\n")
+    body.append("Content-Type: application/octet-stream\r\n\r\n")
+    body.append(Data([0x61, 0xFF, 0x62]))
+    body.append("\r\n--\(boundary)--\r\n")
+
+    let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
+
+    _ = try await URLSession.shared.data(for: request)
+
+    #expect(uploader.uploadCalled)
+    #expect(uploader.lastFields.map(\.name) == ["post"], "only filename-less parts belong in fields")
+    #expect(!uploader.lastFields.contains { $0.value.contains("\u{FFFD}") }, "no field value should have been lossily decoded")
+  }
+
   private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data, fields: [MediaUploadField] = []) -> Data {
     var body = Data()
     for field in fields {

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -604,6 +604,54 @@ struct DefaultMediaUploaderRelayTests {
     #expect(response.body == errorBody)
   }
 
+  @Test("relays the upload attachment ID header from a failed upload")
+  func relaysUploadAttachmentIdHeader() async throws {
+    // WordPress sets this header on an upload whose attachment row was created
+    // before metadata generation fataled. The editor reads it to retry
+    // post-process and clean up the orphan, so it must survive the relay.
+    let client = RelayStubHTTPClient(
+      statusCode: 500,
+      body: Data(#"{"code":"rest_upload_error"}"#.utf8),
+      headerFields: ["x-wp-upload-attachment-id": "4242"]
+    )
+    let uploader = DefaultMediaUploader(
+      httpClient: client, siteApiRoot: URL(string: "https://example.com/wp-json/")!)
+
+    let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "header-\(UUID().uuidString).jpg")
+    try Data("fake image".utf8).write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    let response = try await uploader.upload(
+      fileURL: tempFile, mimeType: "image/jpeg", filename: "photo.jpg", extraParts: [], query: ""
+    )
+
+    #expect(response.statusCode == 500)
+    #expect(response.headers["x-wp-upload-attachment-id"] == "4242")
+  }
+
+  @Test("omits unrelated upstream headers from the relay")
+  func omitsUnrelatedHeaders() async throws {
+    let client = RelayStubHTTPClient(
+      statusCode: 201,
+      body: Data("{}".utf8),
+      headerFields: ["X-Powered-By": "PHP/8.2", "Set-Cookie": "session=secret"]
+    )
+    let uploader = DefaultMediaUploader(
+      httpClient: client, siteApiRoot: URL(string: "https://example.com/wp-json/")!)
+
+    let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "unrelated-\(UUID().uuidString).jpg")
+    try Data("fake image".utf8).write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    let response = try await uploader.upload(
+      fileURL: tempFile, mimeType: "image/jpeg", filename: "photo.jpg", extraParts: [], query: ""
+    )
+
+    #expect(response.headers.isEmpty)
+  }
+
   @Test("carries the namespace and request query through to the media endpoint")
   func forwardsNamespaceAndQuery() async throws {
     let client = URLCapturingHTTPClient()
@@ -635,9 +683,11 @@ struct DefaultMediaUploaderRelayTests {
 private struct RelayStubHTTPClient: EditorHTTPClientProtocol {
   let statusCode: Int
   let body: Data
+  var headerFields: [String: String]?
 
   func perform(_ urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse) {
-    let response = HTTPURLResponse(url: urlRequest.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+    let response = HTTPURLResponse(
+      url: urlRequest.url!, statusCode: statusCode, httpVersion: nil, headerFields: headerFields)!
     guard (200...299).contains(statusCode) else {
       throw NSError(domain: "RelayStubHTTPClient", code: statusCode)
     }
@@ -645,7 +695,8 @@ private struct RelayStubHTTPClient: EditorHTTPClientProtocol {
   }
 
   func performRaw(_ urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse) {
-    let response = HTTPURLResponse(url: urlRequest.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+    let response = HTTPURLResponse(
+      url: urlRequest.url!, statusCode: statusCode, httpVersion: nil, headerFields: headerFields)!
     return (body, response)
   }
 

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -502,24 +502,95 @@ struct MediaUploadServerTests {
     #expect(FileManager.default.fileExists(atPath: fresh.path(percentEncoded: false)))
   }
 
-  @Test("does not strongly retain the processor (weak — preserves deinit teardown)")
-  func doesNotStronglyRetainProcessor() async throws {
+  @Test("retains the processor for the server's lifetime, and releases it on stop")
+  func retainsProcessorForServerLifetime() async throws {
     weak var weakProcessor: PassthroughProcessor?
-    let server: MediaUploadServer
+    var server: MediaUploadServer?
     do {
       let processor = PassthroughProcessor()
       weakProcessor = processor
       server = try await MediaUploadServer.start(processor: processor, internalClient: MockInternalMediaClient())
     }
+
+    // The server (via UploadContext) holds the processor *strongly*, matching both the
+    // editor's own ownership (see `EditorMediaHandlerOwnershipTests`) and Android's
+    // plain `val`. Holding it weakly here bought no leak protection — a host object
+    // that retains the editor already cycles through the editor's own strong
+    // `mediaProcessor` — and only risked the reference vanishing mid-request.
+    #expect(weakProcessor != nil, "the server must own its processor while it runs")
+
+    // …and releases it when the server goes away, so nothing outlives the editor.
+    // `stop()` cancels the NWListener, whose handlers are torn down asynchronously,
+    // so the final release lands a beat after `server = nil` — poll rather than
+    // assert instantly.
+    server?.stop()
+    server = nil
+    for _ in 0..<200 where weakProcessor != nil {
+      try await Task.sleep(for: .milliseconds(10))
+    }
+    #expect(weakProcessor == nil, "releasing the server must release the processor")
+  }
+
+  @Test("delivers through an uploader the host releases mid-request")
+  func uploaderReleasedMidRequestStillDelivers() async throws {
+    let mockClient = MockInternalMediaClient()
+    let gate = UnsafeMutableSendablePointer(false)
+    let didUpload = UnsafeMutableSendablePointer(false)
+    let processor = GatedProcessor(gate: gate)
+
+    // `holder` stands in for the *host's* own reference to its uploader, which the
+    // docs say it may drop after assigning. It's built in a nested scope so the
+    // `start` call's existential temporary dies with that scope; left in the test's
+    // own frame, that temporary keeps the uploader alive whatever the server does,
+    // and the test would pass vacuously. The uploader's record of having run lives in
+    // `didUpload`, off the object, so it survives the release either way.
+    let holder = UnsafeMutableSendablePointer<(any MediaUploader)?>(nil)
+    let server: MediaUploadServer
+    do {
+      let uploader = ReleasableUploader(didUpload: didUpload)
+      holder.value = uploader
+      server = try await MediaUploadServer.start(
+        processor: processor, uploader: uploader, internalClient: mockClient
+      )
+    }
     defer { server.stop() }
 
-    // The server (via UploadContext) holds the processor *weakly*, so once the only
-    // strong reference is released it deallocates. This is deliberately the opposite
-    // of the editor, which owns the processor *strongly* for its lifetime (see
-    // `EditorMediaHandlerOwnershipTests`): a strong capture here would reintroduce the
-    // EditorViewController → uploadServer → … → processor → EditorViewController cycle,
-    // so deinit would never fire and the server would never stop.
-    #expect(weakProcessor == nil)
+    let boundary = UUID().uuidString
+    let body = buildMultipartBody(
+      boundary: boundary, filename: "photo.jpg", mimeType: "image/jpeg",
+      data: Data("fake image data".utf8)
+    )
+    let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
+
+    let requestTask = Task { try await URLSession.shared.data(for: request) }
+
+    // Park the request inside `processFile` — past the gate that saw the uploader,
+    // before the delivery step. This is the window a real host sits in while a
+    // transcode runs.
+    while !processor.processFileStarted {
+      try await Task.sleep(for: .milliseconds(5))
+    }
+
+    // The host drops its reference mid-upload. While `UploadContext` held the uploader
+    // weakly this dropped the last one: delivery then read nil and silently uploaded
+    // through the internal client instead — breaking the "GutenbergKit out of the
+    // network entirely" contract and creating an attachment the host never learns
+    // about. The server owns the uploader now, so the request delivers as promised.
+    holder.value = nil
+
+    gate.value = true
+    let (_, response) = try await requestTask.value
+
+    let httpResponse = try #require(response as? HTTPURLResponse)
+    #expect(httpResponse.statusCode == 201)
+    #expect(didUpload.value, "the released uploader must still own delivery")
+    #expect(!mockClient.uploadCalled, "GutenbergKit must not upload behind an uploader")
+    #expect(!mockClient.passthroughUploadCalled)
   }
 
   private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data, fields: [(name: String, value: String)] = []) -> Data {
@@ -957,6 +1028,45 @@ private final class MockUploader: MediaUploader, @unchecked Sendable {
     }
     if let error { throw error }
     return uploadBody
+  }
+}
+
+/// Holds a request open inside `processFile` until the test opens `gate`, so the test
+/// can act while the request is parked between the admission gate and delivery.
+private final class GatedProcessor: MediaProcessor, @unchecked Sendable {
+  private let lock = NSLock()
+  private var _processFileStarted = false
+  private let gate: UnsafeMutableSendablePointer<Bool>
+
+  var processFileStarted: Bool { lock.withLock { _processFileStarted } }
+
+  init(gate: UnsafeMutableSendablePointer<Bool>) {
+    self.gate = gate
+  }
+
+  func handlesFile(ofType mimeType: String, named filename: String) -> Bool { true }
+
+  func processFile(at url: URL, mimeType: String, filename: String) async throws -> ProcessedProxyFile {
+    lock.withLock { _processFileStarted = true }
+    while !gate.value {
+      try await Task.sleep(for: .milliseconds(5))
+    }
+    return .original
+  }
+}
+
+/// An uploader whose record of having run lives *outside* the object, so a test can
+/// release its last strong reference mid-request and still assert that it delivered.
+private final class ReleasableUploader: MediaUploader, @unchecked Sendable {
+  private let didUpload: UnsafeMutableSendablePointer<Bool>
+
+  init(didUpload: UnsafeMutableSendablePointer<Bool>) {
+    self.didUpload = didUpload
+  }
+
+  func upload(_ upload: MediaUpload) async throws -> Data {
+    didUpload.value = true
+    return Data(#"{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}"#.utf8)
   }
 }
 

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -9,7 +9,7 @@ private let _canStartUploadServer: Bool = {
   let semaphore = DispatchSemaphore(value: 0)
   Task {
     do {
-      let server = try await MediaUploadServer.start()
+      let server = try await MediaUploadServer.start(internalClient: MockInternalMediaClient())
       server.stop()
       result.value = true
     } catch {
@@ -34,7 +34,7 @@ struct MediaUploadServerTests {
 
   @Test("starts and provides a port and token")
   func startAndStop() async throws {
-    let server = try await MediaUploadServer.start()
+    let server = try await MediaUploadServer.start(internalClient: MockInternalMediaClient())
     #expect(server.port > 0)
     #expect(!server.token.isEmpty)
     server.stop()
@@ -42,7 +42,7 @@ struct MediaUploadServerTests {
 
   @Test("rejects requests without auth token")
   func rejectsUnauthenticated() async throws {
-    let server = try await MediaUploadServer.start()
+    let server = try await MediaUploadServer.start(internalClient: MockInternalMediaClient())
     defer { server.stop() }
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
@@ -56,7 +56,7 @@ struct MediaUploadServerTests {
 
   @Test("rejects requests with wrong token")
   func rejectsWrongToken() async throws {
-    let server = try await MediaUploadServer.start()
+    let server = try await MediaUploadServer.start(internalClient: MockInternalMediaClient())
     defer { server.stop() }
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
@@ -71,7 +71,7 @@ struct MediaUploadServerTests {
 
   @Test("responds to OPTIONS preflight with CORS headers")
   func corsPreflightResponse() async throws {
-    let server = try await MediaUploadServer.start()
+    let server = try await MediaUploadServer.start(internalClient: MockInternalMediaClient())
     defer { server.stop() }
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
@@ -87,7 +87,7 @@ struct MediaUploadServerTests {
 
   @Test("returns 404 for unknown paths")
   func unknownPath() async throws {
-    let server = try await MediaUploadServer.start()
+    let server = try await MediaUploadServer.start(internalClient: MockInternalMediaClient())
     defer { server.stop() }
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/unknown")!
@@ -103,8 +103,8 @@ struct MediaUploadServerTests {
   @Test("routes /upload with a query string and relays the query")
   func uploadWithQueryString() async throws {
     let processor = PassthroughProcessor()
-    let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(processor: processor, defaultUploader: mockUploader)
+    let mockUploader = MockInternalMediaClient()
+    let server = try await MediaUploadServer.start(processor: processor, internalClient: mockUploader)
     defer { server.stop() }
 
     // `@wordpress/media-utils` uploads to `/wp/v2/media?_embed=wp:featuredmedia`,
@@ -131,14 +131,14 @@ struct MediaUploadServerTests {
     #expect(mockUploader.lastQuery == "?_embed=wp:featuredmedia")
   }
 
-  @Test("relays a deletion to the default uploader even when an uploader owns uploads")
-  func deletesGoToDefaultUploaderNotUploader() async throws {
+  @Test("relays a deletion to the internal media client even when an uploader owns uploads")
+  func deletesGoToInternalClientNotUploader() async throws {
     // An attachment lives on the configured site even when a host uploader delivered
-    // it, so its deletion goes to the default uploader — the host uploader owns
+    // it, so its deletion goes to the internal media client — the host uploader owns
     // uploads, not deletes. Held strongly: UploadContext keeps the uploader weakly.
     let uploader = MockUploader()
-    let defaultUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(uploader: uploader, defaultUploader: defaultUploader)
+    let internalClient = MockInternalMediaClient()
+    let server = try await MediaUploadServer.start(uploader: uploader, internalClient: internalClient)
     defer { server.stop() }
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/media/42?force=true")!
@@ -150,16 +150,16 @@ struct MediaUploadServerTests {
     let httpResponse = try #require(response as? HTTPURLResponse)
 
     #expect(httpResponse.statusCode == 200)
-    #expect(defaultUploader.deleteMediaCalled)
-    #expect(defaultUploader.deletedAttachmentId == "42")
+    #expect(internalClient.deleteMediaCalled)
+    #expect(internalClient.deletedAttachmentId == "42")
   }
 
-  @Test("relays a deletion to the default uploader (configured site)")
-  func relaysDeleteToDefaultUploader() async throws {
+  @Test("relays a deletion to the internal media client (configured site)")
+  func relaysDeleteToInternalClient() async throws {
     // With no uploader set, GutenbergKit owns deletes: core's orphan cleanup DELETE
-    // is relayed to the default uploader (the configured site).
-    let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(defaultUploader: mockUploader)
+    // is relayed to the internal media client (the configured site).
+    let mockUploader = MockInternalMediaClient()
+    let server = try await MediaUploadServer.start(internalClient: mockUploader)
     defer { server.stop() }
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/media/512?force=true")!
@@ -176,16 +176,19 @@ struct MediaUploadServerTests {
   @Test("routes an upload to the uploader and relays its attachment")
   func uploaderDeliversAttachment() async throws {
     // With an uploader set, GutenbergKit hands it the file and relays the finished
-    // attachment it returns — the default uploader (configured site) is never used.
+    // attachment it returns — the internal media client (configured site) is never used.
     let uploader = MockUploader()
-    let defaultUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(uploader: uploader, defaultUploader: defaultUploader)
+    let internalClient = MockInternalMediaClient()
+    let server = try await MediaUploadServer.start(uploader: uploader, internalClient: internalClient)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
-    let body = buildMultipartBody(boundary: boundary, filename: "photo.jpg", mimeType: "image/jpeg", data: Data("fake image data".utf8))
+    let body = buildMultipartBody(
+      boundary: boundary, filename: "photo.jpg", mimeType: "image/jpeg",
+      data: Data("fake image data".utf8), fields: ["post": "123"]
+    )
 
-    let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
+    let url = URL(string: "http://127.0.0.1:\(server.port)/upload?_embed=wp:featuredmedia")!
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
@@ -199,9 +202,15 @@ struct MediaUploadServerTests {
     #expect(uploader.uploadCalled)
     #expect(uploader.lastMimeType == "image/jpeg")
     #expect(uploader.lastFilename == "photo.jpg")
+    // The editor's post association and query must reach the host uploader, so it can
+    // reproduce a native upload (attach to the post, honor ?_embed).
+    #expect(uploader.lastFields["post"] == "123")
+    #expect(uploader.lastQuery == "?_embed=wp:featuredmedia")
+    // …and the actual file bytes the editor sent — the host uploads them itself.
+    #expect(uploader.lastFileData == Data("fake image data".utf8))
     // The host owns delivery — GutenbergKit must not upload to the configured site.
-    #expect(!defaultUploader.uploadCalled)
-    #expect(!defaultUploader.passthroughUploadCalled)
+    #expect(!internalClient.uploadCalled)
+    #expect(!internalClient.passthroughUploadCalled)
 
     // The server relays the exact attachment JSON the uploader returned.
     let object = try JSONSerialization.jsonObject(with: data)
@@ -211,11 +220,62 @@ struct MediaUploadServerTests {
     #expect(json["media_type"] as? String == "image")
   }
 
+  @Test("hands the processed file and its new metadata to the uploader")
+  func uploaderReceivesProcessedFile() async throws {
+    // A processor transcodes the file; the host uploader must receive the processed
+    // bytes and the new metadata, not the original clip.mov.
+    let processor = ResizingProcessor()
+    let uploader = MockUploader()
+    let server = try await MediaUploadServer.start(
+      processor: processor, uploader: uploader, internalClient: MockInternalMediaClient()
+    )
+    defer { server.stop() }
+
+    let boundary = UUID().uuidString
+    let body = buildMultipartBody(boundary: boundary, filename: "clip.mov", mimeType: "video/quicktime", data: Data("movie".utf8))
+
+    let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
+
+    _ = try await URLSession.shared.data(for: request)
+
+    #expect(uploader.uploadCalled)
+    #expect(uploader.lastFileData == Data("processed".utf8))
+    #expect(uploader.lastMimeType == "video/mp4")
+    #expect(uploader.lastFilename == "clip.mp4")
+  }
+
+  @Test("relays a 500 when the host uploader throws")
+  func uploaderErrorRelayedAs500() async throws {
+    struct UploaderFailure: Error {}
+    let uploader = MockUploader(error: UploaderFailure())
+    let server = try await MediaUploadServer.start(uploader: uploader, internalClient: MockInternalMediaClient())
+    defer { server.stop() }
+
+    let boundary = UUID().uuidString
+    let body = buildMultipartBody(boundary: boundary, filename: "photo.jpg", mimeType: "image/jpeg", data: Data("fake image data".utf8))
+
+    let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
+
+    let (_, response) = try await URLSession.shared.data(for: request)
+    #expect((response as? HTTPURLResponse)?.statusCode == 500)
+    #expect(uploader.uploadCalled)
+  }
+
   @Test("uses passthrough when the processor does not modify the file")
   func processorPassthrough() async throws {
     let processor = PassthroughProcessor()
-    let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(processor: processor, defaultUploader: mockUploader)
+    let mockUploader = MockInternalMediaClient()
+    let server = try await MediaUploadServer.start(processor: processor, internalClient: mockUploader)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
@@ -247,8 +307,8 @@ struct MediaUploadServerTests {
   @Test("skips processing and the temp copy when the processor declines by metadata")
   func processorDeclinesByMetadata() async throws {
     let processor = DecliningProcessor()
-    let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(processor: processor, defaultUploader: mockUploader)
+    let mockUploader = MockInternalMediaClient()
+    let server = try await MediaUploadServer.start(processor: processor, internalClient: mockUploader)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
@@ -275,8 +335,8 @@ struct MediaUploadServerTests {
   @Test("forwards the processor's processed metadata to the uploader")
   func processedMetadataForwarded() async throws {
     let processor = ResizingProcessor()
-    let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(processor: processor, defaultUploader: mockUploader)
+    let mockUploader = MockInternalMediaClient()
+    let server = try await MediaUploadServer.start(processor: processor, internalClient: mockUploader)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
@@ -301,8 +361,8 @@ struct MediaUploadServerTests {
   @Test("deletes the processor's processed file after upload")
   func deletesProcessedFile() async throws {
     let processor = ResizingProcessor()
-    let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(processor: processor, defaultUploader: mockUploader)
+    let mockUploader = MockInternalMediaClient()
+    let server = try await MediaUploadServer.start(processor: processor, internalClient: mockUploader)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
@@ -326,7 +386,7 @@ struct MediaUploadServerTests {
 
   @Test("returns 413 with CORS headers when request body exceeds max size")
   func oversizedUploadReturns413WithCORSHeaders() async throws {
-    let server = try await MediaUploadServer.start(maxRequestBodySize: 1024)
+    let server = try await MediaUploadServer.start(internalClient: MockInternalMediaClient(), maxRequestBodySize: 1024)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
@@ -351,7 +411,7 @@ struct MediaUploadServerTests {
 
   @Test("unauthenticated oversized request returns 407, not 413 (auth precedes drain)")
   func oversizedUploadWithoutTokenReturns407() async throws {
-    let server = try await MediaUploadServer.start(maxRequestBodySize: 1024)
+    let server = try await MediaUploadServer.start(internalClient: MockInternalMediaClient(), maxRequestBodySize: 1024)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
@@ -397,7 +457,7 @@ struct MediaUploadServerTests {
     // start() kicks off cleanOrphanedUploads() off the editor-startup path.
     // The sweep must delete the aged file and keep the fresh one — a flipped
     // comparison would do the opposite and wipe an in-flight upload.
-    let server = try await MediaUploadServer.start()
+    let server = try await MediaUploadServer.start(internalClient: MockInternalMediaClient())
     await server.cleanupTask.value
     server.stop()
 
@@ -412,19 +472,27 @@ struct MediaUploadServerTests {
     do {
       let processor = PassthroughProcessor()
       weakProcessor = processor
-      server = try await MediaUploadServer.start(processor: processor)
+      server = try await MediaUploadServer.start(processor: processor, internalClient: MockInternalMediaClient())
     }
     defer { server.stop() }
 
-    // UploadContext holds the processor weakly, so releasing the host's strong
-    // reference deallocates it. A strong reference here would reintroduce the
-    // EditorViewController → uploadServer → … → processor → EditorViewController
-    // cycle, so deinit would never fire and the server would never stop.
+    // The server (via UploadContext) holds the processor *weakly*, so once the only
+    // strong reference is released it deallocates. This is deliberately the opposite
+    // of the editor, which owns the processor *strongly* for its lifetime (see
+    // `EditorMediaHandlerOwnershipTests`): a strong capture here would reintroduce the
+    // EditorViewController → uploadServer → … → processor → EditorViewController cycle,
+    // so deinit would never fire and the server would never stop.
     #expect(weakProcessor == nil)
   }
 
-  private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data) -> Data {
+  private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data, fields: [String: String] = [:]) -> Data {
     var body = Data()
+    for (name, value) in fields {
+      body.append("--\(boundary)\r\n")
+      body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+      body.append(value)
+      body.append("\r\n")
+    }
     body.append("--\(boundary)\r\n")
     body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(filename)\"\r\n")
     body.append("Content-Type: \(mimeType)\r\n\r\n")
@@ -436,7 +504,7 @@ struct MediaUploadServerTests {
 
 // MARK: - Streaming Multipart Body Tests
 
-@Suite("DefaultMediaUploader streaming multipart body")
+@Suite("InternalMediaClient streaming multipart body")
 struct MultipartBodyStreamTests {
 
   @Test("streaming output matches in-memory multipart format")
@@ -459,7 +527,7 @@ struct MultipartBodyStreamTests {
     expected.append(Data("\r\n--\(boundary)--\r\n".utf8))
 
     // Build streaming output.
-    let (stream, contentLength) = try DefaultMediaUploader.multipartBodyStream(
+    let (stream, contentLength) = try InternalMediaClient.multipartBodyStream(
       fileURL: tempFile, boundary: boundary, filename: filename, mimeType: mimeType, extraFields: []
     )
     #expect(contentLength == expected.count)
@@ -476,7 +544,7 @@ struct MultipartBodyStreamTests {
 
     // Craft a filename, field name, and MIME type that each try to smuggle a CRLF
     // and a fake header into the body relayed to WordPress.
-    let (stream, _) = try DefaultMediaUploader.multipartBodyStream(
+    let (stream, _) = try InternalMediaClient.multipartBodyStream(
       fileURL: tempFile,
       boundary: "boundary",
       filename: "evil\"\r\nX-Injected-File: 1.jpg",
@@ -511,7 +579,7 @@ struct MultipartBodyStreamTests {
     expected.append(fileContent)
     expected.append(Data("\r\n--\(boundary)--\r\n".utf8))
 
-    let (stream, contentLength) = try DefaultMediaUploader.multipartBodyStream(
+    let (stream, contentLength) = try InternalMediaClient.multipartBodyStream(
       fileURL: tempFile, boundary: boundary, filename: filename, mimeType: mimeType,
       extraFields: [("post", Data("123".utf8))]
     )
@@ -543,7 +611,7 @@ struct MultipartBodyStreamTests {
     expected.append(fileContent)
     expected.append(Data("\r\n--\(boundary)--\r\n".utf8))
 
-    let (stream, contentLength) = try DefaultMediaUploader.multipartBodyStream(
+    let (stream, contentLength) = try InternalMediaClient.multipartBodyStream(
       fileURL: tempFile, boundary: boundary, filename: filename, mimeType: mimeType,
       extraFields: [("blob", binaryValue)]
     )
@@ -559,7 +627,7 @@ struct MultipartBodyStreamTests {
     try fileContent.write(to: tempFile)
     defer { try? FileManager.default.removeItem(at: tempFile) }
 
-    let (stream, contentLength) = try DefaultMediaUploader.multipartBodyStream(
+    let (stream, contentLength) = try InternalMediaClient.multipartBodyStream(
       fileURL: tempFile, boundary: "boundary", filename: "big.bin", mimeType: "application/octet-stream", extraFields: []
     )
 
@@ -583,7 +651,7 @@ struct MultipartBodyStreamTests {
 
     let preamble = Data("PREAMBLE".utf8)
     let epilogue = Data("EPILOGUE".utf8)
-    let ok = DefaultMediaUploader.writeMultipartBody(
+    let ok = InternalMediaClient.writeMultipartBody(
       fileHandle: fileHandle, fileSize: fileContent.count,
       preamble: preamble, epilogue: epilogue, to: output
     )
@@ -610,7 +678,7 @@ struct MultipartBodyStreamTests {
     let preamble = Data("PREAMBLE".utf8)
     let epilogue = Data("EPILOGUE".utf8)
     // Claim the file is larger than it is, as if it shrank after being measured.
-    let ok = DefaultMediaUploader.writeMultipartBody(
+    let ok = InternalMediaClient.writeMultipartBody(
       fileHandle: fileHandle, fileSize: fileContent.count + 100,
       preamble: preamble, epilogue: epilogue, to: output
     )
@@ -623,17 +691,17 @@ struct MultipartBodyStreamTests {
   }
 }
 
-// MARK: - DefaultMediaUploader Relay Tests
+// MARK: - InternalMediaClient Relay Tests
 
-@Suite("DefaultMediaUploader relay")
-struct DefaultMediaUploaderRelayTests {
+@Suite("InternalMediaClient relay")
+struct InternalMediaClientRelayTests {
 
   @Test("relays a non-2xx WordPress response instead of throwing")
   func relaysErrorResponseVerbatim() async throws {
     // A WordPress REST error body, returned with a non-2xx status.
     let errorBody = Data(#"{"code":"rest_cannot_create","message":"Sorry, you are not allowed to upload this file type."}"#.utf8)
     let client = RelayStubHTTPClient(statusCode: 403, body: errorBody)
-    let uploader = DefaultMediaUploader(httpClient: client, siteApiRoot: URL(string: "https://example.com/wp-json/")!)
+    let uploader = InternalMediaClient(httpClient: client, siteApiRoot: URL(string: "https://example.com/wp-json/")!)
 
     let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent("relay-\(UUID().uuidString).jpg")
     try Data("fake image".utf8).write(to: tempFile)
@@ -660,7 +728,7 @@ struct DefaultMediaUploaderRelayTests {
       body: Data(#"{"code":"rest_upload_error"}"#.utf8),
       headerFields: ["x-wp-upload-attachment-id": "4242"]
     )
-    let uploader = DefaultMediaUploader(
+    let uploader = InternalMediaClient(
       httpClient: client, siteApiRoot: URL(string: "https://example.com/wp-json/")!)
 
     let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(
@@ -683,7 +751,7 @@ struct DefaultMediaUploaderRelayTests {
       body: Data("{}".utf8),
       headerFields: ["X-Powered-By": "PHP/8.2", "Set-Cookie": "session=secret"]
     )
-    let uploader = DefaultMediaUploader(
+    let uploader = InternalMediaClient(
       httpClient: client, siteApiRoot: URL(string: "https://example.com/wp-json/")!)
 
     let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(
@@ -701,7 +769,7 @@ struct DefaultMediaUploaderRelayTests {
   @Test("deletes an attachment, carrying the namespace and force query")
   func deletesAttachment() async throws {
     let client = URLCapturingHTTPClient()
-    let uploader = DefaultMediaUploader(
+    let uploader = InternalMediaClient(
       httpClient: client,
       siteApiRoot: URL(string: "https://example.com/wp-json")!,
       siteApiNamespace: ["sites/123"]
@@ -717,7 +785,7 @@ struct DefaultMediaUploaderRelayTests {
   @Test("carries the namespace and request query through to the media endpoint")
   func forwardsNamespaceAndQuery() async throws {
     let client = URLCapturingHTTPClient()
-    let uploader = DefaultMediaUploader(
+    let uploader = InternalMediaClient(
       httpClient: client,
       siteApiRoot: URL(string: "https://example.com/wp-json")!,
       siteApiNamespace: ["sites/123"]
@@ -740,7 +808,7 @@ struct DefaultMediaUploaderRelayTests {
 
 /// An HTTP client whose `performRaw` relays a canned response without validating
 /// status, while `perform` throws on a non-2xx — mirroring the real
-/// `EditorHTTPClient`. Lets a test prove `DefaultMediaUploader` routes uploads
+/// `EditorHTTPClient`. Lets a test prove `InternalMediaClient` routes uploads
 /// through `performRaw` (relay) rather than `perform` (throw).
 private struct RelayStubHTTPClient: EditorHTTPClientProtocol {
   let statusCode: Int
@@ -818,22 +886,39 @@ private final class MockUploader: MediaUploader, @unchecked Sendable {
   private var _uploadCalled = false
   private var _lastMimeType: String?
   private var _lastFilename: String?
+  private var _lastFields: [String: String] = [:]
+  private var _lastQuery: String?
+  private var _lastFileData: Data?
   private let uploadBody: Data
+  private let error: (any Error)?
 
   var uploadCalled: Bool { lock.withLock { _uploadCalled } }
   var lastMimeType: String? { lock.withLock { _lastMimeType } }
   var lastFilename: String? { lock.withLock { _lastFilename } }
+  var lastFields: [String: String] { lock.withLock { _lastFields } }
+  var lastQuery: String? { lock.withLock { _lastQuery } }
+  var lastFileData: Data? { lock.withLock { _lastFileData } }
 
-  init(uploadBody: Data = Data(#"{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}"#.utf8)) {
+  init(
+    uploadBody: Data = Data(#"{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}"#.utf8),
+    error: (any Error)? = nil
+  ) {
     self.uploadBody = uploadBody
+    self.error = error
   }
 
-  func upload(fileAt url: URL, mimeType: String, filename: String) async throws -> Data {
+  func upload(_ upload: MediaUpload) async throws -> Data {
+    // Read the file the server handed us so a test can assert its contents.
+    let fileData = try? Data(contentsOf: upload.fileURL)
     lock.withLock {
       _uploadCalled = true
-      _lastMimeType = mimeType
-      _lastFilename = filename
+      _lastMimeType = upload.mimeType
+      _lastFilename = upload.filename
+      _lastFields = upload.fields
+      _lastQuery = upload.query
+      _lastFileData = fileData
     }
+    if let error { throw error }
     return uploadBody
   }
 }
@@ -883,7 +968,7 @@ private final class ResizingProcessor: MediaProcessor, @unchecked Sendable {
   }
 }
 
-private final class MockDefaultUploader: DefaultMediaUploader, @unchecked Sendable {
+private final class MockInternalMediaClient: InternalMediaClient, @unchecked Sendable {
   private let lock = NSLock()
   private var _uploadCalled = false
   private var _passthroughUploadCalled = false

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -131,6 +131,28 @@ struct MediaUploadServerTests {
     #expect(mockUploader.lastQuery == "?_embed=wp:featuredmedia")
   }
 
+  @Test("routes a deletion to the delegate when it handles one")
+  func delegateHandlesDeletion() async throws {
+    // A host that uploaded the attachment itself owns an ID only it can
+    // resolve, so the default uploader must not be asked to delete it.
+    // No default uploader is configured, so a 200 here can only come from the
+    // delegate — the fallback path would fail with "no uploader".
+    let delegate = DeletingDelegate()
+    let server = try await MediaUploadServer.start(uploadDelegate: delegate)
+    defer { server.stop() }
+
+    let url = URL(string: "http://127.0.0.1:\(server.port)/media/42?force=true")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "DELETE"
+    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
+
+    let (_, response) = try await URLSession.shared.data(for: request)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(delegate.deletedAttachmentId == "42")
+  }
+
   @Test("calls delegate and returns upload result")
   func delegateProcessAndUpload() async throws {
     let delegate = MockUploadDelegate()
@@ -792,6 +814,20 @@ private final class MockUploadDelegate: MediaUploadDelegate, @unchecked Sendable
     }
     let json = #"{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}"#
     return MediaUploadResponse(statusCode: 201, body: Data(json.utf8))
+  }
+}
+
+/// A delegate that handles deletions itself, as a host uploading to its own
+/// media service would.
+private final class DeletingDelegate: MediaUploadDelegate, @unchecked Sendable {
+  private let lock = NSLock()
+  private var _deletedAttachmentId: String?
+
+  var deletedAttachmentId: String? { lock.withLock { _deletedAttachmentId } }
+
+  func deleteFile(attachmentId: String) async throws -> MediaUploadResponse? {
+    lock.withLock { _deletedAttachmentId = attachmentId }
+    return MediaUploadResponse(statusCode: 200, body: Data(#"{"deleted":true}"#.utf8))
   }
 }
 

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -652,6 +652,22 @@ struct DefaultMediaUploaderRelayTests {
     #expect(response.headers.isEmpty)
   }
 
+  @Test("deletes an attachment, carrying the namespace and force query")
+  func deletesAttachment() async throws {
+    let client = URLCapturingHTTPClient()
+    let uploader = DefaultMediaUploader(
+      httpClient: client,
+      siteApiRoot: URL(string: "https://example.com/wp-json")!,
+      siteApiNamespace: ["sites/123"]
+    )
+
+    _ = try await uploader.deleteMedia(attachmentId: "42", query: "?force=true")
+
+    let url = try #require(client.lastURL)
+    #expect(
+      url.absoluteString == "https://example.com/wp-json/wp/v2/sites/123/media/42?force=true")
+  }
+
   @Test("carries the namespace and request query through to the media endpoint")
   func forwardsNamespaceAndQuery() async throws {
     let client = URLCapturingHTTPClient()

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -185,7 +185,7 @@ struct MediaUploadServerTests {
     let boundary = UUID().uuidString
     let body = buildMultipartBody(
       boundary: boundary, filename: "photo.jpg", mimeType: "image/jpeg",
-      data: Data("fake image data".utf8), fields: [(name: "post", value: "123")]
+      data: Data("fake image data".utf8), fields: [MediaUploadField(name: "post", value: "123")]
     )
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/upload?_embed=wp:featuredmedia")!
@@ -235,9 +235,9 @@ struct MediaUploadServerTests {
       boundary: boundary, filename: "photo.jpg", mimeType: "image/jpeg",
       data: Data("fake image data".utf8),
       fields: [
-        (name: "post", value: "123"),
-        (name: "media_folder[]", value: "12"),
-        (name: "media_folder[]", value: "45"),
+        MediaUploadField(name: "post", value: "123"),
+        MediaUploadField(name: "media_folder[]", value: "12"),
+        MediaUploadField(name: "media_folder[]", value: "45"),
       ]
     )
 
@@ -593,12 +593,12 @@ struct MediaUploadServerTests {
     #expect(!mockClient.passthroughUploadCalled)
   }
 
-  private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data, fields: [(name: String, value: String)] = []) -> Data {
+  private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data, fields: [MediaUploadField] = []) -> Data {
     var body = Data()
-    for (name, value) in fields {
+    for field in fields {
       body.append("--\(boundary)\r\n")
-      body.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
-      body.append(value)
+      body.append("Content-Disposition: form-data; name=\"\(field.name)\"\r\n\r\n")
+      body.append(field.value)
       body.append("\r\n")
     }
     body.append("--\(boundary)\r\n")
@@ -994,7 +994,7 @@ private final class MockUploader: MediaUploader, @unchecked Sendable {
   private var _uploadCalled = false
   private var _lastMimeType: String?
   private var _lastFilename: String?
-  private var _lastFields: [(name: String, value: String)] = []
+  private var _lastFields: [MediaUploadField] = []
   private var _lastQuery: String?
   private var _lastFileData: Data?
   private let uploadBody: Data
@@ -1003,7 +1003,7 @@ private final class MockUploader: MediaUploader, @unchecked Sendable {
   var uploadCalled: Bool { lock.withLock { _uploadCalled } }
   var lastMimeType: String? { lock.withLock { _lastMimeType } }
   var lastFilename: String? { lock.withLock { _lastFilename } }
-  var lastFields: [(name: String, value: String)] { lock.withLock { _lastFields } }
+  var lastFields: [MediaUploadField] { lock.withLock { _lastFields } }
   var lastQuery: String? { lock.withLock { _lastQuery } }
   var lastFileData: Data? { lock.withLock { _lastFileData } }
 

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -102,9 +102,9 @@ struct MediaUploadServerTests {
 
   @Test("routes /upload with a query string and relays the query")
   func uploadWithQueryString() async throws {
-    let delegate = ProcessOnlyDelegate()
+    let processor = PassthroughProcessor()
     let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(uploadDelegate: delegate, defaultUploader: mockUploader)
+    let server = try await MediaUploadServer.start(processor: processor, defaultUploader: mockUploader)
     defer { server.stop() }
 
     // `@wordpress/media-utils` uploads to `/wp/v2/media?_embed=wp:featuredmedia`,
@@ -123,7 +123,7 @@ struct MediaUploadServerTests {
     let (_, response) = try await URLSession.shared.data(for: request)
     let httpResponse = try #require(response as? HTTPURLResponse)
     #expect(httpResponse.statusCode == 201)
-    // The delegate returns `.original`, so this is the passthrough branch.
+    // The processor returns `.original`, so this is the passthrough branch.
     // Pin which branch ran — `lastQuery` is recorded by both, so without this
     // the query assertion would pass even if routing collapsed onto one path.
     #expect(mockUploader.passthroughUploadCalled)
@@ -131,14 +131,14 @@ struct MediaUploadServerTests {
     #expect(mockUploader.lastQuery == "?_embed=wp:featuredmedia")
   }
 
-  @Test("routes a deletion to the delegate when it handles one")
-  func delegateHandlesDeletion() async throws {
-    // A host that uploaded the attachment itself owns an ID only it can
-    // resolve, so the default uploader must not be asked to delete it.
-    // No default uploader is configured, so a 200 here can only come from the
-    // delegate — the fallback path would fail with "no uploader".
-    let delegate = DeletingDelegate()
-    let server = try await MediaUploadServer.start(uploadDelegate: delegate)
+  @Test("relays a deletion to the default uploader even when an uploader owns uploads")
+  func deletesGoToDefaultUploaderNotUploader() async throws {
+    // An attachment lives on the configured site even when a host uploader delivered
+    // it, so its deletion goes to the default uploader — the host uploader owns
+    // uploads, not deletes. Held strongly: UploadContext keeps the uploader weakly.
+    let uploader = MockUploader()
+    let defaultUploader = MockDefaultUploader()
+    let server = try await MediaUploadServer.start(uploader: uploader, defaultUploader: defaultUploader)
     defer { server.stop() }
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/media/42?force=true")!
@@ -150,40 +150,40 @@ struct MediaUploadServerTests {
     let httpResponse = try #require(response as? HTTPURLResponse)
 
     #expect(httpResponse.statusCode == 200)
-    #expect(delegate.deletedAttachmentId == "42")
+    #expect(defaultUploader.deleteMediaCalled)
+    #expect(defaultUploader.deletedAttachmentId == "42")
   }
 
-  @Test("relays the delegate's own Content-Type instead of emitting it twice")
-  func delegateContentTypeWins() async throws {
-    // `HTTPResponse` serializes every header it is given, so appending the JSON
-    // default unconditionally would put `Content-Type` on the wire twice.
-    // URLSession joins repeated headers with a comma, which is what a
-    // regression would look like here.
-    let delegate = ContentTypeDeletingDelegate()
-    let server = try await MediaUploadServer.start(uploadDelegate: delegate)
+  @Test("relays a deletion to the default uploader (configured site)")
+  func relaysDeleteToDefaultUploader() async throws {
+    // With no uploader set, GutenbergKit owns deletes: core's orphan cleanup DELETE
+    // is relayed to the default uploader (the configured site).
+    let mockUploader = MockDefaultUploader()
+    let server = try await MediaUploadServer.start(defaultUploader: mockUploader)
     defer { server.stop() }
 
-    let url = URL(string: "http://127.0.0.1:\(server.port)/media/42?force=true")!
+    let url = URL(string: "http://127.0.0.1:\(server.port)/media/512?force=true")!
     var request = URLRequest(url: url)
     request.httpMethod = "DELETE"
     request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
-
     let (_, response) = try await URLSession.shared.data(for: request)
-    let httpResponse = try #require(response as? HTTPURLResponse)
-    let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
 
-    #expect(contentType == "text/plain")
+    #expect((response as? HTTPURLResponse)?.statusCode == 200)
+    #expect(mockUploader.deleteMediaCalled)
+    #expect(mockUploader.deletedAttachmentId == "512")
   }
 
-  @Test("calls delegate and returns upload result")
-  func delegateProcessAndUpload() async throws {
-    let delegate = MockUploadDelegate()
-    let server = try await MediaUploadServer.start(uploadDelegate: delegate)
+  @Test("routes an upload to the uploader and relays its attachment")
+  func uploaderDeliversAttachment() async throws {
+    // With an uploader set, GutenbergKit hands it the file and relays the finished
+    // attachment it returns — the default uploader (configured site) is never used.
+    let uploader = MockUploader()
+    let defaultUploader = MockDefaultUploader()
+    let server = try await MediaUploadServer.start(uploader: uploader, defaultUploader: defaultUploader)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
-    let fileData = "fake image data".data(using: .utf8)!
-    let body = buildMultipartBody(boundary: boundary, filename: "photo.jpg", mimeType: "image/jpeg", data: fileData)
+    let body = buildMultipartBody(boundary: boundary, filename: "photo.jpg", mimeType: "image/jpeg", data: Data("fake image data".utf8))
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
     var request = URLRequest(url: url)
@@ -196,12 +196,14 @@ struct MediaUploadServerTests {
     let httpResponse = try #require(response as? HTTPURLResponse)
     #expect(httpResponse.statusCode == 201)
 
-    #expect(delegate.processFileCalled)
-    #expect(delegate.uploadFileCalled)
-    #expect(delegate.lastMimeType == "image/jpeg")
-    #expect(delegate.lastFilename == "photo.jpg")
+    #expect(uploader.uploadCalled)
+    #expect(uploader.lastMimeType == "image/jpeg")
+    #expect(uploader.lastFilename == "photo.jpg")
+    // The host owns delivery — GutenbergKit must not upload to the configured site.
+    #expect(!defaultUploader.uploadCalled)
+    #expect(!defaultUploader.passthroughUploadCalled)
 
-    // The server relays WordPress's raw response body verbatim.
+    // The server relays the exact attachment JSON the uploader returned.
     let object = try JSONSerialization.jsonObject(with: data)
     let json = try #require(object as? [String: Any])
     #expect(json["id"] as? Int == 42)
@@ -209,11 +211,11 @@ struct MediaUploadServerTests {
     #expect(json["media_type"] as? String == "image")
   }
 
-  @Test("uses passthrough when delegate does not modify file")
-  func delegatePassthrough() async throws {
-    let delegate = ProcessOnlyDelegate()
+  @Test("uses passthrough when the processor does not modify the file")
+  func processorPassthrough() async throws {
+    let processor = PassthroughProcessor()
     let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(uploadDelegate: delegate, defaultUploader: mockUploader)
+    let server = try await MediaUploadServer.start(processor: processor, defaultUploader: mockUploader)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
@@ -231,7 +233,7 @@ struct MediaUploadServerTests {
     let httpResponse = try #require(response as? HTTPURLResponse)
     #expect(httpResponse.statusCode == 201)
 
-    #expect(delegate.processFileCalled)
+    #expect(processor.processFileCalled)
     // Passthrough: original body forwarded directly, not re-encoded.
     #expect(mockUploader.passthroughUploadCalled)
     #expect(!mockUploader.uploadCalled)
@@ -242,11 +244,11 @@ struct MediaUploadServerTests {
     #expect(json["id"] as? Int == 99)
   }
 
-  @Test("skips processing and the temp copy when the delegate declines by metadata")
-  func delegateDeclinesByMetadata() async throws {
-    let delegate = DeclineByMetadataDelegate()
+  @Test("skips processing and the temp copy when the processor declines by metadata")
+  func processorDeclinesByMetadata() async throws {
+    let processor = DecliningProcessor()
     let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(uploadDelegate: delegate, defaultUploader: mockUploader)
+    let server = try await MediaUploadServer.start(processor: processor, defaultUploader: mockUploader)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
@@ -263,18 +265,18 @@ struct MediaUploadServerTests {
     let httpResponse = try #require(response as? HTTPURLResponse)
     #expect(httpResponse.statusCode == 201)
 
-    // Declined by metadata → the delegate is never asked to process (so the file
+    // Declined by metadata → the processor is never asked to process (so the file
     // was never materialized), and the upload is passed through directly.
-    #expect(!delegate.processFileCalled)
+    #expect(!processor.processFileCalled)
     #expect(mockUploader.passthroughUploadCalled)
     #expect(!mockUploader.uploadCalled)
   }
 
-  @Test("forwards the delegate's processed metadata to the uploader")
+  @Test("forwards the processor's processed metadata to the uploader")
   func processedMetadataForwarded() async throws {
-    let delegate = ResizingDelegate()
+    let processor = ResizingProcessor()
     let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(uploadDelegate: delegate, defaultUploader: mockUploader)
+    let server = try await MediaUploadServer.start(processor: processor, defaultUploader: mockUploader)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
@@ -289,18 +291,18 @@ struct MediaUploadServerTests {
 
     _ = try await URLSession.shared.data(for: request)
 
-    // The delegate changed the format, so the uploader must receive the new
+    // The processor changed the format, so the uploader must receive the new
     // metadata — not the original video/quicktime + clip.mov.
     #expect(mockUploader.uploadCalled)
     #expect(mockUploader.lastUploadMimeType == "video/mp4")
     #expect(mockUploader.lastUploadFilename == "clip.mp4")
   }
 
-  @Test("deletes the delegate's processed file after upload")
+  @Test("deletes the processor's processed file after upload")
   func deletesProcessedFile() async throws {
-    let delegate = ResizingDelegate()
+    let processor = ResizingProcessor()
     let mockUploader = MockDefaultUploader()
-    let server = try await MediaUploadServer.start(uploadDelegate: delegate, defaultUploader: mockUploader)
+    let server = try await MediaUploadServer.start(processor: processor, defaultUploader: mockUploader)
     defer { server.stop() }
 
     let boundary = UUID().uuidString
@@ -315,10 +317,10 @@ struct MediaUploadServerTests {
 
     _ = try await URLSession.shared.data(for: request)
 
-    // The server owns the file the delegate produced and must delete it once the
+    // The server owns the file the processor produced and must delete it once the
     // upload finishes — the defer in processAndUpload covers the success and throw
     // paths alike. A leaked processed file is a full-size temp per upload.
-    let processedURL = try #require(delegate.producedURL)
+    let processedURL = try #require(processor.producedURL)
     #expect(!FileManager.default.fileExists(atPath: processedURL.path(percentEncoded: false)))
   }
 
@@ -403,22 +405,22 @@ struct MediaUploadServerTests {
     #expect(FileManager.default.fileExists(atPath: fresh.path(percentEncoded: false)))
   }
 
-  @Test("does not strongly retain the upload delegate (weak — preserves deinit teardown)")
-  func doesNotStronglyRetainDelegate() async throws {
-    weak var weakDelegate: MockUploadDelegate?
+  @Test("does not strongly retain the processor (weak — preserves deinit teardown)")
+  func doesNotStronglyRetainProcessor() async throws {
+    weak var weakProcessor: PassthroughProcessor?
     let server: MediaUploadServer
     do {
-      let delegate = MockUploadDelegate()
-      weakDelegate = delegate
-      server = try await MediaUploadServer.start(uploadDelegate: delegate)
+      let processor = PassthroughProcessor()
+      weakProcessor = processor
+      server = try await MediaUploadServer.start(processor: processor)
     }
     defer { server.stop() }
 
-    // UploadContext holds the delegate weakly, so releasing the host's strong
+    // UploadContext holds the processor weakly, so releasing the host's strong
     // reference deallocates it. A strong reference here would reintroduce the
-    // EditorViewController → uploadServer → … → delegate → EditorViewController
+    // EditorViewController → uploadServer → … → processor → EditorViewController
     // cycle, so deinit would never fire and the server would never stop.
-    #expect(weakDelegate == nil)
+    #expect(weakProcessor == nil)
   }
 
   private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data) -> Data {
@@ -809,63 +811,34 @@ private func readAllFromStream(_ stream: InputStream) -> Data {
 
 // MARK: - Mocks
 
-private final class MockUploadDelegate: MediaUploadDelegate, @unchecked Sendable {
+/// A host uploader: it performs the upload on its own stack. `upload` returns the
+/// finished attachment JSON (or throws).
+private final class MockUploader: MediaUploader, @unchecked Sendable {
   private let lock = NSLock()
-  private var _processFileCalled = false
-  private var _uploadFileCalled = false
+  private var _uploadCalled = false
   private var _lastMimeType: String?
   private var _lastFilename: String?
+  private let uploadBody: Data
 
-  var processFileCalled: Bool { lock.withLock { _processFileCalled } }
-  var uploadFileCalled: Bool { lock.withLock { _uploadFileCalled } }
+  var uploadCalled: Bool { lock.withLock { _uploadCalled } }
   var lastMimeType: String? { lock.withLock { _lastMimeType } }
   var lastFilename: String? { lock.withLock { _lastFilename } }
 
-  func processFile(at url: URL, mimeType: String, filename: String) async throws -> ProcessedProxyFile {
-    lock.withLock {
-      _processFileCalled = true
-      _lastMimeType = mimeType
-    }
-    return .original
+  init(uploadBody: Data = Data(#"{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}"#.utf8)) {
+    self.uploadBody = uploadBody
   }
 
-  func uploadFile(at url: URL, mimeType: String, filename: String) async throws -> MediaUploadResponse? {
+  func upload(fileAt url: URL, mimeType: String, filename: String) async throws -> Data {
     lock.withLock {
-      _uploadFileCalled = true
+      _uploadCalled = true
+      _lastMimeType = mimeType
       _lastFilename = filename
     }
-    let json = #"{"id":42,"source_url":"https://example.com/photo.jpg","media_type":"image"}"#
-    return MediaUploadResponse(statusCode: 201, body: Data(json.utf8))
+    return uploadBody
   }
 }
 
-/// A delegate that handles deletions itself, as a host uploading to its own
-/// media service would.
-private final class DeletingDelegate: MediaUploadDelegate, @unchecked Sendable {
-  private let lock = NSLock()
-  private var _deletedAttachmentId: String?
-
-  var deletedAttachmentId: String? { lock.withLock { _deletedAttachmentId } }
-
-  func deleteFile(attachmentId: String) async throws -> MediaUploadResponse? {
-    lock.withLock { _deletedAttachmentId = attachmentId }
-    return MediaUploadResponse(statusCode: 200, body: Data(#"{"deleted":true}"#.utf8))
-  }
-}
-
-/// A delegate that sets its own `Content-Type`, so the relay must not also
-/// append the JSON default.
-private final class ContentTypeDeletingDelegate: MediaUploadDelegate, @unchecked Sendable {
-  func deleteFile(attachmentId: String) async throws -> MediaUploadResponse? {
-    MediaUploadResponse(
-      statusCode: 200,
-      body: Data("deleted".utf8),
-      headers: ["Content-Type": "text/plain"]
-    )
-  }
-}
-
-private final class ProcessOnlyDelegate: MediaUploadDelegate, @unchecked Sendable {
+private final class PassthroughProcessor: MediaProcessor, @unchecked Sendable {
   private let lock = NSLock()
   private var _processFileCalled = false
 
@@ -877,10 +850,10 @@ private final class ProcessOnlyDelegate: MediaUploadDelegate, @unchecked Sendabl
   }
 }
 
-/// A delegate that declines every file by metadata via `handlesFile`, so the
+/// A processor that declines every file by metadata via `handlesFile`, so the
 /// server must pass through without ever materializing the file or calling
 /// `processFile`.
-private final class DeclineByMetadataDelegate: MediaUploadDelegate, @unchecked Sendable {
+private final class DecliningProcessor: MediaProcessor, @unchecked Sendable {
   private let lock = NSLock()
   private var _processFileCalled = false
 
@@ -894,12 +867,12 @@ private final class DeclineByMetadataDelegate: MediaUploadDelegate, @unchecked S
   }
 }
 
-/// A delegate that produces a new file with changed metadata (e.g. a transcode).
-private final class ResizingDelegate: MediaUploadDelegate, @unchecked Sendable {
+/// A processor that produces a new file with changed metadata (e.g. a transcode).
+private final class ResizingProcessor: MediaProcessor, @unchecked Sendable {
   private let lock = NSLock()
   private var _producedURL: URL?
 
-  /// The URL of the processed file this delegate wrote, for cleanup assertions.
+  /// The URL of the processed file this processor wrote, for cleanup assertions.
   var producedURL: URL? { lock.withLock { _producedURL } }
 
   func processFile(at url: URL, mimeType: String, filename: String) async throws -> ProcessedProxyFile {
@@ -917,14 +890,22 @@ private final class MockDefaultUploader: DefaultMediaUploader, @unchecked Sendab
   private var _lastUploadMimeType: String?
   private var _lastUploadFilename: String?
   private var _lastQuery: String?
+  private var _deleteMediaCalled = false
+  private var _deletedAttachmentId: String?
+
+  /// The response `upload`/`passthroughUpload` return. `nil` uses a 201 default.
+  private let uploadResponse: MediaUploadResponse?
 
   var uploadCalled: Bool { lock.withLock { _uploadCalled } }
   var passthroughUploadCalled: Bool { lock.withLock { _passthroughUploadCalled } }
   var lastUploadMimeType: String? { lock.withLock { _lastUploadMimeType } }
   var lastUploadFilename: String? { lock.withLock { _lastUploadFilename } }
   var lastQuery: String? { lock.withLock { _lastQuery } }
+  var deleteMediaCalled: Bool { lock.withLock { _deleteMediaCalled } }
+  var deletedAttachmentId: String? { lock.withLock { _deletedAttachmentId } }
 
-  init() {
+  init(uploadResponse: MediaUploadResponse? = nil) {
+    self.uploadResponse = uploadResponse
     super.init(httpClient: MockHTTPClient(), siteApiRoot: URL(string: "https://example.com/wp-json/")!)
   }
 
@@ -935,7 +916,7 @@ private final class MockDefaultUploader: DefaultMediaUploader, @unchecked Sendab
       _lastUploadFilename = filename
       _lastQuery = query
     }
-    return mockResponse()
+    return uploadResponse ?? Self.defaultResponse
   }
 
   override func passthroughUpload(body: RequestBody, contentType: String, query: String) async throws -> MediaUploadResponse {
@@ -943,13 +924,20 @@ private final class MockDefaultUploader: DefaultMediaUploader, @unchecked Sendab
       _passthroughUploadCalled = true
       _lastQuery = query
     }
-    return mockResponse()
+    return uploadResponse ?? Self.defaultResponse
   }
 
-  private func mockResponse() -> MediaUploadResponse {
-    let json = #"{"id":99,"source_url":"https://example.com/doc.pdf","media_type":"file"}"#
-    return MediaUploadResponse(statusCode: 201, body: Data(json.utf8))
+  override func deleteMedia(attachmentId: String, query: String) async throws -> MediaUploadResponse {
+    lock.withLock {
+      _deleteMediaCalled = true
+      _deletedAttachmentId = attachmentId
+    }
+    return MediaUploadResponse(statusCode: 200, body: Data(#"{"deleted":true}"#.utf8))
   }
+
+  private static let defaultResponse = MediaUploadResponse(
+    statusCode: 201,
+    body: Data(#"{"id":99,"source_url":"https://example.com/doc.pdf","media_type":"file"}"#.utf8))
 }
 
 private struct MockHTTPClient: EditorHTTPClientProtocol {

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -153,6 +153,28 @@ struct MediaUploadServerTests {
     #expect(delegate.deletedAttachmentId == "42")
   }
 
+  @Test("relays the delegate's own Content-Type instead of emitting it twice")
+  func delegateContentTypeWins() async throws {
+    // `HTTPResponse` serializes every header it is given, so appending the JSON
+    // default unconditionally would put `Content-Type` on the wire twice.
+    // URLSession joins repeated headers with a comma, which is what a
+    // regression would look like here.
+    let delegate = ContentTypeDeletingDelegate()
+    let server = try await MediaUploadServer.start(uploadDelegate: delegate)
+    defer { server.stop() }
+
+    let url = URL(string: "http://127.0.0.1:\(server.port)/media/42?force=true")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "DELETE"
+    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
+
+    let (_, response) = try await URLSession.shared.data(for: request)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+    let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")
+
+    #expect(contentType == "text/plain")
+  }
+
   @Test("calls delegate and returns upload result")
   func delegateProcessAndUpload() async throws {
     let delegate = MockUploadDelegate()
@@ -828,6 +850,18 @@ private final class DeletingDelegate: MediaUploadDelegate, @unchecked Sendable {
   func deleteFile(attachmentId: String) async throws -> MediaUploadResponse? {
     lock.withLock { _deletedAttachmentId = attachmentId }
     return MediaUploadResponse(statusCode: 200, body: Data(#"{"deleted":true}"#.utf8))
+  }
+}
+
+/// A delegate that sets its own `Content-Type`, so the relay must not also
+/// append the JSON default.
+private final class ContentTypeDeletingDelegate: MediaUploadDelegate, @unchecked Sendable {
+  func deleteFile(attachmentId: String) async throws -> MediaUploadResponse? {
+    MediaUploadResponse(
+      statusCode: 200,
+      body: Data("deleted".utf8),
+      headers: ["Content-Type": "text/plain"]
+    )
   }
 }
 

--- a/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaUploadServerTests.swift
@@ -185,7 +185,7 @@ struct MediaUploadServerTests {
     let boundary = UUID().uuidString
     let body = buildMultipartBody(
       boundary: boundary, filename: "photo.jpg", mimeType: "image/jpeg",
-      data: Data("fake image data".utf8), fields: ["post": "123"]
+      data: Data("fake image data".utf8), fields: [(name: "post", value: "123")]
     )
 
     let url = URL(string: "http://127.0.0.1:\(server.port)/upload?_embed=wp:featuredmedia")!
@@ -204,7 +204,7 @@ struct MediaUploadServerTests {
     #expect(uploader.lastFilename == "photo.jpg")
     // The editor's post association and query must reach the host uploader, so it can
     // reproduce a native upload (attach to the post, honor ?_embed).
-    #expect(uploader.lastFields["post"] == "123")
+    #expect(uploader.lastFields.first { $0.name == "post" }?.value == "123")
     #expect(uploader.lastQuery == "?_embed=wp:featuredmedia")
     // …and the actual file bytes the editor sent — the host uploads them itself.
     #expect(uploader.lastFileData == Data("fake image data".utf8))
@@ -218,6 +218,43 @@ struct MediaUploadServerTests {
     #expect(json["id"] as? Int == 42)
     #expect(json["source_url"] as? String == "https://example.com/photo.jpg")
     #expect(json["media_type"] as? String == "image")
+  }
+
+  @Test("hands a host uploader repeated form field names in order, not collapsed")
+  func uploaderReceivesRepeatedFieldNames() async throws {
+    // A `field[]`-style repeated name (e.g. a custom attachment taxonomy): WordPress
+    // builds an array from these, so both values must reach the host uploader in order.
+    // A dictionary would drop the first — the ordered-list contract must not.
+    let uploader = MockUploader()
+    let internalClient = MockInternalMediaClient()
+    let server = try await MediaUploadServer.start(uploader: uploader, internalClient: internalClient)
+    defer { server.stop() }
+
+    let boundary = UUID().uuidString
+    let body = buildMultipartBody(
+      boundary: boundary, filename: "photo.jpg", mimeType: "image/jpeg",
+      data: Data("fake image data".utf8),
+      fields: [
+        (name: "post", value: "123"),
+        (name: "media_folder[]", value: "12"),
+        (name: "media_folder[]", value: "45"),
+      ]
+    )
+
+    let url = URL(string: "http://127.0.0.1:\(server.port)/upload")!
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("Bearer \(server.token)", forHTTPHeaderField: "Relay-Authorization")
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    request.httpBody = body
+
+    _ = try await URLSession.shared.data(for: request)
+
+    #expect(uploader.uploadCalled)
+    // Both repeated values survive, in order — not collapsed to the last.
+    let folderValues = uploader.lastFields.filter { $0.name == "media_folder[]" }.map(\.value)
+    #expect(folderValues == ["12", "45"])
+    #expect(uploader.lastFields.first { $0.name == "post" }?.value == "123")
   }
 
   @Test("hands the processed file and its new metadata to the uploader")
@@ -485,7 +522,7 @@ struct MediaUploadServerTests {
     #expect(weakProcessor == nil)
   }
 
-  private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data, fields: [String: String] = [:]) -> Data {
+  private func buildMultipartBody(boundary: String, filename: String, mimeType: String, data: Data, fields: [(name: String, value: String)] = []) -> Data {
     var body = Data()
     for (name, value) in fields {
       body.append("--\(boundary)\r\n")
@@ -886,7 +923,7 @@ private final class MockUploader: MediaUploader, @unchecked Sendable {
   private var _uploadCalled = false
   private var _lastMimeType: String?
   private var _lastFilename: String?
-  private var _lastFields: [String: String] = [:]
+  private var _lastFields: [(name: String, value: String)] = []
   private var _lastQuery: String?
   private var _lastFileData: Data?
   private let uploadBody: Data
@@ -895,7 +932,7 @@ private final class MockUploader: MediaUploader, @unchecked Sendable {
   var uploadCalled: Bool { lock.withLock { _uploadCalled } }
   var lastMimeType: String? { lock.withLock { _lastMimeType } }
   var lastFilename: String? { lock.withLock { _lastFilename } }
-  var lastFields: [String: String] { lock.withLock { _lastFields } }
+  var lastFields: [(name: String, value: String)] { lock.withLock { _lastFields } }
   var lastQuery: String? { lock.withLock { _lastQuery } }
   var lastFileData: Data? { lock.withLock { _lastFileData } }
 

--- a/src/utils/api-fetch-post-process.test.js
+++ b/src/utils/api-fetch-post-process.test.js
@@ -99,6 +99,37 @@ describe( "core's media upload post-process middleware", () => {
 		global.fetch = originalFetch;
 	} );
 
+	it( 'retries post-process for an upload routed through the native server', async () => {
+		// Regression test for middleware ordering. The native middleware handles
+		// the upload without calling `next`, so core's middleware only ever sees
+		// it by running *above* — registered after. With the two swapped, this
+		// upload surfaces as a permanent failure and no post-process is issued.
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: SITE_API_ROOT,
+			authHeader: 'Bearer test-token',
+			siteApiNamespace: [],
+			namespaceExcludedPaths: [],
+			nativeUploadPort: 8080,
+			nativeUploadToken: 'relay-token',
+		} );
+
+		global.fetch = vi.fn( ( url ) => {
+			const path = String( url );
+			if ( path.includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 200, null, { id: 42 } ) );
+			}
+			// The native server relays WordPress's 500 plus the attachment ID.
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		await expect( apiFetch( uploadOptions() ) ).resolves.toEqual( {
+			id: 42,
+		} );
+
+		expect( fetchedPath( 0 ) ).toContain( 'localhost:8080/upload' );
+		expect( fetchedPath( 1 ) ).toContain( '/wp/v2/media/42/post-process' );
+	} );
+
 	it( 'retries post-process when the upload fails with an attachment ID', async () => {
 		global.fetch = vi.fn( ( url ) => {
 			if ( String( url ).includes( 'post-process' ) ) {

--- a/src/utils/api-fetch-post-process.test.js
+++ b/src/utils/api-fetch-post-process.test.js
@@ -21,6 +21,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import { configureApiFetch } from './api-fetch';
 import * as bridge from './bridge';
+import { error } from './logger';
 
 vi.mock( './bridge', async ( importOriginal ) => {
 	const actual = await importOriginal();
@@ -257,5 +258,31 @@ describe( "core's media upload post-process middleware", () => {
 		} );
 
 		expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not log an error for an upload that recovers', async () => {
+		// The initial 5xx is a handoff to core's post-process retry, not a
+		// failure. A silently-recovered upload must surface no error to the host.
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: SITE_API_ROOT,
+			authHeader: 'Bearer test-token',
+			siteApiNamespace: [],
+			namespaceExcludedPaths: [],
+			nativeUploadPort: 8080,
+			nativeUploadToken: 'relay-token',
+		} );
+
+		global.fetch = vi.fn( ( url ) => {
+			if ( String( url ).includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 200, null, { id: 42 } ) );
+			}
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		await expect( apiFetch( uploadOptions() ) ).resolves.toEqual( {
+			id: 42,
+		} );
+
+		expect( error ).not.toHaveBeenCalled();
 	} );
 } );

--- a/src/utils/api-fetch-post-process.test.js
+++ b/src/utils/api-fetch-post-process.test.js
@@ -1,0 +1,189 @@
+/**
+ * External dependencies
+ */
+import {
+	describe,
+	it,
+	expect,
+	beforeAll,
+	beforeEach,
+	afterEach,
+	vi,
+} from 'vitest';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { configureApiFetch } from './api-fetch';
+import * as bridge from './bridge';
+
+vi.mock( './bridge', async ( importOriginal ) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		getGBKit: vi.fn(),
+	};
+} );
+
+vi.mock( './logger', () => ( {
+	info: vi.fn(),
+	error: vi.fn(),
+	warn: vi.fn(),
+	debug: vi.fn(),
+} ) );
+
+const SITE_API_ROOT = 'https://example.com/wp-json/';
+
+/**
+ * A `Response`-like object carrying the upload attachment ID header, which is
+ * what core's middleware keys off to decide whether a failure is recoverable.
+ *
+ * @param {number}  status       The HTTP status.
+ * @param {?string} attachmentId The `x-wp-upload-attachment-id` header value.
+ * @param {Object}  body         The JSON body.
+ * @return {Response} The response.
+ */
+function makeResponse( status, attachmentId, body = {} ) {
+	const headers = { 'Content-Type': 'application/json' };
+	if ( attachmentId ) {
+		headers[ 'x-wp-upload-attachment-id' ] = attachmentId;
+	}
+	return new Response( JSON.stringify( body ), { status, headers } );
+}
+
+/** A media upload request, as `@wordpress/media-utils` issues it. */
+function uploadOptions() {
+	const body = new FormData();
+	body.append(
+		'file',
+		new File( [ 'data' ], 'photo.jpg', { type: 'image/jpeg' } )
+	);
+	return { path: '/wp/v2/media', method: 'POST', body };
+}
+
+/**
+ * The path of the Nth `fetch` call, normalized to a string.
+ *
+ * @param {number} index The zero-based call index.
+ * @return {string} The requested URL.
+ */
+function fetchedPath( index ) {
+	return String( global.fetch.mock.calls[ index ][ 0 ] );
+}
+
+describe( "core's media upload post-process middleware", () => {
+	let originalFetch;
+
+	beforeAll( () => {
+		bridge.getGBKit.mockReturnValue( { siteApiRoot: SITE_API_ROOT } );
+		configureApiFetch();
+	} );
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		originalFetch = global.fetch;
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: SITE_API_ROOT,
+			authHeader: 'Bearer test-token',
+			siteApiNamespace: [],
+			namespaceExcludedPaths: [],
+		} );
+	} );
+
+	afterEach( () => {
+		global.fetch = originalFetch;
+	} );
+
+	it( 'retries post-process when the upload fails with an attachment ID', async () => {
+		global.fetch = vi.fn( ( url ) => {
+			if ( String( url ).includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 200, null, { id: 42 } ) );
+			}
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		// A recovered upload resolves with the post-process result rather than
+		// surfacing the original 5xx to the block.
+		await expect( apiFetch( uploadOptions() ) ).resolves.toEqual( {
+			id: 42,
+		} );
+
+		expect( global.fetch ).toHaveBeenCalledTimes( 2 );
+		expect( fetchedPath( 1 ) ).toContain( '/wp/v2/media/42/post-process' );
+	} );
+
+	it( 'deletes the orphaned attachment after exhausting retries', async () => {
+		global.fetch = vi.fn( ( url ) => {
+			const path = String( url );
+			if ( path.includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 500, null ) );
+			}
+			if ( path.includes( 'force=true' ) ) {
+				return Promise.resolve(
+					makeResponse( 200, null, { deleted: true } )
+				);
+			}
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		await expect( apiFetch( uploadOptions() ) ).rejects.toBeDefined();
+
+		const paths = global.fetch.mock.calls.map( ( [ url ] ) =>
+			String( url )
+		);
+		// The initial upload, five post-process attempts, then the cleanup.
+		expect(
+			paths.filter( ( p ) => p.includes( 'post-process' ) )
+		).toHaveLength( 5 );
+		expect( paths.at( -1 ) ).toContain( '/wp/v2/media/42?force=true' );
+	} );
+
+	it( 'authenticates the post-process retry', async () => {
+		global.fetch = vi.fn( ( url ) => {
+			if ( String( url ).includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 200, null, { id: 42 } ) );
+			}
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		await expect( apiFetch( uploadOptions() ) ).resolves.toBeDefined();
+
+		// The retry is issued through `next`, so it must still pick up the auth
+		// header and the site API root from the middlewares below it.
+		const [ url, options ] = global.fetch.mock.calls[ 1 ];
+		expect( String( url ) ).toContain(
+			`${ SITE_API_ROOT }wp/v2/media/42/post-process`
+		);
+		expect( options.headers.Authorization ).toBe( 'Bearer test-token' );
+	} );
+
+	it( 'does not retry when the failure carries no attachment ID', async () => {
+		global.fetch = vi.fn( () =>
+			Promise.resolve( makeResponse( 500, null ) )
+		);
+
+		await expect( apiFetch( uploadOptions() ) ).rejects.toBeDefined();
+
+		expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'leaves a successful upload untouched', async () => {
+		global.fetch = vi.fn( () =>
+			Promise.resolve(
+				makeResponse( 201, null, { id: 42, source_url: 'x' } )
+			)
+		);
+
+		await expect( apiFetch( uploadOptions() ) ).resolves.toEqual( {
+			id: 42,
+			source_url: 'x',
+		} );
+
+		expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/src/utils/api-fetch-post-process.test.js
+++ b/src/utils/api-fetch-post-process.test.js
@@ -174,6 +174,47 @@ describe( "core's media upload post-process middleware", () => {
 		expect( paths.at( -1 ) ).toContain( '/wp/v2/media/42?force=true' );
 	} );
 
+	it( 'relays the orphan cleanup through the native server', async () => {
+		// End-to-end shape of the `always` case on a native-upload host: the
+		// upload fails, five post-process attempts fail, and the resulting
+		// DELETE goes to the loopback server rather than direct to WordPress —
+		// where a cross-origin editor's tunnelled DELETE would be blocked at
+		// preflight, leaving the orphan behind.
+		bridge.getGBKit.mockReturnValue( {
+			siteApiRoot: SITE_API_ROOT,
+			authHeader: 'Bearer test-token',
+			siteApiNamespace: [],
+			namespaceExcludedPaths: [],
+			nativeUploadPort: 8080,
+			nativeUploadToken: 'relay-token',
+		} );
+
+		global.fetch = vi.fn( ( url ) => {
+			const path = String( url );
+			if ( path.includes( 'post-process' ) ) {
+				return Promise.resolve( makeResponse( 500, null ) );
+			}
+			if ( path.includes( '/media/42' ) ) {
+				return Promise.resolve(
+					makeResponse( 200, null, { deleted: true } )
+				);
+			}
+			return Promise.resolve( makeResponse( 500, '42' ) );
+		} );
+
+		await expect( apiFetch( uploadOptions() ) ).rejects.toBeDefined();
+
+		const paths = global.fetch.mock.calls.map( ( [ url ] ) =>
+			String( url )
+		);
+		expect(
+			paths.filter( ( p ) => p.includes( 'post-process' ) )
+		).toHaveLength( 5 );
+		expect( paths.at( -1 ) ).toBe(
+			'http://localhost:8080/media/42?force=true'
+		);
+	} );
+
 	it( 'authenticates the post-process retry', async () => {
 		global.fetch = vi.fn( ( url ) => {
 			if ( String( url ).includes( 'post-process' ) ) {

--- a/src/utils/api-fetch-upload-middleware.test.js
+++ b/src/utils/api-fetch-upload-middleware.test.js
@@ -625,6 +625,66 @@ describe( 'nativeMediaUploadMiddleware', () => {
 		expect( next ).not.toHaveBeenCalled();
 	} );
 
+	// MARK: - Raw response passthrough
+
+	describe( 'parse: false', () => {
+		beforeEach( () => {
+			getGBKit.mockReturnValue( {
+				nativeUploadPort: 8080,
+				nativeUploadToken: 'token',
+			} );
+		} );
+
+		it( 'rejects with the Response so the attachment ID stays readable', async () => {
+			// Core's media upload middleware needs the `Response` itself to read
+			// `x-wp-upload-attachment-id` and retry post-process. Parsing the
+			// body here would hide the header.
+			const response = new Response( '{"code":"rest_upload_error"}', {
+				status: 500,
+				headers: { 'x-wp-upload-attachment-id': '4242' },
+			} );
+			global.fetch = vi.fn( () => Promise.resolve( response ) );
+
+			const options = makePostMediaOptions( makeFile() );
+			options.parse = false;
+
+			const thrown = await nativeMediaUploadMiddleware(
+				options,
+				makeNext()
+			).catch( ( error ) => error );
+
+			expect( thrown ).toBe( response );
+			expect( thrown.headers.get( 'x-wp-upload-attachment-id' ) ).toBe(
+				'4242'
+			);
+		} );
+
+		it( 'resolves with the Response on success', async () => {
+			const response = new Response( '{"id":1}', { status: 201 } );
+			global.fetch = vi.fn( () => Promise.resolve( response ) );
+
+			const options = makePostMediaOptions( makeFile() );
+			options.parse = false;
+
+			await expect(
+				nativeMediaUploadMiddleware( options, makeNext() )
+			).resolves.toBe( response );
+		} );
+
+		it( 'still parses the body when parse is not disabled', async () => {
+			global.fetch = vi.fn( () =>
+				Promise.resolve( new Response( '{"id":1}', { status: 201 } ) )
+			);
+
+			await expect(
+				nativeMediaUploadMiddleware(
+					makePostMediaOptions( makeFile() ),
+					makeNext()
+				)
+			).resolves.toEqual( { id: 1 } );
+		} );
+	} );
+
 	// MARK: - Signal forwarding
 
 	it( 'forwards abort signal to fetch', async () => {

--- a/src/utils/api-fetch-upload-middleware.test.js
+++ b/src/utils/api-fetch-upload-middleware.test.js
@@ -717,4 +717,103 @@ describe( 'nativeMediaUploadMiddleware', () => {
 			controller.signal
 		);
 	} );
+
+	// MARK: - Media deletion
+
+	describe( 'media deletion', () => {
+		beforeEach( () => {
+			getGBKit.mockReturnValue( {
+				nativeUploadPort: 8080,
+				nativeUploadToken: 'token',
+			} );
+		} );
+
+		it( 'routes an attachment deletion through the native server', async () => {
+			// api-fetch tunnels DELETE as POST + `X-HTTP-Method-Override`, which
+			// core's CORS allow-list omits, so a cross-origin editor cannot make
+			// this request directly. Relaying it keeps the orphan cleanup working.
+			global.fetch = vi.fn( () =>
+				Promise.resolve(
+					new Response( '{"deleted":true}', { status: 200 } )
+				)
+			);
+			const next = makeNext();
+
+			await expect(
+				nativeMediaUploadMiddleware(
+					{ method: 'DELETE', path: '/wp/v2/media/42?force=true' },
+					next
+				)
+			).resolves.toEqual( { deleted: true } );
+
+			expect( next ).not.toHaveBeenCalled();
+			const [ url, options ] = global.fetch.mock.calls[ 0 ];
+			expect( String( url ) ).toBe(
+				'http://localhost:8080/media/42?force=true'
+			);
+			expect( options.method ).toBe( 'DELETE' );
+			expect( options.headers[ 'Relay-Authorization' ] ).toBe(
+				'Bearer token'
+			);
+		} );
+
+		it( 'passes through a deletion of a non-media path', async () => {
+			global.fetch = vi.fn();
+			const next = makeNext();
+
+			nativeMediaUploadMiddleware(
+				{ method: 'DELETE', path: '/wp/v2/posts/42' },
+				next
+			);
+
+			expect( next ).toHaveBeenCalled();
+			expect( global.fetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'passes through the media collection path', async () => {
+			// `/wp/v2/media` has no attachment ID, so it is not a deletion this
+			// server relays.
+			global.fetch = vi.fn();
+			const next = makeNext();
+
+			nativeMediaUploadMiddleware(
+				{ method: 'DELETE', path: '/wp/v2/media' },
+				next
+			);
+
+			expect( next ).toHaveBeenCalled();
+			expect( global.fetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'passes through when the native server is not configured', async () => {
+			getGBKit.mockReturnValue( {} );
+			global.fetch = vi.fn();
+			const next = makeNext();
+
+			nativeMediaUploadMiddleware(
+				{ method: 'DELETE', path: '/wp/v2/media/42?force=true' },
+				next
+			);
+
+			expect( next ).toHaveBeenCalled();
+			expect( global.fetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'rejects with the parsed error body on failure', async () => {
+			global.fetch = vi.fn( () =>
+				Promise.resolve(
+					new Response( '{"code":"rest_cannot_delete"}', {
+						status: 403,
+					} )
+				)
+			);
+
+			const thrown = await nativeMediaUploadMiddleware(
+				{ method: 'DELETE', path: '/wp/v2/media/42?force=true' },
+				makeNext()
+			).catch( ( error ) => error );
+
+			expect( thrown ).toEqual( { code: 'rest_cannot_delete' } );
+		} );
+	} );
 } );

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -43,10 +43,13 @@ export function configureApiFetch() {
 	// when the server exposes it via CORS:
 	//
 	// - Through the native upload server, which exposes it: works on both
-	//   platforms.
+	//   platforms. This is the only path that recovers everywhere.
 	// - Direct to WordPress, which does not expose it (see
-	//   `rest_send_cors_headers()`): works on Android, whose editor is
-	//   same-origin with the site, and fails on iOS, which loads from `file://`.
+	//   `rest_send_cors_headers()`): never recovers on iOS, which loads from
+	//   `file://`. On Android it recovers only when the editor is genuinely
+	//   same-origin — `GutenbergView` derives the asset domain from the site's
+	//   host, which drops the port, so a site on a non-default port (any local
+	//   dev setup) is cross-origin and does not recover.
 	//
 	// There is no fallback: core sends the header before
 	// `wp_generate_attachment_metadata()`, so the fatal leaves no body to parse

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -300,9 +300,10 @@ function nativeMediaUpload( options, port, token ) {
 			// failure.
 			if ( options.parse === false ) {
 				if ( ! response.ok ) {
-					logError(
-						`Native upload failed with status ${ response.status }`
-					);
+					// A handoff to core's post-process retry, not an outcome —
+					// core reads `x-wp-upload-attachment-id` off this response and
+					// may still recover. Stay silent (as `nativeMediaDelete` does)
+					// rather than reporting a failure that hasn't happened yet.
 					return Promise.reject( response );
 				}
 				return response;

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -31,6 +31,12 @@ export function configureApiFetch() {
 	apiFetch.use( apiPathModifierMiddleware );
 	apiFetch.use( tokenAuthMiddleware );
 	apiFetch.use( filterEndpointsMiddleware );
+	// `apiFetch.use` unshifts, so the last registration runs first. Core's media
+	// upload middleware is registered before the native one so that it runs
+	// after it, and below auth, namespacing, and the root URL so the
+	// `post-process` requests it issues through `next` stay authenticated and
+	// correctly addressed.
+	apiFetch.use( apiFetch.mediaUploadMiddleware );
 	apiFetch.use( nativeMediaUploadMiddleware );
 	apiFetch.use( stripDraftPostIdMiddleware );
 	apiFetch.use( transformOEmbedApiResponse );

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -18,6 +18,9 @@ import { info, error as logError } from './logger';
 /** Matches `POST /wp/v2/media` but not sub-paths like `/wp/v2/media/123`. */
 const MEDIA_UPLOAD_PATH = /^\/wp\/v2\/media(\?|$)/;
 
+/** Matches `/wp/v2/media/<id>`, capturing the attachment ID. */
+const MEDIA_ATTACHMENT_PATH = /^\/wp\/v2\/media\/(\d+)(\?|$)/;
+
 /**
  * Initializes the API fetch configuration and middleware.
  *
@@ -224,6 +227,17 @@ function filterEndpointsMiddleware( options, next ) {
 export function nativeMediaUploadMiddleware( options, next ) {
 	const { nativeUploadPort, nativeUploadToken } = getGBKit();
 
+	if ( nativeUploadPort && nativeUploadToken ) {
+		const deletion = nativeMediaDelete(
+			options,
+			nativeUploadPort,
+			nativeUploadToken
+		);
+		if ( deletion ) {
+			return deletion;
+		}
+	}
+
 	if (
 		! nativeUploadPort ||
 		! nativeUploadToken ||
@@ -371,6 +385,99 @@ export function nativeMediaUploadMiddleware( options, next ) {
 					),
 				};
 			}
+			throw {
+				code: 'fetch_error',
+				message: __(
+					'Could not get a valid response from the server.'
+				),
+			};
+		}
+	);
+}
+
+/**
+ * Routes a media attachment deletion through the native upload server.
+ *
+ * Returns `null` when the request is not a media deletion, so the caller falls
+ * through to its normal handling.
+ *
+ * Core's media upload middleware deletes the orphaned attachment when every
+ * `post-process` retry fails. That request cannot be made directly from a
+ * cross-origin editor: `@wordpress/api-fetch` tunnels `DELETE` as a `POST`
+ * carrying `X-HTTP-Method-Override`, and core's `rest_allowed_cors_headers`
+ * does not list that header, so the browser blocks it at preflight and the
+ * orphan survives. Relaying through the loopback server — which sets its own
+ * CORS policy — is what lets the cleanup complete.
+ *
+ * This runs before `X-HTTP-Method-Override` exists: api-fetch's `httpV1`
+ * middleware adds it further down the chain, so the method here is still a
+ * plain `DELETE`.
+ *
+ * @param {Object} options The api-fetch options.
+ * @param {number} port    The native upload server port.
+ * @param {string} token   The native upload server bearer token.
+ * @return {?Promise} The relayed deletion, or `null` if not applicable.
+ */
+function nativeMediaDelete( options, port, token ) {
+	if ( options.method?.toUpperCase() !== 'DELETE' || ! options.path ) {
+		return null;
+	}
+
+	const match = MEDIA_ATTACHMENT_PATH.exec( options.path );
+	if ( ! match ) {
+		return null;
+	}
+
+	const attachmentId = match[ 1 ];
+	const query = requestQuery( options.path );
+
+	info(
+		`Routing deletion of attachment ${ attachmentId } through native server`
+	);
+
+	return fetch(
+		`http://localhost:${ port }/media/${ attachmentId }${ query }`,
+		{
+			method: 'DELETE',
+			headers: { 'Relay-Authorization': `Bearer ${ token }` },
+			signal: options.signal,
+		}
+	).then(
+		( response ) => {
+			if ( options.parse === false ) {
+				if ( ! response.ok ) {
+					return Promise.reject( response );
+				}
+				return response;
+			}
+
+			if ( ! response.ok ) {
+				return response
+					.json()
+					.catch( () => invalidUploadResponseError() )
+					.then( ( body ) => {
+						logError( 'Native media deletion failed', body );
+						throw body;
+					} );
+			}
+
+			return response.json().catch( () => {
+				const error = invalidUploadResponseError();
+				logError(
+					'Native media deletion returned an invalid response',
+					error
+				);
+				throw error;
+			} );
+		},
+		( connectionError ) => {
+			if ( options.signal?.aborted ) {
+				throw uploadAbortError( options.signal );
+			}
+			logError(
+				'Native media deletion failed at the transport layer',
+				connectionError
+			);
 			throw {
 				code: 'fetch_error',
 				message: __(

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -38,6 +38,19 @@ export function configureApiFetch() {
 	// above auth, namespacing, and the root URL, so the `post-process` requests
 	// core issues through `next` are still authenticated and correctly
 	// addressed.
+	//
+	// Recovery needs `x-wp-upload-attachment-id`, readable only same-origin or
+	// when the server exposes it via CORS:
+	//
+	// - Through the native upload server, which exposes it: works on both
+	//   platforms.
+	// - Direct to WordPress, which does not expose it (see
+	//   `rest_send_cors_headers()`): works on Android, whose editor is
+	//   same-origin with the site, and fails on iOS, which loads from `file://`.
+	//
+	// There is no fallback: core sends the header before
+	// `wp_generate_attachment_metadata()`, so the fatal leaves no body to parse
+	// the ID from.
 	apiFetch.use( nativeMediaUploadMiddleware );
 	apiFetch.use( apiFetch.mediaUploadMiddleware );
 	apiFetch.use( stripDraftPostIdMiddleware );

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -32,7 +32,7 @@ export function configureApiFetch() {
 	apiFetch.use( tokenAuthMiddleware );
 	apiFetch.use( filterEndpointsMiddleware );
 	apiFetch.use( nativeMediaUploadMiddleware );
-	apiFetch.use( mediaUploadMiddleware );
+	apiFetch.use( stripDraftPostIdMiddleware );
 	apiFetch.use( transformOEmbedApiResponse );
 	apiFetch.use(
 		apiFetch.createPreloadingMiddleware( preloadData ?? defaultPreloadData )
@@ -379,14 +379,14 @@ function uploadAbortError( signal ) {
 }
 
 /**
- * Middleware to modify media upload requests.
+ * Middleware that strips the placeholder post ID from media upload requests.
  *
  * This middleware intercepts requests to the media endpoint and conditionally
  * removes the 'post' field if its value is '-1', which is used for draft posts.
  *
  * @type {APIFetchMiddleware}
  */
-function mediaUploadMiddleware( options, next ) {
+function stripDraftPostIdMiddleware( options, next ) {
 	if (
 		options.path &&
 		MEDIA_UPLOAD_PATH.test( options.path ) &&

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -193,16 +193,11 @@ function filterEndpointsMiddleware( options, next ) {
 }
 
 /**
- * Middleware that routes media uploads through the native host's local HTTP
- * server for processing (e.g. image resizing) before uploading to WordPress.
+ * Middleware that routes media requests through the native host's local HTTP
+ * server: uploads for processing (e.g. image resizing) before they reach
+ * WordPress, and attachment deletions for the editor's orphan cleanup.
  *
  * Exported for testing only.
- *
- * When `nativeUploadPort` is configured in GBKit, this middleware intercepts
- * `POST /wp/v2/media` requests, forwards the file to the native server, and
- * returns the response in WordPress REST API attachment format so the existing
- * Gutenberg upload pipeline (blob previews, save locking, entity caching)
- * works unchanged.
  *
  * When the native server is not configured, requests pass through unmodified.
  *
@@ -223,27 +218,44 @@ function filterEndpointsMiddleware( options, next ) {
 export function nativeMediaUploadMiddleware( options, next ) {
 	const { nativeUploadPort, nativeUploadToken } = getGBKit();
 
-	if ( nativeUploadPort && nativeUploadToken ) {
-		const deletion = nativeMediaDelete(
-			options,
-			nativeUploadPort,
-			nativeUploadToken
-		);
-		if ( deletion ) {
-			return deletion;
-		}
+	if ( ! nativeUploadPort || ! nativeUploadToken ) {
+		return next( options );
 	}
 
+	// Each helper returns `null` when the request is not its concern, so an
+	// unhandled request falls through to the default path.
+	return (
+		nativeMediaDelete( options, nativeUploadPort, nativeUploadToken ) ??
+		nativeMediaUpload( options, nativeUploadPort, nativeUploadToken ) ??
+		next( options )
+	);
+}
+
+/**
+ * Routes a media upload through the native upload server.
+ *
+ * Returns `null` when the request is not a media upload, so the caller falls
+ * through to its normal handling.
+ *
+ * Intercepts `POST /wp/v2/media`, forwards the file to the native server, and
+ * returns the response in WordPress REST API attachment format so the existing
+ * Gutenberg upload pipeline (blob previews, save locking, entity caching) works
+ * unchanged.
+ *
+ * @param {Object} options The api-fetch options.
+ * @param {number} port    The native upload server port.
+ * @param {string} token   The native upload server bearer token.
+ * @return {?Promise} The relayed upload, or `null` if not applicable.
+ */
+function nativeMediaUpload( options, port, token ) {
 	if (
-		! nativeUploadPort ||
-		! nativeUploadToken ||
 		! options.method ||
 		options.method.toUpperCase() !== 'POST' ||
 		! options.path ||
 		! MEDIA_UPLOAD_PATH.test( options.path ) ||
 		! ( options.body instanceof FormData )
 	) {
-		return next( options );
+		return null;
 	}
 
 	// Only intercept a genuine file upload. `FormData.get('file')` returns a
@@ -253,11 +265,11 @@ export function nativeMediaUploadMiddleware( options, next ) {
 	// through to the default path — and guarantees `file.name` below is safe.
 	const file = options.body.get( 'file' );
 	if ( ! ( file instanceof File ) ) {
-		return next( options );
+		return null;
 	}
 
 	info(
-		`Routing upload of ${ file.name } through native server on port ${ nativeUploadPort }`
+		`Routing upload of ${ file.name } through native server on port ${ port }`
 	);
 
 	// Forward the original request body — the file plus every sibling field
@@ -269,10 +281,10 @@ export function nativeMediaUploadMiddleware( options, next ) {
 	// Use the two-argument form of `.then()` so the rejection handler catches
 	// *only* a connection-level failure of the `fetch()` itself — not errors
 	// thrown while handling a response (those must surface as real failures).
-	return fetch( `http://localhost:${ nativeUploadPort }/upload${ query }`, {
+	return fetch( `http://localhost:${ port }/upload${ query }`, {
 		method: 'POST',
 		headers: {
-			'Relay-Authorization': `Bearer ${ nativeUploadToken }`,
+			'Relay-Authorization': `Bearer ${ token }`,
 		},
 		body: options.body,
 		signal: options.signal,

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -32,12 +32,14 @@ export function configureApiFetch() {
 	apiFetch.use( tokenAuthMiddleware );
 	apiFetch.use( filterEndpointsMiddleware );
 	// `apiFetch.use` unshifts, so the last registration runs first. Core's media
-	// upload middleware is registered before the native one so that it runs
-	// after it, and below auth, namespacing, and the root URL so the
-	// `post-process` requests it issues through `next` stay authenticated and
-	// correctly addressed.
-	apiFetch.use( apiFetch.mediaUploadMiddleware );
+	// upload middleware is registered after the native one so that it runs
+	// before it, wrapping it: the native middleware handles an upload without
+	// calling `next`, so core's would never run at all from below. Both stay
+	// above auth, namespacing, and the root URL, so the `post-process` requests
+	// core issues through `next` are still authenticated and correctly
+	// addressed.
 	apiFetch.use( nativeMediaUploadMiddleware );
+	apiFetch.use( apiFetch.mediaUploadMiddleware );
 	apiFetch.use( stripDraftPostIdMiddleware );
 	apiFetch.use( transformOEmbedApiResponse );
 	apiFetch.use(
@@ -250,6 +252,24 @@ export function nativeMediaUploadMiddleware( options, next ) {
 		signal: options.signal,
 	} ).then(
 		( response ) => {
+			// `parse: false` asks for raw `Response` semantics. Core's media
+			// upload middleware runs above this one and makes exactly that
+			// request so it can read `x-wp-upload-attachment-id` off a failed
+			// upload and retry `post-process`. Honor it by resolving or
+			// rejecting with the `Response` itself, leaving the parsing (and
+			// the recovery decision) to that middleware — parsing here would
+			// hide the header and turn a recoverable upload into a permanent
+			// failure.
+			if ( options.parse === false ) {
+				if ( ! response.ok ) {
+					logError(
+						`Native upload failed with status ${ response.status }`
+					);
+					return Promise.reject( response );
+				}
+				return response;
+			}
+
 			// The native server relays WordPress's response verbatim. On a
 			// non-2xx, mirror @wordpress/api-fetch: reject with the parsed WP
 			// error body ({ code, message, data }) so @wordpress/media-utils

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -73,16 +73,23 @@ function corsMiddleware( options, next ) {
  */
 function apiPathModifierMiddleware( options, next ) {
 	const { siteApiNamespace, namespaceExcludedPaths } = getGBKit();
-	const namespaceRegex = new RegExp( `(${ siteApiNamespace.join( '|' ) })` );
+	// Self-hosted sites configure no namespace, so there is nothing to insert.
+	// This has to gate the rewrite explicitly: the namespace match below cannot
+	// stand in for it, and an empty namespace would otherwise interpolate
+	// `undefined` into the path.
 	const isEligiblePath =
 		options.path &&
+		siteApiNamespace.length > 0 &&
 		! namespaceExcludedPaths.some( ( path ) =>
 			options.path.startsWith( path )
 		);
 
+	// Escape the namespaces so each is matched literally rather than as a
+	// pattern.
 	const alreadyHasSiteNamespace =
-		namespaceRegex.test( options.path ) ||
-		/\/sites\/[^/]+\//.test( options.path );
+		new RegExp(
+			`(${ siteApiNamespace.map( escapeRegExp ).join( '|' ) })`
+		).test( options.path ) || /\/sites\/[^/]+\//.test( options.path );
 
 	if ( isEligiblePath && ! alreadyHasSiteNamespace ) {
 		// Insert the API namespace after the first two path segments.
@@ -93,6 +100,16 @@ function apiPathModifierMiddleware( options, next ) {
 	}
 
 	return next( options );
+}
+
+/**
+ * Escapes a string for literal use inside a regular expression.
+ *
+ * @param {string} value The string to escape.
+ * @return {string} The escaped string.
+ */
+function escapeRegExp( value ) {
+	return value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
 }
 
 /**

--- a/src/utils/api-fetch.js
+++ b/src/utils/api-fetch.js
@@ -94,10 +94,6 @@ function corsMiddleware( options, next ) {
  */
 function apiPathModifierMiddleware( options, next ) {
 	const { siteApiNamespace, namespaceExcludedPaths } = getGBKit();
-	// Self-hosted sites configure no namespace, so there is nothing to insert.
-	// This has to gate the rewrite explicitly: the namespace match below cannot
-	// stand in for it, and an empty namespace would otherwise interpolate
-	// `undefined` into the path.
 	const isEligiblePath =
 		options.path &&
 		siteApiNamespace.length > 0 &&

--- a/src/utils/api-fetch.test.js
+++ b/src/utils/api-fetch.test.js
@@ -194,6 +194,69 @@ describe( 'api-fetch credentials handling', () => {
 		} );
 	} );
 
+	describe( 'apiPathModifierMiddleware', () => {
+		/** The URL of the first `fetch` call. */
+		function requestedUrl() {
+			return String( global.fetch.mock.calls[ 0 ][ 0 ] );
+		}
+
+		it( 'inserts the namespace when the path lacks it', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [ 'sites/123/' ],
+				namespaceExcludedPaths: [],
+			} );
+
+			await apiFetch( { path: '/wp/v2/posts' } ).catch( () => {} );
+
+			expect( requestedUrl() ).toContain( '/wp/v2/sites/123/posts' );
+		} );
+
+		it( 'leaves the path alone when it already carries the namespace', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [ 'sites/123/' ],
+				namespaceExcludedPaths: [],
+			} );
+
+			await apiFetch( { path: '/wp/v2/sites/123/posts' } ).catch(
+				() => {}
+			);
+
+			expect( requestedUrl() ).toContain( '/wp/v2/sites/123/posts' );
+			expect( requestedUrl() ).not.toContain( 'sites/123/sites/123' );
+		} );
+
+		it( 'leaves the path alone when no namespace is configured', async () => {
+			// An empty namespace previously built `new RegExp('()')`, which
+			// matches every string. Nothing should be inserted either way, but
+			// the guard must reach that outcome by reporting no namespace.
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [],
+				namespaceExcludedPaths: [],
+			} );
+
+			await apiFetch( { path: '/wp/v2/posts' } ).catch( () => {} );
+
+			expect( requestedUrl() ).toContain( '/wp/v2/posts' );
+			expect( requestedUrl() ).not.toContain( 'undefined' );
+		} );
+
+		it( 'skips paths excluded from namespacing', async () => {
+			bridge.getGBKit.mockReturnValue( {
+				siteApiRoot: 'https://example.com/wp-json/',
+				siteApiNamespace: [ 'sites/123/' ],
+				namespaceExcludedPaths: [ '/oembed' ],
+			} );
+
+			await apiFetch( { path: '/oembed/1.0/proxy' } ).catch( () => {} );
+
+			expect( requestedUrl() ).toContain( '/oembed/1.0/proxy' );
+			expect( requestedUrl() ).not.toContain( 'sites/123' );
+		} );
+	} );
+
 	it( 'should preserve other headers when adding Authorization', async () => {
 		bridge.getGBKit.mockReturnValue( {
 			siteApiRoot: 'https://example.com/wp-json/',

--- a/wp-env/mu-plugins/gutenbergkit-cors.php
+++ b/wp-env/mu-plugins/gutenbergkit-cors.php
@@ -9,12 +9,13 @@
  */
 function gutenbergkit_cors_allowed_origins() {
 	return array(
-		'http://localhost:5173',                    // Vite dev server
-		'http://localhost:4173',                    // Vite preview server
-		'http://10.0.2.2:5173',                    // Vite dev server (Android emulator)
-		'http://10.0.2.2:4173',                    // Vite preview server (Android emulator)
-		'https://appassets.androidplatform.net',   // Android production build (HTTPS site)
-		'http://appassets.androidplatform.net',    // Android production build (HTTP site)
+		'http://localhost:5173',                 // Vite dev server
+		'http://localhost:4173',                 // Vite preview server
+		'http://10.0.2.2',                       // wp-env site origin (Android emulator)
+		'http://10.0.2.2:5173',                  // Vite dev server (Android emulator)
+		'http://10.0.2.2:4173',                  // Vite preview server (Android emulator)
+		'https://appassets.androidplatform.net', // Android production build (HTTPS site)
+		'http://appassets.androidplatform.net',  // Android production build (HTTP site)
 	);
 }
 

--- a/wp-env/mu-plugins/gutenbergkit-media-failure.php
+++ b/wp-env/mu-plugins/gutenbergkit-media-failure.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Plugin Name: GutenbergKit Media Failure Simulator
+ * Description: Fatals during image sub-size generation so the editor's media upload post-process retry can be exercised locally. Development only.
+ *
+ * Reproduces the failure the retry recovers from: WordPress creates the
+ * attachment row and sends `X-WP-Upload-Attachment-ID`, then
+ * `wp_generate_attachment_metadata()` fatals — typically a PHP `memory_limit`
+ * or `max_execution_time` fatal on a large image. The editor reads that header
+ * off the 5xx and retries `POST /wp/v2/media/<id>/post-process`.
+ *
+ * Adapted from https://github.com/WordPress/gutenberg/pull/17858#issuecomment-540114688,
+ * with the random failure rate replaced by an explicit mode so both outcomes
+ * are reproducible:
+ *
+ *   recover  Fail once per attachment, then succeed. The retry recovers the
+ *            upload and the attachment completes.
+ *   always   Fail every time. Exhausts all five retries, after which the editor
+ *            DELETEs the orphaned attachment.
+ *   off      Normal uploads (the default).
+ *
+ * The mode is stored as an option rather than read per-request, because the
+ * upload and each post-process retry are separate requests — and an upload
+ * routed through the native upload server is relayed by URLSession/OkHttp,
+ * which carries no browser cookie. Set it over the REST API:
+ *
+ *   curl -u "$USER:$APP_PASSWORD" -X POST \
+ *     'http://localhost:8888/wp-json/gutenbergkit/v1/media-failure?mode=recover'
+ *
+ * Or with WP-CLI:
+ *
+ *   npx wp-env run cli wp option update gbk_media_failure_mode recover
+ */
+
+const GBK_MEDIA_FAILURE_OPTION = 'gbk_media_failure_mode';
+const GBK_MEDIA_FAILURE_MODES  = array( 'off', 'recover', 'always' );
+
+/**
+ * Registers a route for flipping the failure mode without WP-CLI.
+ */
+function gbk_media_failure_register_route() {
+	register_rest_route(
+		'gutenbergkit/v1',
+		'/media-failure',
+		array(
+			'methods'             => array( 'GET', 'POST' ),
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' );
+			},
+			'args'                => array(
+				'mode' => array(
+					'type'    => 'string',
+					'enum'    => GBK_MEDIA_FAILURE_MODES,
+					'default' => null,
+				),
+			),
+			'callback'            => function ( $request ) {
+				$mode = $request->get_param( 'mode' );
+
+				if ( null !== $mode ) {
+					update_option( GBK_MEDIA_FAILURE_OPTION, $mode );
+					// A stale per-attachment counter would make `recover` skip
+					// its failure on an attachment that already burned one.
+					gbk_media_failure_reset_counters();
+				}
+
+				return array( 'mode' => gbk_media_failure_mode() );
+			},
+		)
+	);
+}
+add_action( 'rest_api_init', 'gbk_media_failure_register_route' );
+
+/**
+ * Clears the per-attachment failure counters.
+ */
+function gbk_media_failure_reset_counters() {
+	global $wpdb;
+	$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => '_gbk_media_failure_count' ) );
+}
+
+/**
+ * Returns the active failure mode.
+ */
+function gbk_media_failure_mode() {
+	$mode = get_option( GBK_MEDIA_FAILURE_OPTION, 'off' );
+
+	return in_array( $mode, GBK_MEDIA_FAILURE_MODES, true ) ? $mode : 'off';
+}
+
+/**
+ * Whether this sub-size generation pass should fatal.
+ *
+ * In `recover` mode the count is tracked per attachment, so a second upload
+ * fails once too rather than succeeding immediately because an earlier upload
+ * already burned the failure.
+ *
+ * @param int $attachment_id The attachment being processed.
+ */
+function gbk_media_failure_should_fail( $attachment_id ) {
+	switch ( gbk_media_failure_mode() ) {
+		case 'always':
+			return true;
+
+		case 'recover':
+			$key = '_gbk_media_failure_count';
+			// `get_post_meta` returns '' when unset, which casts to 0.
+			$attempts = (int) get_post_meta( $attachment_id, $key, true );
+			update_post_meta( $attachment_id, $key, $attempts + 1 );
+			return 0 === $attempts;
+
+		default:
+			return false;
+	}
+}
+
+/**
+ * Fatals during sub-size generation when the active mode calls for it.
+ *
+ * Hooks both filters core runs while building sub-sizes: the initial upload
+ * goes through `intermediate_image_sizes_advanced`, and the `post-process`
+ * retry goes through `wp_get_missing_image_subsizes`.
+ *
+ * @param array $sizes         The sizes to generate.
+ * @param mixed $metadata      Image metadata (unused).
+ * @param int   $attachment_id The attachment being processed.
+ */
+function gbk_media_failure_maybe_fail( $sizes, $metadata = null, $attachment_id = 0 ) {
+	if ( gbk_media_failure_should_fail( $attachment_id ) ) {
+		// Send the 500 explicitly before dying. A real PHP fatal under FPM
+		// surfaces as a 500, but the Playground runtime wp-env uses returns 200,
+		// which the editor's retry (`status >= 500`) would ignore. The status
+		// has to be set here because `X-WP-Upload-Attachment-ID` was already
+		// sent above this filter, so PHP has committed the response.
+		if ( ! headers_sent() ) {
+			http_response_code( 500 );
+		}
+
+		// Terminate the way a memory_limit or max_execution_time fatal does,
+		// after the attachment row exists and its ID header has been sent.
+		trigger_error( 'GutenbergKit simulated media failure', E_USER_ERROR );
+		exit;
+	}
+
+	return $sizes;
+}
+add_filter( 'intermediate_image_sizes_advanced', 'gbk_media_failure_maybe_fail', 10, 3 );
+add_filter( 'wp_get_missing_image_subsizes', 'gbk_media_failure_maybe_fail', 10, 3 );

--- a/wp-env/mu-plugins/gutenbergkit-media-failure.php
+++ b/wp-env/mu-plugins/gutenbergkit-media-failure.php
@@ -115,6 +115,31 @@ function gbk_media_failure_should_fail( $attachment_id ) {
 }
 
 /**
+ * Whether the current request is one this simulator should be able to fail.
+ *
+ * Only the upload and its `post-process` retries. A `DELETE` must be left alone
+ * even in `always` mode: core's `force=true` delete path also runs sub-size
+ * handling, so failing there fatals the editor's orphan cleanup — the very
+ * request that proves the retry gave up correctly. Worse, a fatal aborts the
+ * request before `rest_pre_serve_request` adds CORS headers, so the editor sees
+ * a CORS error rather than the 500, which reads like a bug in the editor rather
+ * than in this plugin.
+ */
+function gbk_media_failure_is_failable_request() {
+	$method = isset( $_SERVER['REQUEST_METHOD'] )
+		? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) )
+		: '';
+
+	// api-fetch tunnels DELETE through POST with an override header, so the
+	// bare method is not enough to identify a delete.
+	$override = isset( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] )
+		? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ) ) )
+		: '';
+
+	return 'DELETE' !== $method && 'DELETE' !== $override;
+}
+
+/**
  * Fatals during sub-size generation when the active mode calls for it.
  *
  * Hooks both filters core runs while building sub-sizes: the initial upload
@@ -126,6 +151,10 @@ function gbk_media_failure_should_fail( $attachment_id ) {
  * @param int   $attachment_id The attachment being processed.
  */
 function gbk_media_failure_maybe_fail( $sizes, $metadata = null, $attachment_id = 0 ) {
+	if ( ! gbk_media_failure_is_failable_request() ) {
+		return $sizes;
+	}
+
 	if ( gbk_media_failure_should_fail( $attachment_id ) ) {
 		// Send the 500 explicitly before dying. A real PHP fatal under FPM
 		// surfaces as a 500, but the Playground runtime wp-env uses returns 200,


### PR DESCRIPTION
Stacked on #594. Makes performing a media upload — and retrying it — a single, all-or-nothing responsibility: either GutenbergKit performs the upload and owns its retries, or the host does (say, to run it through its own networking so it can log every request). Both go to the same configured site; the only difference is who executes the requests. There's no in-between where the host performs the upload but GutenbergKit retries it.

## Summary

Two protocols replace the single `MediaUploadDelegate`:

- **`MediaProcessor`** — transform the file before upload; GutenbergKit performs the upload and owns its retries. The common, safe extension point.
- **`MediaUploader`** — perform the upload yourself (your own networking, logging, retry policy, a background session) and own its whole lifecycle: retries, recovery, and cleanup. Receives a **`MediaUpload`** value carrying the file, its metadata, the editor's non-file form fields (`post`, additionalData), and the request query (`?_embed`).

`EditorViewController` / `GutenbergView` **own** whichever handler you set — their properties are strong on both platforms, so you can assign one and drop your own reference (just don't strongly retain the editor back).

**Breaking**: hosts migrate `mediaUploadDelegate` → `mediaProcessor` / `mediaUploader`.

## The problem with the old design

When an upload fatals in server-side post-processing, it has to be retried: core retries `POST …/post-process` up to 5×, and cleans up the orphan if that fails.

`MediaUploadDelegate.uploadFile` let a host perform the upload itself by returning the raw response it received. But that split one upload's HTTP across two owners: the host performed the `POST /wp/v2/media`, then core — reading that raw response — drove the `post-process` retries (and the orphan cleanup) behind it. A host that took over uploads to run them through its own stack still didn't own the retries; those went out through the browser, not the host. Delivery and its retries were owned by different parties.

## The fix

Make the upload and its retries one unit with one owner:

- **`MediaProcessor`** (`handlesFile`, `processFile`) only transforms the file. It never performs the upload, so GutenbergKit performs it and owns the retries. The extension point almost every host wants.
- **`MediaUploader`** (`upload(_:)`) performs the upload on the host's own stack and owns the whole lifecycle. `upload` returns the **finished attachment or throws** — there's no raw response for core to retry behind it, so the host drives its own `post-process` recovery and force-deletes its own orphan on terminal failure. The **`MediaUpload`** it receives carries everything needed to reproduce a native request — the file, the editor's `post` / additionalData fields, and the `?_embed` query — so a host upload attaches to its post instead of landing as an unattached orphan.

So it's all-or-nothing: the host performs the upload and its retries, or GutenbergKit does — never a split. An uploader and GutenbergKit's built-in default both target the same configured site; the choice is only who executes the requests.

Media **deletes** always relay to the default uploader (the configured site) — every attachment lives there, even one a host uploader delivered, so there's no per-host delete path. The server starts if either handler is set and builds a default uploader whenever site credentials are present (it delivers GutenbergKit's own uploads and relays every delete). Because deletes need it, a `mediaUploader` set **without** site credentials is a configuration error and traps at startup rather than starting a server whose every delete would 500. `MediaUploadResponse` is now `internal` — it's no longer on any public API.

## Accepted Risk / Out of Scope

- **The configured-site delete relay isn't scoped.** GutenbergKit relays core's cleanup `DELETE` to the configured site, but the relay can't distinguish it from any other `DELETE` the WebView sends — a _client-side-compromised_ editor (a supply-chain-tampered JS bundle, or editor XSS) holding the loopback token could force-delete arbitrary media there. We accept this: such a script already has broad write access via allowed methods, and a _server-side_ compromise (a malicious plugin) deletes media directly without the editor. An earlier revision carried a per-session ledger to scope the relay; it's dropped as not worth the cost for a client-side-only threat.

## Test Plan

- [x] iOS host suite green
- [x] Android unit suites green — `MediaUploadServer`, `GutenbergView`
- [x] SwiftLint + Detekt clean
- [x] iOS demo app builds (`xcodebuild`, Xcode 26.4.1); Android demo builds (Detekt compiles it)
- [ ] Migrate `mediaUploadDelegate` in WordPress-iOS / WordPress-Android / Jetpack

## Related

- Stacked on #594; merges into it.
