### PR TITLE
fix(android)!: preserve the post title when the editor cannot be read

### DIFF
--- a/android/Gutenberg/src/androidTest/java/org/wordpress/gutenberg/EditorBridgeTeardownInstrumentedTest.kt
+++ b/android/Gutenberg/src/androidTest/java/org/wordpress/gutenberg/EditorBridgeTeardownInstrumentedTest.kt
@@ -4,6 +4,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import org.json.JSONException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -12,15 +13,10 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 /**
- * Pins what a real [WebView] hands back once the editor's bridge is gone.
+ * Pins what a real [WebView] returns for [getTitleAndContentScript] once the
+ * editor's bridge is gone, and that [parseTitleAndContent] reports it as a failed
+ * read.
  *
- * When the editor's `ErrorBoundary` catches, React unmounts the editor and
- * `useHostBridge`'s cleanup deletes every `window.editor.*` method, while
- * `window.editor` survives as an empty object because it is assigned at module
- * scope. `GutenbergView.isEditorLoaded` is never reset, so `getTitleAndContent`
- * still reaches the web view in that state.
- *
- * The exact string returned here is what [parseTitleAndContent] has to reject.
  * A unit test asserting `"null"` in isolation would keep passing even if the
  * platform started returning something else, which is why this runs on a device.
  *
@@ -32,6 +28,19 @@ import java.util.concurrent.TimeUnit
 class EditorBridgeTeardownInstrumentedTest {
 
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
+
+    @Test
+    fun aTornDownBridgeIsReportedAsAFailedRead() {
+        val result = evaluateAgainstTornDownBridge(
+            getTitleAndContentScript(completeComposition = true)
+        )
+
+        assertEquals("null", result)
+        assertTrue(
+            "a failed read must not resolve to a title the host would persist",
+            parseTitleAndContent(result, ORIGINAL_CONTENT).exceptionOrNull() is JSONException
+        )
+    }
 
     private fun evaluateAgainstTornDownBridge(script: String): String {
         lateinit var webView: WebView
@@ -49,41 +58,30 @@ class EditorBridgeTeardownInstrumentedTest {
                 null, "<html><body></body></html>", "text/html", "utf-8", null
             )
         }
-        assertTrue("page loaded", loaded.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
 
-        val result = arrayOfNulls<String>(1)
-        val evaluated = CountDownLatch(1)
-        instrumentation.runOnMainSync {
-            // The post-crash bridge: the object remains, the methods are gone.
-            webView.evaluateJavascript("window.editor = {};", null)
-            webView.evaluateJavascript(script) { value ->
-                result[0] = value
-                evaluated.countDown()
+        try {
+            assertTrue("page loaded", loaded.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+            val result = arrayOfNulls<String>(1)
+            val evaluated = CountDownLatch(1)
+            instrumentation.runOnMainSync {
+                // The post-crash bridge: the object remains, the methods are gone.
+                webView.evaluateJavascript("window.editor = {};", null)
+                webView.evaluateJavascript(script) { value ->
+                    result[0] = value
+                    evaluated.countDown()
+                }
             }
+            assertTrue("script evaluated", evaluated.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+            return result[0]!!
+        } finally {
+            instrumentation.runOnMainSync { webView.destroy() }
         }
-        assertTrue("script evaluated", evaluated.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
-
-        return result[0]!!
-    }
-
-    @Test
-    fun evaluateJavaScriptYieldsNullWhenTheBridgeMethodIsGone() {
-        assertEquals("null", evaluateAgainstTornDownBridge(GET_TITLE_AND_CONTENT))
-    }
-
-    @Test
-    fun theTornDownBridgeResultIsRejectedRatherThanReadAsAnEmptyTitle() {
-        val result = evaluateAgainstTornDownBridge(GET_TITLE_AND_CONTENT)
-
-        assertTrue(
-            "a failed read must not resolve to a title the host would persist",
-            parseTitleAndContent(result, ORIGINAL_CONTENT).isFailure
-        )
     }
 
     private companion object {
         const val TIMEOUT_SECONDS = 10L
-        const val GET_TITLE_AND_CONTENT = "editor.getTitleAndContent(true);"
         const val ORIGINAL_CONTENT = "<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->"
     }
 }

--- a/android/Gutenberg/src/androidTest/java/org/wordpress/gutenberg/EditorBridgeTeardownInstrumentedTest.kt
+++ b/android/Gutenberg/src/androidTest/java/org/wordpress/gutenberg/EditorBridgeTeardownInstrumentedTest.kt
@@ -1,0 +1,90 @@
+package org.wordpress.gutenberg
+
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Pins what a real [WebView] hands back once the editor's bridge is gone.
+ *
+ * When the editor's `ErrorBoundary` catches, React unmounts the editor and
+ * `useHostBridge`'s cleanup deletes every `window.editor.*` method, while
+ * `window.editor` survives as an empty object because it is assigned at module
+ * scope. `GutenbergView.isEditorLoaded` is never reset, so `getTitleAndContent`
+ * still reaches the web view in that state.
+ *
+ * The exact string returned here is what [parseTitleAndContent] has to reject.
+ * A unit test asserting `"null"` in isolation would keep passing even if the
+ * platform started returning something else, which is why this runs on a device.
+ *
+ *   ./gradlew :Gutenberg:connectedDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=\
+ *     org.wordpress.gutenberg.EditorBridgeTeardownInstrumentedTest
+ */
+@RunWith(AndroidJUnit4::class)
+class EditorBridgeTeardownInstrumentedTest {
+
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+
+    private fun evaluateAgainstTornDownBridge(script: String): String {
+        lateinit var webView: WebView
+        val loaded = CountDownLatch(1)
+
+        instrumentation.runOnMainSync {
+            webView = WebView(instrumentation.targetContext)
+            webView.settings.javaScriptEnabled = true
+            webView.webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView, url: String) {
+                    loaded.countDown()
+                }
+            }
+            webView.loadDataWithBaseURL(
+                null, "<html><body></body></html>", "text/html", "utf-8", null
+            )
+        }
+        assertTrue("page loaded", loaded.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+        val result = arrayOfNulls<String>(1)
+        val evaluated = CountDownLatch(1)
+        instrumentation.runOnMainSync {
+            // The post-crash bridge: the object remains, the methods are gone.
+            webView.evaluateJavascript("window.editor = {};", null)
+            webView.evaluateJavascript(script) { value ->
+                result[0] = value
+                evaluated.countDown()
+            }
+        }
+        assertTrue("script evaluated", evaluated.await(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+
+        return result[0]!!
+    }
+
+    @Test
+    fun evaluateJavaScriptYieldsNullWhenTheBridgeMethodIsGone() {
+        assertEquals("null", evaluateAgainstTornDownBridge(GET_TITLE_AND_CONTENT))
+    }
+
+    @Test
+    fun theTornDownBridgeResultIsRejectedRatherThanReadAsAnEmptyTitle() {
+        val result = evaluateAgainstTornDownBridge(GET_TITLE_AND_CONTENT)
+
+        assertNull(
+            "a failed read must not resolve to a title the host would persist",
+            parseTitleAndContent(result, ORIGINAL_CONTENT)
+        )
+    }
+
+    private companion object {
+        const val TIMEOUT_SECONDS = 10L
+        const val GET_TITLE_AND_CONTENT = "editor.getTitleAndContent(true);"
+        const val ORIGINAL_CONTENT = "<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->"
+    }
+}

--- a/android/Gutenberg/src/androidTest/java/org/wordpress/gutenberg/EditorBridgeTeardownInstrumentedTest.kt
+++ b/android/Gutenberg/src/androidTest/java/org/wordpress/gutenberg/EditorBridgeTeardownInstrumentedTest.kt
@@ -5,7 +5,6 @@ import android.webkit.WebViewClient
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -76,9 +75,9 @@ class EditorBridgeTeardownInstrumentedTest {
     fun theTornDownBridgeResultIsRejectedRatherThanReadAsAnEmptyTitle() {
         val result = evaluateAgainstTornDownBridge(GET_TITLE_AND_CONTENT)
 
-        assertNull(
+        assertTrue(
             "a failed read must not resolve to a title the host would persist",
-            parseTitleAndContent(result, ORIGINAL_CONTENT)
+            parseTitleAndContent(result, ORIGINAL_CONTENT).isFailure
         )
     }
 

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -96,7 +96,7 @@ const val ASSET_PATH_INDEX = "/assets/index.html"
  */
 class GutenbergView : FrameLayout {
     private val webView: WebView
-    private var isEditorLoaded = false
+    @Volatile private var isEditorLoaded = false
     private var didFireEditorLoaded = false
     private lateinit var assetLoader: WebViewAssetLoader
     private lateinit var assetAuthority: String

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -867,7 +867,6 @@ class GutenbergView : FrameLayout {
         }
     }
 
-
     fun undo() {
         handler.post {
             webView.evaluateJavascript("editor.undo();", null)

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -757,9 +757,8 @@ class GutenbergView : FrameLayout {
         fun onResult(title: CharSequence, content: CharSequence)
 
         /**
-         * The editor could not be read. Most often the editor crashed and its
-         * `window.editor.*` bridge methods were torn down, so the evaluation
-         * returned no usable value.
+         * The editor could not be read, so there is no title or content to
+         * report.
          *
          * A failed read is not an empty post: hosts must leave the last known
          * title and content in place rather than persisting anything derived
@@ -768,8 +767,11 @@ class GutenbergView : FrameLayout {
          * Defaults to a no-op. A host that has not adopted it simply receives
          * no callback at all, so its own timeout path applies — still safe,
          * just slower than handling this directly.
+         *
+         * @param error [EditorNotReadyException] when the editor has not
+         * loaded, or a [JSONException] when its result could not be read.
          */
-        fun onError() {}
+        fun onError(error: Throwable) {}
     }
 
     interface ContentChangeListener {
@@ -854,17 +856,15 @@ class GutenbergView : FrameLayout {
             // Report rather than returning silently, so both ways this call can
             // fail look the same to the host. A host awaiting a callback would
             // otherwise wait out its own timeout here, or never resume at all.
-            callback.onError()
+            callback.onError(EditorNotReadyException())
             return
         }
         handler.post {
             webView.evaluateJavascript("editor.getTitleAndContent($completeComposition);") { result ->
-                val fields = parseTitleAndContent(result, originalContent)
-                if (fields == null) {
-                    callback.onError()
-                } else {
-                    callback.onResult(fields.first, fields.second)
-                }
+                parseTitleAndContent(result, originalContent).fold(
+                    onSuccess = { (title, content) -> callback.onResult(title, content) },
+                    onFailure = { error -> callback.onError(error) }
+                )
             }
         }
     }
@@ -1306,10 +1306,17 @@ class GutenbergView : FrameLayout {
 }
 
 /**
- * Parses the result of `editor.getTitleAndContent`, returning `null` when it
- * cannot be read.
+ * Reported when the editor is read before it has loaded.
+ */
+class EditorNotReadyException : IllegalStateException(
+    "The editor is not ready. Wait for onEditorAvailable before calling bridge methods."
+)
+
+/**
+ * Parses the result of `editor.getTitleAndContent`, failing when it cannot be
+ * read.
  *
- * Returning `null` rather than a partially defaulted pair is the point. A crashed
+ * Failing rather than returning a partially defaulted pair is the point. A crashed
  * editor leaves `window.editor` an empty object, so the evaluation yields the
  * string `"null"`; substituting `""` for the title there is indistinguishable
  * from the user clearing it, and the host persists it over their own.
@@ -1318,14 +1325,14 @@ class GutenbergView : FrameLayout {
 internal fun parseTitleAndContent(
     result: String?,
     originalContent: CharSequence
-): Pair<CharSequence, CharSequence>? = try {
+): Result<Pair<CharSequence, CharSequence>> = try {
     val json = JSONObject(result.orEmpty())
     val title: CharSequence = json.getString("title")
     val updatedContent: CharSequence = json.getString("content")
-    title to if (json.getBoolean("changed")) updatedContent else originalContent
+    Result.success(title to if (json.getBoolean("changed")) updatedContent else originalContent)
 } catch (e: JSONException) {
     Log.e("GutenbergView", "Received invalid JSON from editor.getTitleAndContent", e)
-    null
+    Result.failure(e)
 }
 
 data class Media(

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -851,6 +851,10 @@ class GutenbergView : FrameLayout {
     fun getTitleAndContent(originalContent: CharSequence, callback: TitleAndContentCallback, completeComposition: Boolean = false) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
+            // Report rather than returning silently, so both ways this call can
+            // fail look the same to the host. A host awaiting a callback would
+            // otherwise wait out its own timeout here, or never resume at all.
+            callback.onError()
             return
         }
         handler.post {

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -853,10 +853,8 @@ class GutenbergView : FrameLayout {
     fun getTitleAndContent(originalContent: CharSequence, callback: TitleAndContentCallback, completeComposition: Boolean = false) {
         if (!isEditorLoaded) {
             Log.e("GutenbergView", "You can't change the editor content until it has loaded")
-            // Report rather than returning silently, so both ways this call can
-            // fail look the same to the host. A host awaiting a callback would
-            // otherwise wait out its own timeout here, or never resume at all.
-            callback.onError(EditorNotReadyException())
+            // Posted so the error arrives on the main thread, as a read's result does.
+            handler.post { callback.onError(EditorNotReadyException()) }
             return
         }
         handler.post {

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -858,7 +858,7 @@ class GutenbergView : FrameLayout {
             return
         }
         handler.post {
-            webView.evaluateJavascript("editor.getTitleAndContent($completeComposition);") { result ->
+            webView.evaluateJavascript(getTitleAndContentScript(completeComposition)) { result ->
                 parseTitleAndContent(result, originalContent).fold(
                     onSuccess = { (title, content) -> callback.onResult(title, content) },
                     onFailure = { error -> callback.onError(error) }
@@ -1309,6 +1309,14 @@ class GutenbergView : FrameLayout {
 class EditorNotReadyException : IllegalStateException(
     "The editor is not ready. Wait for onEditorAvailable before calling bridge methods."
 )
+
+/**
+ * The script `getTitleAndContent` evaluates, shared so tests run exactly what the
+ * editor is sent.
+ */
+@VisibleForTesting
+internal fun getTitleAndContentScript(completeComposition: Boolean): String =
+    "editor.getTitleAndContent($completeComposition);"
 
 /**
  * Parses the result of `editor.getTitleAndContent`, failing when it cannot be

--- a/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
+++ b/android/Gutenberg/src/main/java/org/wordpress/gutenberg/GutenbergView.kt
@@ -30,6 +30,7 @@ import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import android.widget.ProgressBar
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
 import kotlinx.coroutines.CoroutineScope
@@ -754,6 +755,21 @@ class GutenbergView : FrameLayout {
 
     interface TitleAndContentCallback {
         fun onResult(title: CharSequence, content: CharSequence)
+
+        /**
+         * The editor could not be read. Most often the editor crashed and its
+         * `window.editor.*` bridge methods were torn down, so the evaluation
+         * returned no usable value.
+         *
+         * A failed read is not an empty post: hosts must leave the last known
+         * title and content in place rather than persisting anything derived
+         * from this call.
+         *
+         * Defaults to a no-op. A host that has not adopted it simply receives
+         * no callback at all, so its own timeout path applies — still safe,
+         * just slower than handling this directly.
+         */
+        fun onError() {}
     }
 
     interface ContentChangeListener {
@@ -839,28 +855,16 @@ class GutenbergView : FrameLayout {
         }
         handler.post {
             webView.evaluateJavascript("editor.getTitleAndContent($completeComposition);") { result ->
-                var lastUpdatedTitle: CharSequence? = null
-                var lastUpdatedContent: CharSequence? = null
-                var changed = false
-                try {
-                    val jsonObject = JSONObject(result)
-                    lastUpdatedTitle = jsonObject.getString("title")
-                    lastUpdatedContent = jsonObject.getString("content")
-                    changed = jsonObject.getBoolean("changed")
-                } catch (e: JSONException) {
-                    Log.e("GutenbergView", "Received invalid JSON from editor.getTitleAndContent")
-                }
-
-                val title = lastUpdatedTitle ?: ""
-                val content = if (changed) {
-                    lastUpdatedContent ?: ""
+                val fields = parseTitleAndContent(result, originalContent)
+                if (fields == null) {
+                    callback.onError()
                 } else {
-                    originalContent
+                    callback.onResult(fields.first, fields.second)
                 }
-                callback.onResult(title, content)
             }
         }
     }
+
 
     fun undo() {
         handler.post {
@@ -1295,6 +1299,29 @@ class GutenbergView : FrameLayout {
             warmupRunnable = null
         }
     }
+}
+
+/**
+ * Parses the result of `editor.getTitleAndContent`, returning `null` when it
+ * cannot be read.
+ *
+ * Returning `null` rather than a partially defaulted pair is the point. A crashed
+ * editor leaves `window.editor` an empty object, so the evaluation yields the
+ * string `"null"`; substituting `""` for the title there is indistinguishable
+ * from the user clearing it, and the host persists it over their own.
+ */
+@VisibleForTesting
+internal fun parseTitleAndContent(
+    result: String?,
+    originalContent: CharSequence
+): Pair<CharSequence, CharSequence>? = try {
+    val json = JSONObject(result.orEmpty())
+    val title: CharSequence = json.getString("title")
+    val updatedContent: CharSequence = json.getString("content")
+    title to if (json.getBoolean("changed")) updatedContent else originalContent
+} catch (e: JSONException) {
+    Log.e("GutenbergView", "Received invalid JSON from editor.getTitleAndContent", e)
+    null
 }
 
 data class Media(

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
@@ -390,7 +390,7 @@ class GutenbergViewTest {
     @Test
     fun `getTitleAndContent reports an error when the editor has not loaded`() {
         // The fixture has never received onEditorLoaded, so the read cannot proceed.
-        var errors = 0
+        val errors = mutableListOf<Throwable>()
         var results = 0
 
         gutenbergView.getTitleAndContent(
@@ -400,14 +400,15 @@ class GutenbergViewTest {
                     results++
                 }
 
-                override fun onError() {
-                    errors++
+                override fun onError(error: Throwable) {
+                    errors += error
                 }
             }
         )
         shadowOf(Looper.getMainLooper()).idle()
 
-        assertEquals("the host is told the read failed", 1, errors)
+        assertEquals("the host is told the read failed", 1, errors.size)
+        assertTrue("because the editor is not ready", errors.first() is EditorNotReadyException)
         assertEquals("no content is reported", 0, results)
     }
 }

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
@@ -386,4 +386,28 @@ class GutenbergViewTest {
             result
         )
     }
+
+    @Test
+    fun `getTitleAndContent reports an error when the editor has not loaded`() {
+        // The fixture has never received onEditorLoaded, so the read cannot proceed.
+        var errors = 0
+        var results = 0
+
+        gutenbergView.getTitleAndContent(
+            "original content",
+            object : GutenbergView.TitleAndContentCallback {
+                override fun onResult(title: CharSequence, content: CharSequence) {
+                    results++
+                }
+
+                override fun onError() {
+                    errors++
+                }
+            }
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals("the host is told the read failed", 1, errors)
+        assertEquals("no content is reported", 0, results)
+    }
 }

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTest.kt
@@ -405,6 +405,7 @@ class GutenbergViewTest {
                 }
             }
         )
+        assertTrue("the error is posted to the main thread, not reported inline", errors.isEmpty())
         shadowOf(Looper.getMainLooper()).idle()
 
         assertEquals("the host is told the read failed", 1, errors.size)

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTitleAndContentTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTitleAndContentTest.kt
@@ -1,7 +1,8 @@
 package org.wordpress.gutenberg
 
+import org.json.JSONException
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -16,20 +17,20 @@ class GutenbergViewTitleAndContentTest {
     private val originalContent = "<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->"
 
     @Test
-    fun `returns null when the bridge method is gone`() {
-        assertNull(parseTitleAndContent("null", originalContent))
+    fun `fails when the bridge method is gone`() {
+        assertUnreadable("null")
     }
 
     @Test
-    fun `returns null for a malformed result`() {
-        assertNull(parseTitleAndContent("undefined", originalContent))
-        assertNull(parseTitleAndContent("", originalContent))
-        assertNull(parseTitleAndContent(null, originalContent))
+    fun `fails for a malformed result`() {
+        assertUnreadable("undefined")
+        assertUnreadable("")
+        assertUnreadable(null)
     }
 
     @Test
-    fun `returns null when expected fields are absent`() {
-        assertNull(parseTitleAndContent("""{"title":"Only a title"}""", originalContent))
+    fun `fails when expected fields are absent`() {
+        assertUnreadable("""{"title":"Only a title"}""")
     }
 
     @Test
@@ -37,10 +38,10 @@ class GutenbergViewTitleAndContentTest {
         val fields = parseTitleAndContent(
             """{"title":"New title","content":"New body","changed":true}""",
             originalContent
-        )
+        ).getOrThrow()
 
-        assertEquals("New title", fields?.first)
-        assertEquals("New body", fields?.second)
+        assertEquals("New title", fields.first)
+        assertEquals("New body", fields.second)
     }
 
     @Test
@@ -48,10 +49,10 @@ class GutenbergViewTitleAndContentTest {
         val fields = parseTitleAndContent(
             """{"title":"New title","content":"ignored","changed":false}""",
             originalContent
-        )
+        ).getOrThrow()
 
-        assertEquals("New title", fields?.first)
-        assertEquals(originalContent, fields?.second)
+        assertEquals("New title", fields.first)
+        assertEquals(originalContent, fields.second)
     }
 
     /**
@@ -64,9 +65,16 @@ class GutenbergViewTitleAndContentTest {
         val fields = parseTitleAndContent(
             """{"title":"","content":"Body","changed":true}""",
             originalContent
-        )
+        ).getOrThrow()
 
-        assertEquals("", fields?.first)
-        assertEquals("Body", fields?.second)
+        assertEquals("", fields.first)
+        assertEquals("Body", fields.second)
+    }
+
+    private fun assertUnreadable(result: String?) {
+        assertTrue(
+            "expected <$result> to fail with a JSONException",
+            parseTitleAndContent(result, originalContent).exceptionOrNull() is JSONException
+        )
     }
 }

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTitleAndContentTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTitleAndContentTest.kt
@@ -7,11 +7,7 @@ import org.junit.Test
 
 /**
  * Covers how `GutenbergView` interprets the result of `editor.getTitleAndContent`.
- *
- * The case that matters is a failed read. When the editor's `ErrorBoundary`
- * catches, React unmounts the editor and deletes every `window.editor.*` method,
- * so the evaluation returns the string `"null"`. Treating that as an empty title
- * let the host persist it over the user's own — locally, and then on the server.
+ * See [parseTitleAndContent] for why an unreadable result must fail.
  */
 class GutenbergViewTitleAndContentTest {
     private val originalContent = "<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->"
@@ -56,9 +52,7 @@ class GutenbergViewTitleAndContentTest {
     }
 
     /**
-     * A title the user genuinely cleared must still come through. The fix has to
-     * separate "the read failed" from "the title is empty", or it would trade one
-     * bug for a different kind of data loss.
+     * A title the user cleared is a successful read and must still be reported.
      */
     @Test
     fun `reports a deliberately emptied title`() {

--- a/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTitleAndContentTest.kt
+++ b/android/Gutenberg/src/test/java/org/wordpress/gutenberg/GutenbergViewTitleAndContentTest.kt
@@ -1,0 +1,72 @@
+package org.wordpress.gutenberg
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Covers how `GutenbergView` interprets the result of `editor.getTitleAndContent`.
+ *
+ * The case that matters is a failed read. When the editor's `ErrorBoundary`
+ * catches, React unmounts the editor and deletes every `window.editor.*` method,
+ * so the evaluation returns the string `"null"`. Treating that as an empty title
+ * let the host persist it over the user's own — locally, and then on the server.
+ */
+class GutenbergViewTitleAndContentTest {
+    private val originalContent = "<!-- wp:paragraph --><p>Body</p><!-- /wp:paragraph -->"
+
+    @Test
+    fun `returns null when the bridge method is gone`() {
+        assertNull(parseTitleAndContent("null", originalContent))
+    }
+
+    @Test
+    fun `returns null for a malformed result`() {
+        assertNull(parseTitleAndContent("undefined", originalContent))
+        assertNull(parseTitleAndContent("", originalContent))
+        assertNull(parseTitleAndContent(null, originalContent))
+    }
+
+    @Test
+    fun `returns null when expected fields are absent`() {
+        assertNull(parseTitleAndContent("""{"title":"Only a title"}""", originalContent))
+    }
+
+    @Test
+    fun `reports the edited title and content when changed`() {
+        val fields = parseTitleAndContent(
+            """{"title":"New title","content":"New body","changed":true}""",
+            originalContent
+        )
+
+        assertEquals("New title", fields?.first)
+        assertEquals("New body", fields?.second)
+    }
+
+    @Test
+    fun `falls back to the original content when unchanged`() {
+        val fields = parseTitleAndContent(
+            """{"title":"New title","content":"ignored","changed":false}""",
+            originalContent
+        )
+
+        assertEquals("New title", fields?.first)
+        assertEquals(originalContent, fields?.second)
+    }
+
+    /**
+     * A title the user genuinely cleared must still come through. The fix has to
+     * separate "the read failed" from "the title is empty", or it would trade one
+     * bug for a different kind of data loss.
+     */
+    @Test
+    fun `reports a deliberately emptied title`() {
+        val fields = parseTitleAndContent(
+            """{"title":"","content":"Body","changed":true}""",
+            originalContent
+        )
+
+        assertEquals("", fields?.first)
+        assertEquals("Body", fields?.second)
+    }
+}

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -370,10 +370,10 @@ private suspend fun persistPost(
                         if (cont.isActive) cont.resume(title to content)
                     }
 
-                    override fun onError() {
+                    override fun onError(error: Throwable) {
                         if (cont.isActive) {
                             cont.resumeWithException(
-                                IllegalStateException("Could not read the editor content")
+                                IllegalStateException("Could not read the editor content", error)
                             )
                         }
                     }

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -58,6 +58,7 @@ import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.PostEndpointType
 import uniffi.wp_api.PostUpdateParams
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 class EditorActivity : ComponentActivity() {
 
@@ -367,6 +368,14 @@ private suspend fun persistPost(
                 callback = object : GutenbergView.TitleAndContentCallback {
                     override fun onResult(title: CharSequence, content: CharSequence) {
                         if (cont.isActive) cont.resume(title to content)
+                    }
+
+                    override fun onError() {
+                        if (cont.isActive) {
+                            cont.resumeWithException(
+                                IllegalStateException("Could not read the editor content")
+                            )
+                        }
                     }
                 }
             )

--- a/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
+++ b/android/app/src/main/java/com/example/gutenbergkit/EditorActivity.kt
@@ -57,6 +57,7 @@ import org.wordpress.gutenberg.model.EditorDependenciesSerializer
 import rs.wordpress.api.kotlin.WpRequestResult
 import uniffi.wp_api.PostEndpointType
 import uniffi.wp_api.PostUpdateParams
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -416,6 +417,8 @@ private suspend fun persistPost(
                 context.getString(R.string.save_failed_generic)
             }
         }
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Log.e("EditorActivity", "Failed to persist post $postId", e)
         context.getString(R.string.save_failed_with_reason, e.message ?: "unknown error")

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -221,6 +221,10 @@ gutenbergView.getTitleAndContent(
         override fun onResult(title: CharSequence, content: CharSequence) {
             // Use title and content
         }
+
+        override fun onError(error: Throwable) {
+            // Keep the last known title and content rather than saving
+        }
     },
     completeComposition = true
 )


### PR DESCRIPTION
## What?

`GutenbergView.getTitleAndContent` reported a fabricated result when its JSON could not be parsed, letting hosts persist an empty post title over the user's own.

## Why?

**Live, silent data loss — confirmed on device, and confirmed reaching the server.**

The parse failure was logged and discarded, `changed` stayed `false`, and the callback fired normally:

```kotlin
} catch (e: JSONException) {
    Log.e("GutenbergView", "Received invalid JSON from editor.getTitleAndContent")
}
val title = lastUpdatedTitle ?: ""       // ← empty
callback.onResult(title, content)        // ← fires as if it succeeded
```

That path is reachable in normal use. When the `ErrorBoundary` catches, React unmounts the editor and deletes every `window.editor.*` method while `window.editor` survives as an empty object, so `evaluateJavascript` returns the string `"null"`. `isEditorLoaded` is never reset, so the call still goes out.

Because the callback fired normally, hosts could not tell a failed read from a title the user cleared. In WordPress-Android the empty title flows into `PostModel.setTitle("")`, persists to SQLite, and reaches the server on the next save. The post list keeps rendering the last synced title, so nothing looks wrong until the post is reopened.

[CMM-2008](https://linear.app/a8c/issue/CMM-2008) covers the iOS half of the same teardown, where the equivalent call throws instead — which happened to be protective.

## How?

Parse into a `Result` and report a new, required `TitleAndContentCallback.onError(error: Throwable)` rather than inventing a result. The error is an `EditorNotReadyException` when the editor has not loaded or the view has been detached, or the `JSONException` when its result could not be parsed — the same distinction iOS makes by throwing `EditorNotReadyError` or an invalid data format error.

**Breaking:** hosts must implement `onError`. A no-op default would compile without complaint and leave a host that waits only on `onResult` waiting forever. WordPress-Android needs a one-line `onError` that releases its latch when it upgrades.

The distinction that matters: separating _the read failed_ from _the title is empty_. A blanket empty-title guard in the host would have broken clearing a title legitimately, which is covered by a test.

`getTitleAndContent` also returned silently when `isEditorLoaded` was false, so a host awaiting a result had to wait out its own timeout, or never resumed at all. It now reports `EditorNotReadyException`, posted to the main thread like every other result. `isEditorLoaded` is `@Volatile`, since that check runs on the host's thread.

Detaching the view clears its queued callbacks and destroys the web view, which could drop a read's error or leave a read unanswered. Reads are now tracked until they report, and any still pending when the view detaches report `EditorNotReadyException`.

The demo app only resumed its `suspendCancellableCoroutine` from `onResult`, so it hung forever on a failed read; it now fails the save instead, and lets cancellation propagate rather than reporting it as a failure.

`isEditorLoaded` is still not reset when the editor crashes; that is [#640](https://github.com/wordpress-mobile/GutenbergKit/pull/640), which this PR is deliberately independent of.

## Testing Instructions

End to end, against WordPress-Android:

1. Open a post with a non-empty title and at least one block.
2. Trip the boundary from `chrome://inspect` (needs `setWebContentsDebuggingEnabled(true)` on a debug build):
   ```js
   const be = wp.data.select("core/block-editor");
   be.getBlockOrder = () => {
     throw new Error("repro");
   };
   wp.data.dispatch("core/block-editor").updateSettings({});
   ```
3. Close or save, then reopen the post.
4. Before: the title is gone and reaches the server on the next save. After: intact, and the save is skipped.
5. `adb logcat | grep GutenbergView` still shows `Received invalid JSON from editor.getTitleAndContent`, now with the cause attached.

### Accessibility Testing Instructions

N/A — no UI changes.

## Screenshots or screencast

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuxMbKtUsaUF8nUVgKdxwK
