### PR TITLE
build(deps): update browserslist caniuse-lite data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11806,9 +11806,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-			"integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+			"version": "2.11.22",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.22.tgz",
+			"integrity": "sha512-pWc4w51fBFd7mav43/zKRC+RI6f4yfzQoVlfvE8dECePyfkn1bzLp01Fj0QACcyCZyFhiEMyD2qScfKRWgWibA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -12240,9 +12240,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001774",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-			"integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+			"version": "1.0.30001810",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+			"integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
## What?

`make lint-js` prints a warning that the Browserslist browser data is out of date:

```
Browserslist: browsers data (caniuse-lite) is 7 months old. Please run:
  npx update-browserslist-db@latest
```

## Why?

The warning adds noise to every lint run. The data reaches ESLint through `@wordpress/eslint-plugin`'s Babel preset; the Vite build doesn't use it, so the editor bundle is unaffected.

## How?

Ran `npx update-browserslist-db@latest`, which bumps two lockfile entries: `caniuse-lite` (1.0.30001774 → 1.0.30001810) and `baseline-browser-mapping` (2.10.0 → 2.11.22). It reported no target browser changes.

## Testing Instructions

1. `REFRESH_DEPS=1 make lint-js` — passes with no Browserslist warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgDmHEUFHyR7t7aVHWF6WW
