### PR TITLE
build: pin the wp-env WordPress core and plugin versions

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,8 +1,8 @@
 {
-	"core": "https://wordpress.org/latest.zip",
+	"core": "https://wordpress.org/wordpress-7.1.zip",
 	"plugins": [
-		"https://downloads.wordpress.org/plugin/gutenberg.zip",
-		"https://downloads.wordpress.org/plugin/jetpack.zip"
+		"https://downloads.wordpress.org/plugin/gutenberg.23.9.1.zip",
+		"https://downloads.wordpress.org/plugin/jetpack.16.1.3.zip"
 	],
 	"mappings": {
 		"wp-content/mu-plugins": "./wp-env/mu-plugins"

--- a/docs/code/local-wordpress.md
+++ b/docs/code/local-wordpress.md
@@ -47,6 +47,30 @@ The `.wp-env.json` file at the project root configures the environment:
 -   A **CORS mu-plugin** (`wp-env/mu-plugins/gutenbergkit-cors.php`) adds CORS headers to REST API responses, allowing requests from the Vite dev server, preview server, and native WebViews.
 -   **WP_DEBUG** and **WP_DEBUG_LOG** are enabled for development.
 
+WordPress core and both plugins are **pinned to explicit versions**. wp-env
+downloads whatever the URL resolves to, so unpinned URLs mean every CI run
+installs whatever shipped that day — and a third-party release can turn every
+open PR red without a line of code changing. That has happened: a Jetpack
+release began requiring `window.wp.theme`, and until #614 exposed it, no
+Jetpack block registered and the third-party block E2E tests failed on every
+branch that predated the fix.
+
+Pinning trades that for a manual bump. Nothing watches these versions —
+Dependabot does not read `.wp-env.json` — so raise them deliberately, in their
+own PR, where a failure is attributable to the upgrade rather than to whatever
+else is in flight:
+
+```json
+"core": "https://wordpress.org/wordpress-<version>.zip",
+"plugins": [
+    "https://downloads.wordpress.org/plugin/gutenberg.<version>.zip",
+    "https://downloads.wordpress.org/plugin/jetpack.<version>.zip"
+]
+```
+
+Bumping requires `make wp-env-start RESET=1`, since an existing environment
+keeps the version it was created with.
+
 ### Credential Provisioning
 
 The `bin/wp-env-setup.sh` script runs automatically after `wp-env start`:


### PR DESCRIPTION
## What?

Pins `.wp-env.json` to explicit versions instead of `latest.zip` and unversioned plugin zips.

```diff
-"core": "https://wordpress.org/latest.zip",
+"core": "https://wordpress.org/wordpress-7.1.zip",
 "plugins": [
-    "https://downloads.wordpress.org/plugin/gutenberg.zip",
-    "https://downloads.wordpress.org/plugin/jetpack.zip"
+    "https://downloads.wordpress.org/plugin/gutenberg.23.9.1.zip",
+    "https://downloads.wordpress.org/plugin/jetpack.16.1.3.zip"
 ]
```

## Why?

wp-env downloads whatever the URL resolves to, so every CI run installed whatever shipped that day. **A third-party release could turn every open PR red without a line of code changing** — and did.

A Jetpack release began bundling `@wordpress/ui` 0.21, whose `ThemeProvider` shim reads `window.wp.theme` at module-evaluation time and throws when it is missing. No Jetpack block registered, so `e2e/third-party-blocks.spec.js` failed on every branch that predated #614:

```
Boolean( window.wp.blocks.getBlockType( 'jetpack/tiled-gallery' ) )  // false
```

Nothing in any affected branch had changed. #594 last passed on Aug 21 and first failed on Sept 3; the only commit between the two deletes a `logError` call. The break came from outside the repo, arrived unannounced, and surfaced as a red check on eleven unrelated PRs — where the natural first assumption is that the PR broke something.

## Trade-off

Pinning is not free, and this is the part worth arguing about.

**Cost**: nothing watches these versions — Dependabot does not read `.wp-env.json` — so they will rot until someone bumps them, and the local environment drifts from what users actually run.

**Benefit**: an upgrade becomes a reviewable change whose failure is attributable to the upgrade, rather than a surprise on someone else's PR.

A lighter alternative, if the bump chore isn't wanted: pin **only Jetpack**, the third-party dependency we don't control and the one that actually broke, and leave core and Gutenberg tracking latest since those are the surfaces GutenbergKit is meant to stay current with. Happy to cut it back to that.

## How?

The three versions are what CI resolved `latest` to on a passing run, so this freezes a known-good state rather than proposing an upgrade. Each was confirmed against the WordPress.org API (`core/stable-check`, `plugins/info/1.0`), and all three versioned URLs return HTTP 200 — a 404 would break wp-env outright.

`.wp-env.json` is strict JSON with no comment support, so the rationale and the bump procedure go in **docs/code/local-wordpress.md**, under the existing "wp-env Configuration" section. That includes the part that bites: bumping requires `make wp-env-start RESET=1`, since an existing environment keeps the version it was created with.

## Testing Instructions

- [x] `.wp-env.json` is valid JSON
- [x] All three versioned URLs return HTTP 200
- [x] ESLint and Prettier clean
- [ ] **Web E2E green in CI** — the actual proof

I have not booted wp-env with these pins locally; the versions match what CI just used and the URLs resolve, but only a green E2E run demonstrates it. Worth watching that check specifically before this merges.

## Related

- #614 — exposed `window.wp.theme`, the fix for the incident above
- Found while rebasing the #594 stack (#624–#633) onto trunk to pick up that fix