### PR TITLE
fix(ios): gate the media upload server on the site root too

### DIFF
--- a/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
+++ b/ios/Sources/GutenbergKit/Sources/EditorViewController.swift
@@ -468,7 +468,13 @@ public final class EditorViewController: UIViewController, GutenbergEditorContro
         // it because the WebView has no auth cookies). Without both there is nothing
         // to upload through, so leave the server down and let uploads fall to the
         // default WebView path rather than start a server that could only fail.
-        guard !configuration.authHeader.isEmpty else {
+        //
+        // `MediaServerCredentials` owns the check so it is reachable from the host
+        // test suite — this file is not.
+        guard MediaServerCredentials.areUsable(
+            siteApiRoot: configuration.siteApiRoot,
+            authHeader: configuration.authHeader
+        ) else {
             return
         }
 

--- a/ios/Sources/GutenbergKit/Sources/Media/MediaServerCredentials.swift
+++ b/ios/Sources/GutenbergKit/Sources/Media/MediaServerCredentials.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Whether the editor configuration can reach the configured site for media.
+///
+/// Deliberately outside `EditorViewController`. That type is `#if canImport(UIKit)`,
+/// so on the macOS host it does not exist and nothing in it can be tested — including
+/// this check, which already diverged silently between iOS and Android once. Living
+/// here, it is reachable from the host test suite.
+enum MediaServerCredentials {
+    /// Whether a ``DefaultMediaUploader`` built from this configuration could actually
+    /// reach the site.
+    ///
+    /// Both fields are required. The uploader delivers GutenbergKit's uploads to the
+    /// configured site, so it needs somewhere to send them and credentials to be
+    /// accepted; with either missing, every media request it makes fails.
+    ///
+    /// `siteApiRoot` is a `URL` here where Android types it as a `String`, so the
+    /// equivalent of Android's `isEmpty()` check is "not absolute" — a URL with no
+    /// scheme or host cannot address the site, and every request built from it fails at
+    /// the URLSession layer.
+    static func areUsable(siteApiRoot: URL, authHeader: String) -> Bool {
+        siteApiRoot.scheme != nil && siteApiRoot.host() != nil && !authHeader.isEmpty
+    }
+}

--- a/ios/Tests/GutenbergKitTests/Media/MediaServerCredentialsTests.swift
+++ b/ios/Tests/GutenbergKitTests/Media/MediaServerCredentialsTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+@testable import GutenbergKit
+
+@Suite("MediaServerCredentials")
+struct MediaServerCredentialsTests {
+  private static let siteRoot = URL(string: "https://example.com/wp-json/")!
+
+  @Test("accepts an absolute site root with an auth header")
+  func acceptsUsableCredentials() {
+    #expect(MediaServerCredentials.areUsable(siteApiRoot: Self.siteRoot, authHeader: "Bearer t"))
+  }
+
+  @Test("rejects an empty auth header")
+  func rejectsEmptyAuthHeader() {
+    #expect(!MediaServerCredentials.areUsable(siteApiRoot: Self.siteRoot, authHeader: ""))
+  }
+
+  // The two arms below are what a `URL` makes different from Android's `String`:
+  // `isEmpty()` has no direct equivalent, so "addressable" is spelled as scheme and
+  // host both being present. A URL missing either cannot reach the site, and every
+  // request built from it fails at the URLSession layer.
+
+  @Test("rejects a site root with no scheme")
+  func rejectsSchemelessSiteRoot() {
+    let relative = URL(string: "example.com/wp-json/")!
+    #expect(!MediaServerCredentials.areUsable(siteApiRoot: relative, authHeader: "Bearer t"))
+  }
+
+  @Test("rejects a site root with no host")
+  func rejectsHostlessSiteRoot() {
+    let fileURL = URL(fileURLWithPath: "/tmp/wp-json")
+    #expect(!MediaServerCredentials.areUsable(siteApiRoot: fileURL, authHeader: "Bearer t"))
+  }
+
+  @Test("rejects an empty site root, the default when a host configures none")
+  func rejectsEmptySiteRoot() {
+    #expect(!MediaServerCredentials.areUsable(siteApiRoot: URL(string: "/")!, authHeader: "Bearer t"))
+  }
+}


### PR DESCRIPTION
Stacked on #594. First of nine PRs splitting #621, each building on the one before. Most are a single commit; #625 and #685 carry follow-up fixes an adversarial review turned up.

## What?

iOS starts the native media upload server without checking that `siteApiRoot` is usable. Android has checked it since it landed.

## Why?

`startUploadServer` guards on `authHeader.isEmpty` alone, though the comment directly above it says the uploader "needs a site root and an auth header". An iOS host that configured an auth header but no `siteApiRoot` started a server whose every request failed at the URLSession layer, instead of falling back to the WebView upload path the way Android does.

The two platforms diverged here unnoticed because the check lives in `EditorViewController`, which is `#if canImport(UIKit)` — it does not exist on the macOS host, so nothing in it is reachable from the test suite.

## How?

- **ios/Sources/GutenbergKit/Sources/Media/MediaServerCredentials.swift**: new. `areUsable(siteApiRoot:authHeader:)` owns the check, outside the UIKit gate so it is testable.
- **ios/Sources/GutenbergKit/Sources/EditorViewController.swift**: `startUploadServer` calls it.

`siteApiRoot` is a `URL` here where Android types it as a `String`, so `isEmpty()` has no direct equivalent — "addressable" is spelled as scheme and host both being present.

## Testing Instructions

Five tests pin the predicate, including both arms of the site-root check.

- [x] `swift test` — host suite green
- [x] iOS Simulator `xcodebuild` (the host build compiles `EditorViewController` as empty, so the gated change needs a simulator build)
- [x] SwiftLint clean
