### PR TITLE
build: compile the Android modules against Java 11

### DIFF
--- a/android/Gutenberg/build.gradle.kts
+++ b/android/Gutenberg/build.gradle.kts
@@ -80,8 +80,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+        targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
     }
     testOptions {
         unitTests {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -67,8 +67,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+        targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
     }
     buildFeatures {
         compose = true

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "9.3.1"
+java = "11"
 kotlin = "2.4.10"
 kotlinx-serialization = "1.7.3"
 coreKtx = "1.13.1"


### PR DESCRIPTION
## What?

Raises the Android modules from Java 8 to Java 11, taking the version from the version catalog rather than repeating a literal in each module.

## Why?

JDK 21 warns on every build that the Java 8 source/target is obsolete, twice per module:

```
Java compiler version 21 has deprecated support for compiling with source/target version 8.
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
```

This predates #644 — the same warning appears on `trunk` with AGP 8.10.1, since the trigger is the JDK running `javac`, not AGP. AGP 9 only makes it wordier by adding a remediation list.

WordPress-Android moved to Java 11 as part of its AGP 9 upgrade, so this closes another gap between the two toolchains and removes recurring noise from the build log.

## How?

Adds `java = "11"` to `[versions]` and reads it via `JavaVersion.toVersion(libs.versions.java.get())` in both modules, mirroring WordPress-Android. Sourcing it from the catalog means the two modules cannot silently drift apart, which was possible while each repeated `JavaVersion.VERSION_1_8`.

No Kotlin-side change is needed: under AGP 9's built-in Kotlin the JVM target follows `compileOptions`.

## Testing Instructions

1. `make build`
2. `./android/gradlew -p ./android :Gutenberg:assembleRelease :app:assembleDebug` — succeeds, and the `source value 8 is obsolete` warnings are gone
3. `make lint-android` — passes
4. `make test-android` — 663 tests, 6 pre-existing failures (see below)

### Notes for the reviewer

**This changes the published artifact.** The AAR's classes move from bytecode major version 52 (Java 8) to 55 (Java 11) — verified in `classes.jar` inside `Gutenberg-release.aar`, not just the intermediates. That is the substantive decision in this PR, and the reason it is split out of #644 rather than folded in.

WordPress-Android is already on Java 11, so the one known consumer is unaffected. `minSdk` is untouched (24 for the library, 26 for the demo app); D8 handles Java 11 bytecode for those levels.

The 6 failures in `HttpServerAuthenticationTests` are unrelated and pre-existing — the same 6 fail on `trunk`. Local JDK 21 strips `Proxy-Authorization` from `HttpURLConnection`; the tests that build requests over raw sockets pass.
